### PR TITLE
feat: port the adaptive tilt-segment beam union (union_adaptive)

### DIFF
--- a/src/diffBloch/config/schema.py
+++ b/src/diffBloch/config/schema.py
@@ -281,10 +281,14 @@ class CouplingConfig(_StrictConfig):
     keeps its own defaults for programmatic pipeline authors -- only the config edge is explicit.
     """
 
-    n_splits: int  # contiguous tilt chunks
+    n_splits: int  # contiguous tilt chunks (fixed mode)
     g_max: float  # coupling radius (1/Angstrom)
     cap_margin: float  # subtracted from g_max for the coupling cap
     sg_max: float  # excitation-error cutoff
+    # Adaptive segmentation is a mode toggle with a faithful-fixed default, so (unlike the four
+    # physics fields) it may be omitted -- an absent block runs the current even-split behaviour.
+    union_adaptive: bool = False  # recursive-bisection chunk boundaries instead of even splits
+    union_max_new_beams_pct: float = 0.01  # adaptive: split while a midpoint adds > this fraction
 
     def to_policy(self) -> TiltSegmentUnion:
         """Parse into the validated value-type the coupled ``fit_orientation`` consumes."""
@@ -293,6 +297,8 @@ class CouplingConfig(_StrictConfig):
             g_max=self.g_max,
             cap_margin=self.cap_margin,
             sg_max=self.sg_max,
+            union_adaptive=self.union_adaptive,
+            union_max_new_beams_pct=self.union_max_new_beams_pct,
         )
 
     @model_validator(mode="after")

--- a/src/diffBloch/core/solver.py
+++ b/src/diffBloch/core/solver.py
@@ -38,6 +38,17 @@ type Method = Literal["matrix_exp", "bloch_eigen"]
 type FloatFormat = Literal["fp32", "fp64"]
 type Thicknesses = float | Sequence[float] | Tensor
 
+# `matrix_exp` scaling-and-squaring holds several N*N temporaries per matrix (Pade numerator/
+# denominator, the linear solve). This conservative multiplier estimates the live footprint of one
+# (blk, N, N) block so `memory_safe_max_batch` can keep the peak well under accelerator memory.
+_MATRIX_EXP_LIVE_COPIES = 8
+# The default per-block budget the engine bounds a `matrix_exp` call to when no explicit `max_batch`
+# is given. A guardrail, not a tuned value: ~2 GiB is a no-op for ordinary solves (their whole
+# operator stack is far smaller) yet caps the wide-segment / many-thickness stacks that would
+# otherwise materialize tens of GiB at once (the adaptive-union fit_thickness OOM). Override
+# `max_batch` explicitly for a specific device budget.
+DEFAULT_MATRIX_EXP_BUDGET_BYTES = 2 * 1024**3
+
 
 def precision_dtypes(fmt: FloatFormat) -> tuple[torch.dtype, torch.dtype]:
     """The ``(real, complex)`` torch dtypes for a float format -- the single source of the mapping.
@@ -56,6 +67,7 @@ def propagate(
     *,
     method: Method = "matrix_exp",
     precision: FloatFormat = "fp64",
+    max_batch: int | None = None,
 ) -> Tensor:
     """Propagate ``system.psi0`` to each thickness, returning the exit wavefunction.
 
@@ -76,7 +88,19 @@ def propagate(
     cell volume). The terminal estimators (``run_inference`` scoring, ``refine``) never enable it:
     fp32 perturbs the fit's basin, so the reproducible pinned result stays fp64. Ports
     ``diffBloch_private`` ``dynamical.py``'s complex64 eigensolve (#127/#133).
+
+    ``max_batch`` (``matrix_exp`` only) caps how many ``(N, N)`` operators are exponentiated in one
+    ``torch.matrix_exp`` call. ``None`` (the default) builds the whole ``(..., T, N, N)`` transfer
+    at once (byte-identical to before). A positive integer instead streams the flattened
+    ``(B*T, N, N)`` operator stack in row-blocks, so that transfer is never materialized -- the peak
+    drops from ``~K*B*T*N**2`` to ``~K*max_batch*N**2``. ``torch.matrix_exp`` shares one
+    scaling-and-squaring count across a batch (from its max norm), so regrouping shifts rounding by
+    ~1 ulp: the result matches the unbounded solve *to machine precision*, never in accuracy. A
+    memory knob, not a result knob. ``bloch_eigen`` ignores it (it diagonalises once, no
+    ``(B, T, N, N)`` intermediate).
     """
+    if max_batch is not None and max_batch < 1:
+        raise ValueError(f"max_batch must be a positive integer or None, got {max_batch}")
     real_dtype, _ = precision_dtypes(precision)
     t = torch.as_tensor(thicknesses, dtype=real_dtype, device=system.a.device)
     if t.ndim == 0:
@@ -85,10 +109,31 @@ def propagate(
         raise ValueError("thicknesses must be a scalar or 1-D sequence")
 
     if method == "matrix_exp":
-        return _propagate_matrix_exp(system, t, precision)
+        return _propagate_matrix_exp(system, t, precision, max_batch=max_batch)
     if method == "bloch_eigen":
         return _propagate_bloch_eigen(system, t, precision)
     raise ValueError(f"method must be 'matrix_exp' or 'bloch_eigen', got {method!r}")
+
+
+def memory_safe_max_batch(
+    n_beams: int,
+    precision: FloatFormat,
+    *,
+    budget_bytes: int = DEFAULT_MATRIX_EXP_BUDGET_BYTES,
+) -> int:
+    """The largest ``max_batch`` keeping one ``(max_batch, N, N)`` matrix_exp block under budget.
+
+    ``N`` (``n_beams``) is the solve's beam count, so the bound *adapts to cell size* -- a
+    large-cell compound (bigger ``N``, cubically heavier propagator) gets a proportionally smaller
+    block, where a fixed block *count* would still blow up. Returns at least 1 (a single matrix is
+    always attempted, even if it alone exceeds the budget). This is the safe default the engine
+    applies when a caller does not pin ``max_batch`` itself; the result matches an unbounded solve
+    to machine precision (a rounding-level ~1 ulp shift, see :func:`propagate`), never in accuracy.
+    """
+    _, complex_dtype = precision_dtypes(precision)
+    bytes_per_entry = 16 if complex_dtype == torch.complex128 else 8
+    per_matrix = _MATRIX_EXP_LIVE_COPIES * n_beams * n_beams * bytes_per_entry
+    return max(1, budget_bytes // per_matrix)
 
 
 def _at_precision(operator: Tensor, precision: FloatFormat) -> Tensor:
@@ -102,7 +147,11 @@ def _at_precision(operator: Tensor, precision: FloatFormat) -> Tensor:
 
 
 def _propagate_matrix_exp(
-    system: BlochSystem, thicknesses: Tensor, precision: FloatFormat
+    system: BlochSystem,
+    thicknesses: Tensor,
+    precision: FloatFormat,
+    *,
+    max_batch: int | None = None,
 ) -> Tensor:
     a = _at_precision(_complex_operator(system.a), precision)  # (..., N, N)
     # Co-locate the geometry-plan tensors onto the operator device (they may be built CPU-side while
@@ -110,12 +159,29 @@ def _propagate_matrix_exp(
     psi0 = system.psi0.to(dtype=a.dtype, device=a.device)
     # i pi t / k_n: the dynamical-diffraction propagation scaling. For a Hermitian A this scalar is
     # pure-imaginary, so matrix_exp(A * scalar) is unitary (flux-conserving).
-    scalars = (1j * torch.pi * thicknesses / system.k_n).to(a.dtype)
-    # a.unsqueeze(-3) inserts the thickness axis before (N, N): a single (N, N) becomes (1, N, N)
-    # broadcasting to (T, N, N); a batched (B, N, N) becomes (B, 1, N, N) broadcasting to
-    # (B, T, N, N) -- one matrix_exp over the whole tilt/thickness grid.
-    transfer = torch.matrix_exp(a.unsqueeze(-3) * scalars[:, None, None])  # (..., T, N, N)
-    return (transfer @ psi0.unsqueeze(-1)).squeeze(-1)  # (..., T, N)
+    scalars = (1j * torch.pi * thicknesses / system.k_n).to(a.dtype)  # (T,)
+    if max_batch is None:
+        # a.unsqueeze(-3) inserts the thickness axis before (N, N): a single (N, N) becomes
+        # (1, N, N) broadcasting to (T, N, N); a batched (B, N, N) becomes (B, 1, N, N) broadcasting
+        # to (B, T, N, N) -- one matrix_exp over the whole tilt/thickness grid.
+        transfer = torch.matrix_exp(a.unsqueeze(-3) * scalars[:, None, None])  # (..., T, N, N)
+        return (transfer @ psi0.unsqueeze(-1)).squeeze(-1)  # (..., T, N)
+    # Bounded-memory path: exponentiate the flattened (B*T, N, N) operator stack in row-blocks of
+    # `max_batch`, applying psi0 per block, so the full (..., T, N, N) transfer is never
+    # materialized. Matches the unbounded solve to machine precision (torch.matrix_exp shares one
+    # squaring count per batch, so regrouping shifts rounding by ~1 ulp, never accuracy); this
+    # generalizes diffBloch_private's single-thickness cover-batch chunk (dynamical.py
+    # calculate_dynamical_scattering_batched, max_chunk=8) to the multi-thickness grid.
+    n = a.shape[-1]
+    a_flat = a.reshape(-1, n, n)  # (B, N, N); B == 1 for a single (N, N) system
+    n_batch, n_thick = a_flat.shape[0], scalars.shape[0]
+    total = n_batch * n_thick  # flat index f = b * T + t, so a contiguous block cats back in order
+    amplitudes = []
+    for start in range(0, total, max_batch):
+        flat = torch.arange(start, min(total, start + max_batch), device=a.device)
+        block = a_flat[flat // n_thick] * scalars[flat % n_thick][:, None, None]  # (blk, N, N)
+        amplitudes.append((torch.matrix_exp(block) @ psi0.unsqueeze(-1)).squeeze(-1))  # (blk, N)
+    return torch.cat(amplitudes, dim=0).reshape(*a.shape[:-2], n_thick, n)  # (..., T, N)
 
 
 def _propagate_bloch_eigen(

--- a/src/diffBloch/engine/forward.py
+++ b/src/diffBloch/engine/forward.py
@@ -35,7 +35,13 @@ from diffBloch.core.products import (
     reduce_tilts,
 )
 from diffBloch.core.scattering import structure_factors
-from diffBloch.core.solver import FloatFormat, Method, precision_dtypes, propagate
+from diffBloch.core.solver import (
+    FloatFormat,
+    Method,
+    memory_safe_max_batch,
+    precision_dtypes,
+    propagate,
+)
 from diffBloch.core.symmetry import AsuExpansionPlan, expand_asu
 from diffBloch.engine.constraints import ConstraintTransform
 from diffBloch.engine.plan import (
@@ -100,6 +106,19 @@ class RefinementEngine:
     # fits build; the terminal estimators (objective/refine here, run_inference via build_engine)
     # never enable it, so the reproducible pinned result stays fp64. See core.solver.propagate.
     precision: FloatFormat = "fp64"
+    # matrix_exp propagator block cap (memory only; matches unbounded to machine precision, a
+    # rounding-level ~1 ulp shift, never accuracy). None (default) lets each
+    # solve pick a memory-safe block from its beam count (memory_safe_max_batch), which bounds the
+    # (B, T, N, N) propagator that a wide coupled segment x a thickness grid would otherwise
+    # materialize all at once (the adaptive-union fit_thickness OOM). A positive int pins the block
+    # for a specific device budget. Execution-only, like precision/method.
+    max_batch: int | None = None
+
+    def _max_batch_for(self, n_beams: int) -> int:
+        """The matrix_exp block cap for a solve over ``n_beams`` beams (explicit pin, else safe)."""
+        if self.max_batch is not None:
+            return self.max_batch
+        return memory_safe_max_batch(n_beams, self.precision)
 
     def simulate(self, params: RefinableParams) -> tuple[BlochSolution, ...]:
         """Return the calculated :class:`BlochSolution` for every orientation (no loss)."""
@@ -311,6 +330,7 @@ class RefinementEngine:
                 thicknesses,
                 method=self.method,
                 precision=self.precision,
+                max_batch=self._max_batch_for(beam_hkl.shape[0]),
             )
             return BlochSolution.from_propagation(amplitudes, beam_hkl, thicknesses)
         # Rocking-curve integration: the tilts share this orientation's beam set, so ONE batched
@@ -323,6 +343,7 @@ class RefinementEngine:
             thicknesses,
             method=self.method,
             precision=self.precision,
+            max_batch=self._max_batch_for(beam_hkl.shape[0]),
         )  # (B, T, N)
         return BlochSolution.integrate_batched(
             amplitudes, beam_hkl, thicknesses, reduction=orientation.tilt_reduction
@@ -355,6 +376,7 @@ class RefinementEngine:
                 thicknesses,
                 method=self.method,
                 precision=self.precision,
+                max_batch=self._max_batch_for(segment.union_index.shape[0]),
             )  # (C, T, n_seg)
             cover = segment.cover.to(device)
             union_index = segment.union_index.to(device)

--- a/src/diffBloch/preprocess/coupling.py
+++ b/src/diffBloch/preprocess/coupling.py
@@ -18,6 +18,7 @@ step turns the segments into per-chunk plans and reassembles their curves before
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import numpy as np
@@ -108,6 +109,43 @@ def _split_boundaries(n_tilts: int, n_splits: int) -> NDArray[np.int64]:
     return boundaries
 
 
+def _adaptive_segment_ranges(
+    n_tilts: int,
+    excited_mask: Callable[[int], NDArray[np.bool_]],
+    max_new_pct: float,
+) -> list[tuple[int, int]]:
+    """Adaptive chunk boundaries by recursive bisection (the private's ``union_adaptive`` path).
+
+    Ported from ``BlochNet.forward``: a range ``(a, b)`` is split at its midpoint only while the
+    midpoint's excited set adds more than ``max_new_pct`` *new* beams beyond the boundary union
+    ``mask(a) | mask(b)`` (else the range freezes as one chunk). Returns the ordered, inclusive
+    ``(a, b)`` segment ranges partitioning ``0 .. n_tilts - 1`` (disjoint, covering each tilt once);
+    each chunk's beam set is later the boundary union of *its own* endpoints, as in the fixed path.
+    """
+    if n_tilts <= 1:
+        return [(0, max(0, n_tilts - 1))]
+    stack: list[tuple[int, int]] = [(0, n_tilts - 1)]
+    final: list[tuple[int, int]] = []
+    while stack:
+        a, b = stack.pop()
+        if b <= a + 1:
+            final.append((a, b))
+            continue
+        mid = (a + b) // 2
+        union_end = excited_mask(a) | excited_mask(b)
+        if not bool(union_end.any()):  # defensive: (0,0,0) is always excited, so normally non-empty
+            union_end = union_end | excited_mask(mid)
+        new_mid = excited_mask(mid) & ~union_end
+        new_pct = int(new_mid.sum()) / max(int(union_end.sum()), 1)
+        if new_pct > max_new_pct:
+            stack.append((mid + 1, b))
+            stack.append((a, mid))
+        else:
+            final.append((a, b))
+    final.sort(key=lambda ab: ab[0])
+    return final
+
+
 def tilt_segment_coupling(
     policy: TiltSegmentUnion,
     candidate_hkl: NDArray[np.int64],
@@ -142,7 +180,6 @@ def tilt_segment_coupling(
         raise ValueError(f"tilts must have shape (B, 3, 3), got {tilts.shape}")
     n_tilts = tilts.shape[0]
     cap = coupling_cap(policy)
-    boundaries = _split_boundaries(n_tilts, policy.n_splits)
 
     # ``|g|`` is invariant under the orientation/tilt rotation (an orthogonal transform preserves
     # the vector norm), so the coupling-radius cut ``|g| < cap`` selects the SAME candidate subset
@@ -154,16 +191,35 @@ def tilt_segment_coupling(
     g_nominal = candidate_hkl @ orientation_basis(cell, orientation)  # any orientation: |g| invar.
     pool = candidate_hkl[np.linalg.norm(g_nominal, axis=1) < cap]
 
+    _mask_cache: dict[int, NDArray[np.bool_]] = {}
+
     def excited_mask(tilt_index: int) -> NDArray[np.bool_]:
+        cached = _mask_cache.get(tilt_index)
+        if cached is not None:
+            return cached
         basis = orientation_basis(cell, tilts[tilt_index] @ orientation)
         sg = excitation_errors(pool @ basis, energy, u0=u0)
-        return np.abs(sg) < policy.sg_max  # |g| < cap already guaranteed by the pool
+        mask = np.abs(sg) < policy.sg_max  # |g| < cap already guaranteed by the pool
+        _mask_cache[tilt_index] = mask
+        return mask
 
-    masks = {int(b): excited_mask(int(b)) for b in boundaries}
+    if policy.union_adaptive:
+        # Adaptive boundaries by recursive bisection (n_splits ignored). Each segment's beam set is
+        # the union of *its own* inclusive endpoints, and the covers tile every tilt exactly once.
+        ranges = _adaptive_segment_ranges(n_tilts, excited_mask, policy.union_max_new_beams_pct)
+        return tuple(
+            Segment(
+                beam_hkl=pool[excited_mask(a) | excited_mask(b)].copy(),
+                cover=tuple(range(a, b + 1)),
+            )
+            for a, b in ranges
+        )
+
+    boundaries = _split_boundaries(n_tilts, policy.n_splits)
     segments = []
     for i in range(len(boundaries) - 1):
         a, b = int(boundaries[i]), int(boundaries[i + 1])
-        union = masks[a] | masks[b]
+        union = excited_mask(a) | excited_mask(b)
         cover = tuple(range(a, n_tilts if i == len(boundaries) - 2 else b))
         segments.append(Segment(beam_hkl=pool[union].copy(), cover=cover))
     return tuple(segments)

--- a/src/diffBloch/preprocess/scoring.py
+++ b/src/diffBloch/preprocess/scoring.py
@@ -33,6 +33,7 @@ def build_engine(
     loss: LossFn = scaled_w_rbragg_loss,
     method: Method = "matrix_exp",
     precision: FloatFormat = "fp64",
+    max_batch: int | None = None,
 ) -> RefinementEngine:
     """Wire a geometry ``plan`` and a structure ``refinement`` into a runnable engine (no compute).
 
@@ -51,6 +52,11 @@ def build_engine(
     (complex64) is a search-time knob only the preprocess fits set on their transient scoring
     engines; the terminal callers here and in ``run_inference`` omit it, so scoring/refinement that
     produce the pinned result stay fp64. See :func:`diffBloch.core.solver.propagate`.
+
+    ``max_batch`` (default ``None``) caps the ``matrix_exp`` propagator block; ``None`` lets each
+    solve pick a memory-safe block from its beam count, bounding peak memory while matching the
+    unbounded solve to machine precision (a pin is only needed for a specific device budget).
+    Execution-only, like ``precision``/``method``.
     """
     return RefinementEngine(
         spec=refinement.spec,
@@ -61,6 +67,7 @@ def build_engine(
         loss=loss,
         method=method,
         precision=precision,
+        max_batch=max_batch,
     )
 
 

--- a/src/diffBloch/preprocess/steps/fit_orientation.py
+++ b/src/diffBloch/preprocess/steps/fit_orientation.py
@@ -83,6 +83,7 @@ def fit_orientation(
     validate: bool = True,
     workers: int = 1,
     device: Device | None = None,
+    max_batch: int | None = None,
     logger: Logger = NULL_LOGGER,
 ) -> PlanStep:
     """Return a ``Plan -> Plan`` step refining each orientation by Palatinus hexagonal search.
@@ -133,6 +134,11 @@ def fit_orientation(
     rotation's gather cache is thread-local -- so the results are identical to a sequential run.
     Threads (not processes) suffice because torch's CPU linalg releases the GIL.
 
+    ``max_batch`` (default ``None``) caps the ``matrix_exp`` propagator block; ``None`` lets each
+    solve derive a memory-safe block from its beam count. Execution-only and matches the unbounded
+    solve to machine precision (memory only), like ``device`` -- raise it to fill a larger GPU. See
+    :func:`build_engine`.
+
     ``logger`` receives an :class:`~diffBloch.observability.OrientationFitted` per rotation as its
     search completes (the fit is the run's long phase, so this is the progress stream); the default
     :data:`NULL_LOGGER` discards them. With ``workers > 1`` events arrive in completion order.
@@ -160,7 +166,9 @@ def fit_orientation(
         # O(1), orientation-independent, always on -- fails at setup, not deep in the search.
         if coupling is not None:
             assert_grid_covers_coupling(coupling.policy, plan.grid.g_max)
-        engine = build_engine(plan, refinement, method=method, precision=precision)
+        engine = build_engine(
+            plan, refinement, method=method, precision=precision, max_batch=max_batch
+        )
         params = refinement.params if device is None else refinement.params.to(device)
         fgb = engine.fgb(params)
 

--- a/src/diffBloch/preprocess/steps/fit_thickness.py
+++ b/src/diffBloch/preprocess/steps/fit_thickness.py
@@ -50,6 +50,7 @@ def fit_thickness(
     method: Method = "matrix_exp",
     precision: FloatFormat = "fp64",
     device: Device | None = None,
+    max_batch: int | None = None,
 ) -> PlanStep:
     """Return a ``Plan -> Plan`` step fitting each rotation's thickness by grid search.
 
@@ -67,10 +68,19 @@ def fit_thickness(
     accelerator by moving the seed params there; the engine co-locates every invariant onto the
     param device at the use site. Execution-only (kept out of the recipe identity), exactly as in
     :func:`fit_orientation`.
+
+    ``max_batch`` (default ``None``) caps the ``matrix_exp`` propagator block. ``None`` lets each
+    solve derive a memory-safe block from its beam count -- it matters most here because the grid
+    search evaluates ``grid.n_steps`` thicknesses at once, so a wide coupled segment's
+    ``(C, T, N, N)`` propagator can be tens of GiB if left unbounded. Raise it to fill a larger GPU.
+    The bound matches the unbounded solve to machine precision (memory only) and is execution-only,
+    like ``device``.
     """
 
     def run(plan: Plan) -> Plan:
-        engine = build_engine(plan, refinement, method=method, precision=precision)
+        engine = build_engine(
+            plan, refinement, method=method, precision=precision, max_batch=max_batch
+        )
         params = refinement.params if device is None else refinement.params.to(device)
         fgb = engine.fgb(params)
         candidates = torch.linspace(

--- a/src/diffBloch/specs.py
+++ b/src/diffBloch/specs.py
@@ -308,19 +308,27 @@ class TiltSegmentUnion:
     the safety margin subtracted from it (the private's hardcoded ``0.2``), so the effective cap is
     ``g_max - cap_margin = 2.05``. ``sg_max`` is the excitation-error cutoff. The mean-inner-
     potential ``u0`` and beam energy are experiment quantities threaded in at build time, not policy
-    knobs. The ``union_adaptive`` recursive-bisection variant is deferred (only the fixed even-split
-    ``union_adaptive = False`` path is ported).
+    knobs.
+
+    ``union_adaptive`` chooses how the chunk boundaries are placed. ``False`` (default) uses
+    ``n_splits`` fixed even-sized chunks. ``True`` places boundaries by recursive bisection: a tilt
+    range is split further only while its midpoint adds more than ``union_max_new_beams_pct`` of the
+    boundary union's beams (else the range is frozen as one chunk), so segments are dense where the
+    excited set drifts and sparse where it is stable. In the adaptive mode ``n_splits`` is ignored.
 
     Defaults are the faithful ``diffBloch_private`` values (``config.union_splits = 12``,
-    ``self.g_max = 4.5 / 2``, cap margin ``0.2``, ``self.sg_max = 0.01``).
+    ``self.g_max = 4.5 / 2``, cap margin ``0.2``, ``self.sg_max = 0.01``,
+    ``union_adaptive = False``, ``union_max_new_beams_pct = 0.01``).
     """
 
-    n_splits: int = 12  # contiguous tilt chunks; each gets its own boundary-union beam set
+    n_splits: int = 12  # contiguous tilt chunks (fixed mode); each gets its boundary-union beam set
     g_max: float = (
         2.25  # coupling radius (private g_max_sf / 2); effective cap = g_max - cap_margin
     )
     cap_margin: float = 0.2  # subtracted from g_max for the coupling cap (private hardcoded 0.2)
     sg_max: float = 0.01  # excitation-error cutoff: a beam couples at a tilt when |Sg| < sg_max
+    union_adaptive: bool = False  # place chunk boundaries by recursive bisection, not even splits
+    union_max_new_beams_pct: float = 0.01  # adaptive: split while a midpoint adds > this fraction
 
     def __post_init__(self) -> None:
         if self.n_splits < 1:
@@ -329,6 +337,8 @@ class TiltSegmentUnion:
             raise ValueError("g_max and sg_max must be positive")
         if self.g_max - self.cap_margin <= 0.0:
             raise ValueError("coupling cap g_max - cap_margin must be positive")
+        if not 0.0 < self.union_max_new_beams_pct <= 1.0:
+            raise ValueError("union_max_new_beams_pct must be in (0, 1]")
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -245,6 +245,28 @@ def test_coupling_policy_override_parses() -> None:
     )
 
 
+def test_coupling_adaptive_fields_default_off_and_thread_through() -> None:
+    base = {"name": "abi", "inputs": {"structure": "a.cif", "observations": "a.cif_pets"}}
+    fixed = {"n_splits": 4, "g_max": 1.5, "cap_margin": 0.2, "sg_max": 0.02}
+    # Omitted -> the faithful fixed even-split (adaptive off), unchanged from the current behaviour.
+    default = ExperimentConfig.model_validate({**base, "preprocess": {"coupling": fixed}})
+    assert default.preprocess.coupling is not None
+    assert default.preprocess.coupling.to_policy().union_adaptive is False
+    # Declared -> threaded into the value-type the coupled fit consumes.
+    adaptive = ExperimentConfig.model_validate(
+        {
+            **base,
+            "preprocess": {
+                "coupling": {**fixed, "union_adaptive": True, "union_max_new_beams_pct": 0.02}
+            },
+        }
+    )
+    assert adaptive.preprocess.coupling is not None
+    policy = adaptive.preprocess.coupling.to_policy()
+    assert policy.union_adaptive is True
+    assert policy.union_max_new_beams_pct == 0.02
+
+
 def test_coupling_policy_bounds_are_validated() -> None:
     base = {"name": "bad", "inputs": {"structure": "q.cif", "observations": "q.cif_pets"}}
 

--- a/tests/unit/test_core_solver.py
+++ b/tests/unit/test_core_solver.py
@@ -14,7 +14,7 @@ from diffBloch.core.dynamical import (
     stack_beam_plans,
 )
 from diffBloch.core.reciprocal import g_vectors
-from diffBloch.core.solver import propagate
+from diffBloch.core.solver import memory_safe_max_batch, propagate
 
 _BEAM_HKL = np.array([[0, 0, 0], [1, 0, 0]], dtype=np.int64)
 _GRID_HKL = np.array([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], dtype=np.int64)
@@ -147,6 +147,86 @@ def test_precision_fp32_still_flows_gradient_to_structure_factors(method: str) -
     assert factors.grad is not None
     assert factors.grad.dtype == torch.complex128
     assert factors.grad.abs().sum() > 0
+
+
+def _batched_system(scales: tuple[float, ...], factors: torch.Tensor | None = None):
+    if factors is None:
+        factors = torch.tensor([0.0, 1.0, 1.0], dtype=torch.complex128)
+    plans = [
+        build_beam_plan(_BEAM_HKL, _GRID_HKL, _RECIP_BASIS * s, energy=_ENERGY, gpts=_GPTS)
+        for s in scales
+    ]
+    return build_bloch_systems(stack_beam_plans(plans), factors)
+
+
+@pytest.mark.parametrize("max_batch", [1, 2, 5, 7, 999])
+def test_max_batch_matches_unbounded_to_machine_precision_batched(max_batch: int) -> None:
+    # The matrix_exp chunk streams the flattened (B*T, N, N) operator stack in blocks of `max_batch`
+    # instead of materializing the whole (B, T, N, N) transfer. torch.matrix_exp shares one
+    # scaling-and-squaring count across a batch (from its max norm), so regrouping into blocks
+    # shifts rounding by ~1 ulp -- the amplitudes match to machine precision, never in accuracy.
+    system = _batched_system((1.0, 1.002, 0.998))  # B = 3
+    thicknesses = torch.tensor([0.0, 12.0, 55.0, 137.0], dtype=torch.float64)  # T = 4 -> B*T = 12
+    unbounded = propagate(system, thicknesses, max_batch=None)
+    chunked = propagate(system, thicknesses, max_batch=max_batch)
+    assert torch.allclose(chunked, unbounded, rtol=0.0, atol=1e-13)
+
+
+@pytest.mark.parametrize("max_batch", [1, 3, 999])
+def test_max_batch_matches_unbounded_for_single_system(max_batch: int) -> None:
+    # Leading dim collapses to (T, N): the single (N, N) system chunks over thickness alone.
+    system = _system()
+    thicknesses = torch.tensor([0.0, 1.0, 8.0, 42.0], dtype=torch.float64)
+    unbounded = propagate(system, thicknesses, max_batch=None)
+    chunked = propagate(system, thicknesses, max_batch=max_batch)
+    assert torch.allclose(chunked, unbounded, rtol=0.0, atol=1e-13)
+
+
+def test_max_batch_matches_unbounded_under_fp32() -> None:
+    system = _batched_system((1.0, 1.002, 0.998))
+    thicknesses = torch.tensor([0.0, 12.0, 55.0, 137.0], dtype=torch.float64)
+    unbounded = propagate(system, thicknesses, precision="fp32", max_batch=None)
+    chunked = propagate(system, thicknesses, precision="fp32", max_batch=2)
+    assert chunked.dtype == torch.complex64
+    assert torch.allclose(chunked, unbounded, rtol=0.0, atol=1e-5)
+
+
+def test_max_batch_chunk_still_flows_gradient_to_structure_factors() -> None:
+    factors = torch.tensor([0.0, 1.0, 1.0], dtype=torch.complex128, requires_grad=True)
+    system = _batched_system((1.0, 1.002, 0.998), factors)
+    psi = propagate(system, torch.tensor([1.0, 8.0, 42.0], dtype=torch.float64), max_batch=2)
+    psi[:, :, 1].abs().square().sum().backward()
+    assert factors.grad is not None and factors.grad.abs().sum() > 0
+
+
+def test_max_batch_is_ignored_by_bloch_eigen() -> None:
+    # bloch_eigen diagonalises once (no (B, T, N, N) intermediate), so max_batch is inert there.
+    system = _system()
+    thicknesses = torch.tensor([0.0, 1.0, 8.0, 42.0], dtype=torch.float64)
+    assert torch.equal(
+        propagate(system, thicknesses, method="bloch_eigen", max_batch=1),
+        propagate(system, thicknesses, method="bloch_eigen", max_batch=None),
+    )
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_propagate_rejects_nonpositive_max_batch(bad: int) -> None:
+    with pytest.raises(ValueError, match="max_batch must be a positive integer"):
+        propagate(_system(), [1.0], max_batch=bad)
+
+
+def test_memory_safe_max_batch_shrinks_with_beam_count_and_precision() -> None:
+    # The bound adapts to N (cubically heavier propagator -> smaller block) and to the field width
+    # (complex64 is half complex128, so fp32 permits a larger block at the same budget).
+    small = memory_safe_max_batch(40, "fp64")
+    large = memory_safe_max_batch(640, "fp64")
+    assert small > large >= 1
+    assert memory_safe_max_batch(640, "fp32") > memory_safe_max_batch(640, "fp64")
+
+
+def test_memory_safe_max_batch_floors_at_one() -> None:
+    # A single matrix wider than the whole budget is still attempted (returns 1, never 0).
+    assert memory_safe_max_batch(4000, "fp64", budget_bytes=1) == 1
 
 
 def test_propagate_rejects_bad_method() -> None:

--- a/tests/unit/test_coupling.py
+++ b/tests/unit/test_coupling.py
@@ -10,6 +10,7 @@ the private's per-tilt excitation mask + boundary-union partition, independent o
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import numpy as np
@@ -92,6 +93,81 @@ def test_split_boundaries_match_private() -> None:
 def test_policy_rejects_degenerate_cap() -> None:
     with pytest.raises(ValueError, match="cap"):
         TiltSegmentUnion(g_max=0.2, cap_margin=0.2)
+
+
+# --- adaptive tilt-segment union (recursive bisection) --------------------------------------------
+
+
+def test_policy_rejects_out_of_range_union_pct() -> None:
+    with pytest.raises(ValueError, match="union_max_new_beams_pct"):
+        TiltSegmentUnion(union_max_new_beams_pct=0.0)
+    with pytest.raises(ValueError, match="union_max_new_beams_pct"):
+        TiltSegmentUnion(union_max_new_beams_pct=1.5)
+
+
+def _drifting_mask(n_beams: int) -> Callable[[int], np.ndarray]:
+    """A mask where tilt ``i`` excites the transmitted beam (0) plus a unique beam ``i + 1``."""
+
+    def mask_of(i: int) -> np.ndarray:
+        m = np.zeros(n_beams, dtype=bool)
+        m[0] = True
+        m[i + 1] = True
+        return m
+
+    return mask_of
+
+
+def test_adaptive_collapses_when_excited_set_is_constant() -> None:
+    from diffBloch.preprocess.coupling import _adaptive_segment_ranges
+
+    constant = lambda _i: np.ones(6, dtype=bool)  # noqa: E731 -- terse test stub
+    # A midpoint that adds no new beams never triggers a split: the whole range is one segment.
+    ranges = _adaptive_segment_ranges(8, constant, max_new_pct=0.01)
+    assert ranges == [(0, 7)]
+
+
+def test_adaptive_splits_where_the_excited_set_drifts_and_covers_tile() -> None:
+    from diffBloch.preprocess.coupling import _adaptive_segment_ranges
+
+    mask_of = _drifting_mask(n_beams=6)
+    # (0,3): mid=1 adds beam 2 (1 new / |{0,1,4}|=3 = 33% > 1%) -> split into (0,1) and (2,3).
+    low = _adaptive_segment_ranges(4, mask_of, max_new_pct=0.01)
+    assert low == [(0, 1), (2, 3)]
+    # A permissive threshold never splits: one segment.
+    high = _adaptive_segment_ranges(4, mask_of, max_new_pct=1.0)
+    assert high == [(0, 3)]
+    # Covers always tile 0..B-1 exactly once, disjoint and contiguous.
+    covered = [t for a, b in low for t in range(a, b + 1)]
+    assert covered == list(range(4))
+
+
+def test_adaptive_single_tilt_is_one_segment() -> None:
+    from diffBloch.preprocess.coupling import _adaptive_segment_ranges
+
+    assert _adaptive_segment_ranges(1, lambda _i: np.ones(3, dtype=bool), max_new_pct=0.01) == [
+        (0, 0)
+    ]
+
+
+@pytest.mark.parametrize("rotation", ROTATIONS)
+def test_adaptive_coupling_tiles_tilts_and_keeps_transmitted_beam(rotation: int) -> None:
+    grid, tilts = _grid_and_tilts()
+    d = np.load(REPLAY_ROOT / f"rot_{rotation}.npz")
+    segments = tilt_segment_coupling(
+        TiltSegmentUnion(union_adaptive=True),
+        np.asarray(grid.grid_hkl),
+        cell=np.asarray(grid.cell),
+        orientation=d["orientation"],
+        tilts=tilts,
+        energy=ENERGY_EV,
+        u0=float(d["u0"]),
+    )
+    # Adaptive still partitions every tilt exactly once, contiguous and disjoint.
+    covered = [t for segment in segments for t in segment.cover]
+    assert covered == list(range(42))
+    # Every segment couples the always-excited transmitted beam.
+    for segment in segments:
+        assert (0, 0, 0) in _as_set(segment.beam_hkl)
 
 
 # --- coverage guard (the O(1) invariant that makes validate=False sound on the coupled path) ------


### PR DESCRIPTION
## Summary

Ports the private's **adaptive tilt-segment beam union** (`union_adaptive`) to the public preprocess coupling, alongside the existing fixed even-split. Benchmarking that port on an A100 then surfaced an out-of-memory crash in `fit_thickness` — adaptive makes *fewer, wider* segments, and the batched `matrix_exp` propagator materialized the whole `(B, T, N, N)` transfer at once. So this PR also **bounds the propagator's peak memory** by streaming the operator stack in blocks, a to-machine-precision change that fixes the OOM without touching the coupling result.

Two commits, two concerns:
1. `feat: port the adaptive tilt-segment beam union` — the algorithm port.
2. `perf: bound matrix_exp propagator memory` — the memory fix the port exposed.

## What changed

**Adaptive tilt-segment union (`specs.py`, `config/schema.py`, `preprocess/coupling.py`)**
- `TiltSegmentUnion` / `CouplingConfig`: add `union_adaptive: bool = False` + `union_max_new_beams_pct: float = 0.01` (validated `0 < pct <= 1`), threaded through `to_policy()`. Defaults preserve the current fixed behaviour.
- `tilt_segment_coupling` branches on `union_adaptive`. Adaptive places chunk boundaries by **recursive bisection**: a tilt range splits only while its midpoint's excited set adds more than `union_max_new_beams_pct` of the boundary union's beams, else it freezes — so segments are dense where the excited set drifts and sparse where it is stable. A memoized excited-mask cache serves the arbitrary midpoints the bisection queries. Unchanged: the fixed even-split, the coupling cap, and the downstream shared-off-diagonal batched eigensolve — adaptive yields the same `Segment` tuple shape.

**Bounded `matrix_exp` propagator memory (`core/solver.py`, `engine/forward.py`, `preprocess/{scoring,steps}`)**
- `_propagate_matrix_exp` streams the flattened `(B*T, N, N)` operator stack in row-blocks of `max_batch`, applying `psi0` per block — the full `(B, T, N, N)` transfer is never materialized. Peak drops from `~K*B*T*N^2` to `~K*max_batch*N^2`.
- `max_batch` is a `matrix_exp`-only engine attribute (`bloch_eigen` diagonalizes once — no such intermediate — and ignores it), execution-only like `precision`/`method`. `None` (default) derives a memory-safe block from the solve's beam count via `memory_safe_max_batch`, so the bound *adapts to cell size*; an explicit `int` pins it to fill a specific GPU. Threaded through `build_engine`, `fit_thickness`, `fit_orientation`.

## Architecture & data flow

Where the propagator tensor forms, and how the two segment-sizing modes drive its size:

```mermaid
flowchart TD
    pol["TiltSegmentUnion<br/>union_adaptive?"]
    pol -->|"False: even split by n_splits"| fx["fixed: many NARROW segments<br/>B~8 tilts, N~555 beams"]
    pol -->|"True: recursive bisection on beam drift"| ad["adaptive: few WIDE segments<br/>B~15 tilts, N~640 beams"]
    fx --> solve["_solve_segmented (per segment)"]
    ad --> solve
    solve --> prop["_propagate_matrix_exp<br/>over (B, T, N, N), T = n_thick"]
    prop -->|"unbounded: build whole transfer<br/>K temporaries"| big["fit_thickness peak<br/>fixed ~20 GB / adaptive ~49 GB"]
    big -->|"adaptive on A100"| oom["CUDA OOM in matrix_exp"]
```

The fix — stream the stack instead of materializing it — leaves the coupling untouched:

```mermaid
flowchart LR
    subgraph before["Before - unbounded"]
        b1["matrix_exp(a.unsqueeze(-3) * scalars)<br/>-> (B, T, N, N) transfer"]
        b2["peak ~ K*B*T*N^2<br/>adaptive abiraterone: ~49 GB/segment"]
        b1 --> b2
    end
    subgraph after["After - chunked"]
        a1["flatten to (B*T, N, N)<br/>stream row-blocks of max_batch"]
        a2["peak ~ K*max_batch*N^2<br/>transfer never materialized"]
        a1 --> a2
    end
```

## Design decisions & tradeoffs

- **Adaptive sizing folded into one recursive-bisection predicate** — a verbatim port of the private's `BlochNet.forward` path, drift-only (`new_pct > max_new_pct`). No cover-width cap: matches private exactly, including that a stable large cell produces wide segments.
- **Fix the OOM at the propagator, not the coupling.** Considered a `max_tilts_per_union` cap on the adaptive segmentation (would bound the cover `B`) — rejected: it *changes* the coupling approximation (different segments/beam sets), is public-only (no private analog), and only helps the adaptive path. The `matrix_exp` block chunk is exact, universal (fixed + adaptive, every compound), and has a genuine private analog.
- **`max_batch` is an engine class attribute, not a field on the `Method` value.** A field on a `MatrixExp` value would be the tightest scoping, but `method` rides the config digest (recipe identity) while `max_batch` is memory-only — bundling them would force a digest carve-out. It mirrors `precision`: a solve-level knob, kept out of the digest, documented as `matrix_exp`-only.
- **The device-memory query is a side effect — it stays at the shell.** Reading the GPU's free memory to "maximize the GPU" observes mutable ambient state (unlike `precision`, a pure choice), so it does not belong in the pure core. The engine default uses a pure, fixed per-`N` budget (`memory_safe_max_batch`); a caller that wants to fill a specific GPU pins `max_batch` explicitly. Auto-sizing from live device memory, if wanted, is a shell concern (a follow-up), not core behaviour.
- **Bound derives from `N`, not a fixed block count.** A large cell (bigger `N`, cubically heavier propagator) gets a proportionally smaller block; a fixed count would still blow up at large `N`.

## Honest assessment

- **Chunking matches the unbounded solve to *machine precision*, not bit-for-bit.** *Where:* `core/solver.py`. `torch.matrix_exp` shares one scaling-and-squaring count across a batch (from its max norm), so regrouping into blocks shifts rounding by ~1 ulp — measured `3e-16` (fp64). Whether `torch.equal` holds is data-dependent (only when all norms fall in the same squaring bucket), so the tests assert `allclose`, not equality. *Severity:* not a defect — no accuracy loss; the terminal refine/inference paths (`T=1`, small stacks) don't chunk at all, so the pinned result is unaffected.
- **The default budget (2 GiB) is a guardrail, not a tuned value.** *Where:* `DEFAULT_MATRIX_EXP_BUDGET_BYTES`. It is a no-op for ordinary solves and caps the pathological wide-segment x thickness-grid stacks; it does *not* maximize a large GPU on its own (that needs an explicit `max_batch` pin, by design — see the side-effect decision above). *Severity:* intended; documented.
- **`_MATRIX_EXP_LIVE_COPIES = 8` estimates `matrix_exp`'s live temporaries.** *Where:* `core/solver.py`. A conservative multiplier for the peak estimate; if `torch`'s implementation holds fewer copies the default under-utilizes slightly (safe direction). *Severity:* low; the knob is explicit for tuning.
- **Adaptive private-parity golden fixture still pending** (carried from the port commit). The segmentation is a verbatim algorithm port pinned by deterministic tests + the quartz fixture; a golden segment-set comparison vs a real private `union_adaptive=True` run is the remaining coverage. *Severity:* follow-up.

## File-by-file changes

| File | Change |
| --- | --- |
| `src/diffBloch/specs.py` | `TiltSegmentUnion`: add `union_adaptive`, `union_max_new_beams_pct` + validator; docstring |
| `src/diffBloch/config/schema.py` | `CouplingConfig`: same two fields, threaded through `to_policy()` |
| `src/diffBloch/preprocess/coupling.py` | `_adaptive_segment_ranges` (recursive bisection); `union_adaptive` branch; memoized excited-mask cache |
| `src/diffBloch/core/solver.py` | Chunked `_propagate_matrix_exp` (`max_batch`); `propagate` passthrough + validation; `memory_safe_max_batch` + budget/live-copies constants |
| `src/diffBloch/engine/forward.py` | `RefinementEngine.max_batch` + `_max_batch_for`; pass at the three `propagate` sites (static, batched, segmented) |
| `src/diffBloch/preprocess/scoring.py` | `build_engine(..., max_batch=None)` -> engine |
| `src/diffBloch/preprocess/steps/fit_thickness.py` | `max_batch` execution param -> `build_engine` (the OOM site) |
| `src/diffBloch/preprocess/steps/fit_orientation.py` | `max_batch` execution param -> `build_engine` |
| `tests/unit/test_coupling.py` | Adaptive-range tests: constant->1 seg, drift->splits, tiles `0..B-1`, single tilt, quartz fixture, pct validation |
| `tests/unit/test_config.py` | Adaptive fields default-off + thread-through |
| `tests/unit/test_core_solver.py` | Chunked vs unbounded to machine precision (fp64/fp32, batched + single), gradient flow, `bloch_eigen` ignores, validation, `memory_safe_max_batch` adapts to `N`/precision + floors at 1 |

## Testing

- `ruff` + `ruff format` + `mypy` clean; full unit suite **565 passed / 3 skipped**.
- Adaptive coupling: deterministic range tests + quartz-fixture integration (`union_adaptive=True` tiles all 42 tilts, keeps `(0,0,0)`) + config round-trip/validation.
- Propagator chunking: chunked matches unbounded to machine precision (fp64 `atol=1e-13`, fp32 `atol=1e-5`), across batched and single-system operators; gradient still flows to `Fgb`; `bloch_eigen` is inert to `max_batch`; non-positive `max_batch` rejected.
- A100 benchmark (adaptive abiraterone): the fix clears the `fit_thickness` `matrix_exp` OOM that unbounded adaptive hit — timings / segment-count characterization is the deferred follow-up.

## Migration & compatibility

- Adding the two `CouplingConfig` fields shifts `config_digest`, so committed preprocess checkpoints restale and regenerate on next run (acceptable pre-release).
- `max_batch` is **execution-only** (memory, never result) and is *not* in the digest — the memory fix adds no further restale, and defaulting `None` leaves every existing call path where it was unless a stack is large enough to chunk (then a ~1 ulp shift, never accuracy).

## Follow-ups

- Golden private-parity fixture for the adaptive path (segment ranges + per-segment beam sets vs a real private `union_adaptive=True` run).
- The coupling cap still carries the pre-gmax `g_max_sf/2` + `cap_margin` values (tracked independently; PR #2 addresses the radii).
- Optional shell-side auto-sizing of `max_batch` from live device free memory (the effect stays at the shell).
