### PR TITLE
Make refinement solve precision configurable

### DIFF
--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -225,9 +225,9 @@ def refine_experiment(
     recipe and ``checkpoint``/``refresh``/``device``/``workers`` semantics), then run the
     **default** single-stage refinement on that settled ``Plan``. This is the boring config-knobs
     path: the data term (:meth:`~diffBloch.config.schema.ObjectiveConfig.to_loss`), the trainable
-    selection
-    (:meth:`~diffBloch.config.schema.TrainableConfig.to_spec`), and the optimizer/step budget all
-    come from ``experiment.yaml``. It composes no hard constraints or penalties -- scientific
+    selection (:meth:`~diffBloch.config.schema.TrainableConfig.to_spec`), the solve precision, and
+    the optimizer/step budget all come from ``experiment.yaml``. It composes no hard constraints or
+    penalties -- scientific
     composition (hydrogen riding, freeze-H, penalties, multi-stage) is a Python/API concern, built
     with :func:`~diffBloch.engine.build_refinement_model`,
     :func:`~diffBloch.engine.build_refinement_problem`, and
@@ -257,6 +257,7 @@ def refine_experiment(
         refinement,
         loss=cfg.refinement.objective.to_loss(),
         method=cfg.solver.refine,
+        precision=cfg.refinement.precision,
         max_batch=max_batch,
     )
     initial = refinement.params if device is None else refinement.params.to(device)

--- a/src/diffBloch/config/schema.py
+++ b/src/diffBloch/config/schema.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Literal
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from diffBloch.core.solver import Method
+from diffBloch.core.solver import FloatFormat, Method
 from diffBloch.engine.losses import scaled_w_rbragg_loss, weighted_mse_loss
 from diffBloch.engine.refine import AtomSelection, TrainableSpec
 
@@ -203,13 +203,16 @@ class RefinementConfig(_StrictConfig):
     :func:`~diffBloch.engine.build_refinement_model`,
     :func:`~diffBloch.engine.build_refinement_problem`, and
     :func:`~diffBloch.engine.with_hydrogen_riding` -- and is promoted to config only once the
-    default recipe commits to it as stable public behaviour.
+    default recipe commits to it as stable public behaviour. ``precision`` selects the refinement
+    solve's numeric field: ``"fp64"`` keeps the complex128 default; ``"fp32"`` runs the Bloch solve
+    in complex64 for faster/lower-memory refines at reduced decimal precision.
     """
 
     steps: int = 500
     trainable: TrainableConfig = Field(default_factory=TrainableConfig)
     optimizer: OptimizerConfig = Field(default_factory=OptimizerConfig)
     objective: ObjectiveConfig = Field(default_factory=ObjectiveConfig)
+    precision: FloatFormat = "fp64"
     split: DataSplitConfig = Field(default_factory=DataSplitConfig)
 
 

--- a/src/diffBloch/core/solver.py
+++ b/src/diffBloch/core/solver.py
@@ -30,11 +30,10 @@ type Method = Literal["matrix_exp", "bloch_eigen"]
 # (the exact, reproducible field); "fp32" = float32 + complex64. It is deliberately a *coarse*
 # knob -- the coupled orientation fit's O(N^3) eigensolve scales with the beam count (~cell volume),
 # so on a large cell "fp32" ~halves that dominant cost, trading a basin-sensitive search
-# (non-determinism across platforms) for speed. The terminal Plan->Result (run_inference scoring,
-# refine) stays "fp64": the fit is re-scored there, so the pinned result stays exact even when the
-# search was coarse (design/decisions/combinators-and-recipe-identity.md: precision==checkpoint
-# boundary). The selecting param stays named `precision` (the role); the type is FloatFormat so the
-# type and its members compose (FloatFormat/fp32), avoiding the redundant Precision.FP32.
+# (non-determinism across platforms) for speed. Terminal inference stays "fp64"; refine defaults to
+# "fp64" but can opt into "fp32" as an explicit speed/precision tradeoff. The selecting param stays
+# named `precision` (the role); the type is FloatFormat so the type and its members compose
+# (FloatFormat/fp32), avoiding the redundant Precision.FP32.
 type FloatFormat = Literal["fp32", "fp64"]
 type Thicknesses = float | Sequence[float] | Tensor
 
@@ -83,11 +82,10 @@ def propagate(
     ``precision`` selects the numeric field of the eigensolve/matrix-exponential -- orthogonal to
     ``method``. ``"fp64"`` (the default) runs the whole propagation in complex128/float64 and is a
     pure identity on today's path (byte-identical). ``"fp32"`` downcasts the operator to complex64
-    and builds ``thicknesses`` at float32, roughly halving the O(N^3) solve's time and memory -- a
-    *search-time* knob for the preprocess fits (the O(N^3) cost scales with the beam count, i.e. the
-    cell volume). The terminal estimators (``run_inference`` scoring, ``refine``) never enable it:
-    fp32 perturbs the fit's basin, so the reproducible pinned result stays fp64. Ports
-    ``diffBloch_private`` ``dynamical.py``'s complex64 eigensolve (#127/#133).
+    and builds ``thicknesses`` at float32, roughly halving the O(N^3) solve's time and memory. It is
+    used automatically only by the preprocess fits' coarse search path; terminal inference keeps the
+    fp64 default, while refinement may opt into fp32 explicitly when speed matters more than decimal
+    places. Ports ``diffBloch_private`` ``dynamical.py``'s complex64 eigensolve (#127/#133).
 
     ``max_batch`` (``matrix_exp`` only) caps how many ``(N, N)`` operators are exponentiated in one
     ``torch.matrix_exp`` call. ``None`` (the default) builds the whole ``(..., T, N, N)`` transfer

--- a/src/diffBloch/engine/forward.py
+++ b/src/diffBloch/engine/forward.py
@@ -102,9 +102,9 @@ class RefinementEngine:
     loss: LossFn
     method: Method = "matrix_exp"
     # Solve numeric field. "fp64" everywhere by default (byte-identical to complex128). "fp32"
-    # (complex64) is a search-time knob, set only on the transient scoring engines the preprocess
-    # fits build; the terminal estimators (objective/refine here, run_inference via build_engine)
-    # never enable it, so the reproducible pinned result stays fp64. See core.solver.propagate.
+    # (complex64) is a speed/precision knob: preprocess uses it only for transient coarse-search
+    # engines, and the default refine path stays fp64 unless config opts in. See
+    # core.solver.propagate.
     precision: FloatFormat = "fp64"
     # matrix_exp propagator block cap (memory only; matches unbounded to machine precision, a
     # rounding-level ~1 ulp shift, never accuracy). None (default) lets each

--- a/src/diffBloch/preprocess/scoring.py
+++ b/src/diffBloch/preprocess/scoring.py
@@ -49,9 +49,9 @@ def build_engine(
     :meth:`RefinementEngine.score_orientation`, which apply their own scaling-optimised wR2.
 
     ``precision`` defaults to ``"fp64"`` (complex128 -- byte-identical to today). ``"fp32"``
-    (complex64) is a search-time knob only the preprocess fits set on their transient scoring
-    engines; the terminal callers here and in ``run_inference`` omit it, so scoring/refinement that
-    produce the pinned result stay fp64. See :func:`diffBloch.core.solver.propagate`.
+    (complex64) is a speed/precision knob: preprocess fits use it for transient coarse-search
+    engines, and the app refinement path may opt into it explicitly via config. Terminal inference
+    omits it and stays fp64. See :func:`diffBloch.core.solver.propagate`.
 
     ``max_batch`` (default ``None``) caps the ``matrix_exp`` propagator block; ``None`` lets each
     solve pick a memory-safe block from its beam count, bounding peak memory while matching the

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -37,6 +37,7 @@ def test_minimal_config_validates_with_defaults() -> None:
     assert cfg.refinement.trainable.occupancy == "none"
     assert cfg.refinement.optimizer.name == "lbfgs"
     assert cfg.refinement.objective.data_term == "weighted_r"
+    assert cfg.refinement.precision == "fp64"
     assert cfg.refinement.split.validation == "every_10th_rotation"
 
 
@@ -150,6 +151,14 @@ def test_refinement_trainable_replaces_string_targets() -> None:
         ExperimentConfig.model_validate({**base, "refinement": {"targets": ["positions"]}})
     with pytest.raises(ValidationError, match="[Ee]xtra"):
         ExperimentConfig.model_validate({**base, "refinement": {"trainable": {"thickness": "all"}}})
+
+
+def test_refinement_precision_parses_and_rejects_unknown_values() -> None:
+    base = {"name": "q", "inputs": {"structure": "q.cif", "observations": "q.cif_pets"}}
+    cfg = ExperimentConfig.model_validate({**base, "refinement": {"precision": "fp32"}})
+    assert cfg.refinement.precision == "fp32"
+    with pytest.raises(ValidationError, match="Input should be"):
+        ExperimentConfig.model_validate({**base, "refinement": {"precision": "bf16"}})
 
 
 def test_optimizer_and_objective_values_are_enumerated() -> None:

--- a/tests/unit/test_refine_precision.py
+++ b/tests/unit/test_refine_precision.py
@@ -1,0 +1,61 @@
+"""Refinement precision wiring for the app-level refine path."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+from diffBloch.app.program import refine_experiment
+from diffBloch.config.schema import ExperimentConfig
+
+
+def test_refine_experiment_threads_config_precision_to_engine(monkeypatch) -> None:
+    cfg = ExperimentConfig.model_validate(
+        {
+            "name": "q",
+            "inputs": {"structure": "q.cif", "observations": "q.cif_pets"},
+            "refinement": {"precision": "fp32"},
+        }
+    )
+    refinement = SimpleNamespace(params=SimpleNamespace(to=lambda device: "moved"))
+    prepared = object()
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr("diffBloch.app.program.load_experiment", lambda root: (cfg, object()))
+    monkeypatch.setattr(
+        "diffBloch.app.program._preprocess",
+        lambda *args, **kwargs: (refinement, prepared),
+    )
+
+    def fake_build_engine(plan, setup, *, loss, method, precision, max_batch):
+        seen["plan"] = plan
+        seen["setup"] = setup
+        seen["method"] = method
+        seen["precision"] = precision
+        seen["max_batch"] = max_batch
+        return "engine"
+
+    monkeypatch.setattr("diffBloch.app.program.build_engine", fake_build_engine)
+    monkeypatch.setattr(
+        "diffBloch.app.program.build_refinement_model",
+        lambda *, initial: SimpleNamespace(initial=initial),
+    )
+    monkeypatch.setattr("diffBloch.app.program.build_refinement_problem", lambda: "problem")
+
+    def fake_run_refinement_model(engine, model, problem, **kwargs):
+        seen["engine"] = engine
+        seen["initial"] = model.initial
+        return SimpleNamespace(losses=torch.tensor([1.0]), best_loss=1.0, best_step=0)
+
+    monkeypatch.setattr("diffBloch.app.program.run_refinement_model", fake_run_refinement_model)
+
+    result = refine_experiment(Path("/experiment"), device="cuda", max_batch=7)
+
+    assert result.best_loss == 1.0
+    assert seen["plan"] is prepared
+    assert seen["setup"] is refinement
+    assert seen["method"] == "matrix_exp"
+    assert seen["precision"] == "fp32"
+    assert seen["max_batch"] == 7
+    assert seen["engine"] == "engine"
+    assert seen["initial"] == "moved"

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -213,12 +213,13 @@ def test_fp32_scores_end_to_end_through_build_engine() -> None:
     assert score.shape == () and torch.isfinite(score)
 
 
-def test_terminal_stays_fp64_and_exposes_no_precision_knob() -> None:
-    """The safety-critical invariant: the terminal Plan->Result never runs fp32.
+def test_terminal_defaults_fp64_and_inference_exposes_no_precision_knob() -> None:
+    """The default terminal engine is fp64; inference exposes no coarse precision knob.
 
-    Two layers. (a) The default engine is fp64 -- the solve produces complex128 / float64, so the
-    pinned result is exact. (b) Structural: ``run_inference`` exposes no ``precision`` parameter, so
-    a coarse search cannot leak into the terminal by construction, not merely by callers omitting.
+    The default engine is fp64 -- the solve produces complex128 / float64, so existing callers keep
+    the exact path. ``run_inference`` exposes no ``precision`` parameter, so a coarse preprocess
+    search cannot leak into terminal inference by construction. App refinement has its own explicit
+    config opt-in, covered in the app-layer tests.
     """
     plan, refinement = _silicon_plan()
     engine = build_engine(plan, refinement)  # no precision -> fp64


### PR DESCRIPTION
## Summary

This PR makes the refinement solve precision configurable while preserving the existing complex128/float64 path by default for existing users. It also opts the checked-in example experiment configs into `refinement.precision: fp32`, so example refines use the faster coarse solve path by default.

## What changed

### Refinement config now owns the refine precision knob

- Added `RefinementConfig.precision: FloatFormat = "fp64"` in `src/diffBloch/config/schema.py`.
- The field reuses the existing solver-level `FloatFormat` literal (`"fp32" | "fp64"`).
- The schema default remains `"fp64"`, so existing configs continue to run the current complex128/float64 refinement path unless they opt in.

Example opt-in:

```yaml
refinement:
  precision: fp32
```

### App refine path threads config precision into the engine

- `refine_experiment()` now passes `cfg.refinement.precision` into `build_engine(...)`.
- The existing lower-level precision path was already present (`RefinementEngine.precision`, `build_engine(..., precision=...)`, `propagate(..., precision=...)`, and `precision_dtypes`). This PR exposes that path to the default app refinement run.

### Examples opt into the faster coarse refine path

All example `experiment.yaml` files now declare:

```yaml
refinement:
  precision: fp32
```

This changes example behavior only. It does not change the schema default and does not restale preprocess checkpoints because refinement execution fields are outside the preprocess `config_digest`.

### Documentation/comments updated to match the new invariant

Updated precision prose in:

- `src/diffBloch/core/solver.py`
- `src/diffBloch/engine/forward.py`
- `src/diffBloch/preprocess/scoring.py`
- `src/diffBloch/app/program.py`

The new invariant is:

- terminal inference stays fp64-only;
- app refinement defaults to fp64 at the schema level;
- app refinement may explicitly opt into fp32;
- examples opt into fp32;
- preprocess fp32 remains a coarse-search optimization path.

### Tests added/updated

- `tests/unit/test_config.py` pins the default precision and validates accepted/rejected values.
- `tests/unit/test_refine_precision.py` asserts `refine_experiment()` passes config precision to `build_engine()`.
- `tests/unit/test_scoring.py` updates the default/inference precision invariant wording.

## Architecture & data flow

```mermaid
flowchart TD
    YAML[experiment.yaml\nrefinement.precision] --> Config[ExperimentConfig / RefinementConfig]
    Config --> Program[refine_experiment]
    Program --> EngineBuild[build_engine\nprecision=cfg.refinement.precision]
    EngineBuild --> Engine[RefinementEngine.precision]
    Engine --> Solve[_solve / _solve_segmented]
    Solve --> Propagate[propagate precision]
    Propagate --> DTypes[precision_dtypes]
    DTypes --> FP64[fp64: float64 + complex128]
    DTypes --> FP32[fp32: float32 + complex64]
```

```mermaid
sequenceDiagram
    participant User as experiment.yaml
    participant Program as refine_experiment
    participant Build as build_engine
    participant Engine as RefinementEngine
    participant Solver as propagate

    User->>Program: refinement.precision = fp32 or fp64
    Program->>Build: precision=cfg.refinement.precision
    Build->>Engine: construct engine with precision
    Engine->>Solver: propagate(..., precision=self.precision)
    Solver->>Solver: cast operator/thickness dtype
    Solver-->>Engine: amplitudes in complex64 or complex128
```

## Design decisions & tradeoffs

### Decision: put the knob under `refinement.precision`

- **Alternatives considered**: `solver.precision`, CLI-only flag, or a new `numerics` field.
- **Tradeoff**: Method remains under `solver.refine` while precision lives under `refinement.precision`.
- **Rationale**: The feature is specifically refine-pass precision. Keeping it under `refinement` avoids implying inference or preprocess checkpoint identity should change.

### Decision: schema default remains fp64, examples opt into fp32

- **Alternatives considered**: Change the global default to fp32 or automatically choose fp32 for large cells.
- **Tradeoff**: Existing user configs keep the exact path; examples now prioritize speed over maximum decimal precision.
- **Rationale**: fp32 can alter the objective surface and optimizer trajectory, so global behavior should remain conservative. Examples are performance-oriented entry points and now demonstrate the opt-in explicitly.

### Decision: do not downcast `RefinableParams`

- **Alternatives considered**: Move all trainable tensors and structure-factor calculation into float32 when `refinement.precision == "fp32"`.
- **Tradeoff**: This PR leaves some performance on the table because structure-factor generation remains in the existing dtype before the solve boundary.
- **Rationale**: Profiling showed the existing solve precision path already gives a large speedup (~38.1s -> ~18.0s for one abiraterone rotation/step). Downcasting trainable parameters is a broader semantic change and should be separate.

### Decision: keep preprocess checkpoint identity unchanged

- **Alternatives considered**: Include `refinement.precision` in `config_digest`.
- **Tradeoff**: The same `plan.npz` checkpoint can be reused for both fp64 and fp32 refines.
- **Rationale**: `config_digest()` is scoped to values that determine the settled preprocess `Plan`. Refinement precision changes terminal optimization execution, not checkpointed geometry.

## Honest assessment

### 1. The config field is not surfaced as a CLI override

- **What**: Users must edit YAML to switch precision; there is no `diffbloch run refine --precision fp32` override.
- **Where**: `src/diffBloch/app/cli.py` remains unchanged.
- **Why it's wrong**: Execution knobs like `--device` and `--max-batch` are available at the CLI boundary, and precision is partly an execution/performance knob too.
- **What right looks like**: Add a CLI-only override such as `--refine-precision {fp32,fp64}` that defaults to config and does not alter preprocess checkpoint identity.
- **Severity**: tech debt to track.

### 2. fp32 refine only downcasts the solve, not the whole objective

- **What**: `refinement.precision: fp32` reaches `propagate()` and casts the Bloch operator/thickness path, but trainable params and structure-factor assembly remain in their existing dtype until the solve boundary.
- **Where**: `src/diffBloch/engine/forward.py` through `_structure_factors_from_state()` and `src/diffBloch/core/scattering.py`.
- **Why it's wrong**: “Lower precision refine” could be interpreted as the entire refine pass running float32. This implementation is narrower: complex64 propagation with existing-dtype structure-factor generation.
- **What right looks like**: If profiling shows `structure_factors` dominates, add a separate explicit parameter/model dtype decision and validate optimizer behavior in fp32 end-to-end.
- **Severity**: fix soon after if more speed is needed.

### 3. No e2e fp32 refinement characterization was added

- **What**: Unit tests prove config parsing and wiring, and example configs validate, but no e2e test runs checkpointed `refine_experiment()` with `precision: fp32` and asserts finite descent.
- **Where**: `tests/e2e/test_refine.py` remains fp64/default only.
- **Why it's wrong**: The actual feature is app-level fp32 refinement, and a unit monkeypatch cannot catch unexpected dtype interactions in a full checkpointed refine.
- **What right looks like**: Add a short e2e variant over the quartz checkpoint with `steps: 2` and `precision: fp32`, with loose assertions for finite objective and best-step indexing.
- **Severity**: fix soon after.

### 4. The profiling helper was not kept

- **What**: I used a temporary checkpoint profiling helper to measure fp64 vs fp32 and then removed it before committing.
- **Where**: no committed file; profiling was run from `scripts/profile_refine_checkpoint.py` during development.
- **Why it's wrong**: Performance claims in the PR body are harder to reproduce without a checked-in profiling command.
- **What right looks like**: Add a supported benchmark/profiling script or a `just profile-refine` target that loads a checkpoint, subsets rotations, and runs configurable refinement steps.
- **Severity**: tech debt to track.

### 5. Example configs now choose speed over precision

- **What**: Every example opts into `precision: fp32`.
- **Where**: `examples/**/experiment.yaml`.
- **Why it's wrong**: Examples often teach defaults. A reader may incorrectly infer fp32 is the global recommended scientific default rather than an example-level speed tradeoff.
- **What right looks like**: Add user docs explaining the distinction: schema default is fp64; examples choose fp32 for quicker iteration; use fp64 for final high-precision refines.
- **Severity**: tech debt to track.

## File-by-file changes

| File | Change |
|---|---|
| `src/diffBloch/config/schema.py` | Imports `FloatFormat`; adds `RefinementConfig.precision` defaulting to `"fp64"`; documents fp32/complex64 refine opt-in. |
| `src/diffBloch/app/program.py` | Threads `cfg.refinement.precision` into `build_engine()` in `refine_experiment()` and updates refine docstring. |
| `src/diffBloch/core/solver.py` | Updates precision comments/docstring to reflect fp32 being an explicit refine option while inference remains fp64. |
| `src/diffBloch/engine/forward.py` | Updates `RefinementEngine.precision` comment to reflect default-fp64/refine-opt-in behavior. |
| `src/diffBloch/preprocess/scoring.py` | Updates `build_engine()` precision docstring to mention app refinement config opt-in and inference fp64 default. |
| `tests/unit/test_config.py` | Pins default refine precision and validates accepted/rejected precision values. |
| `tests/unit/test_refine_precision.py` | Adds app-layer wiring test proving `refine_experiment()` passes config precision to `build_engine()`. |
| `tests/unit/test_scoring.py` | Updates terminal precision test wording for the new app-refine opt-in while preserving fp64 default/inference invariant. |
| `examples/**/experiment.yaml` | Adds `refinement.precision: fp32` so example refines use the faster coarse solve path by default. |

## Testing

Automated tests run:

```bash
uv run pytest tests/unit/test_config.py tests/unit/test_refine_precision.py tests/unit/test_scoring.py -q
# 42 passed, 1 skipped

uv run ruff check src/diffBloch/app/program.py src/diffBloch/config/schema.py src/diffBloch/core/solver.py src/diffBloch/engine/forward.py src/diffBloch/preprocess/scoring.py tests/unit/test_config.py tests/unit/test_scoring.py tests/unit/test_refine_precision.py
# All checks passed

uv run mypy src/diffBloch
# Success: no issues found in 62 source files

uv run pytest -q
# 578 passed, 3 skipped, 9 deselected

uv run python - <<'PY'
from pathlib import Path
from diffBloch.config import load_config
for path in sorted(Path('examples').rglob('experiment.yaml')):
    cfg = load_config(path)
    assert cfg.refinement.precision == 'fp32', path
PY
```

Manual profiling before implementation:

```bash
OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 TORCH_NUM_THREADS=1 \
uv run python scripts/profile_refine_checkpoint.py \
  examples/experiments/abiraterone-checkpoint \
  --rotations 1 --steps 1 --precision fp64
# fp64: 38.061 s, initial_loss 0.1115467762

OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 TORCH_NUM_THREADS=1 \
uv run python scripts/profile_refine_checkpoint.py \
  examples/experiments/abiraterone-checkpoint \
  --rotations 1 --steps 1 --precision fp32
# fp32: 17.981 s, initial_loss 0.1115193018
```

## Migration & compatibility

This is backward-compatible for existing user configs:

- existing experiment YAMLs continue to validate because `refinement.precision` defaults to `"fp64"`;
- existing refinement behavior remains fp64/complex128 unless users opt into `"fp32"`;
- example experiment YAMLs now opt into `"fp32"` deliberately;
- preprocess checkpoint identity is unchanged because `config_digest()` only includes refinement split, not refinement execution knobs;
- no serialized `plan.npz` format changes are introduced.