### PR TITLE
examples: opt into fp32 refinement precision

### DIFF
--- a/examples/experiments/abiraterone-checkpoint/experiment.yaml
+++ b/examples/experiments/abiraterone-checkpoint/experiment.yaml
@@ -45,6 +45,7 @@ preprocess:
     sg_max: 0.02
 
 refinement:
+  precision: fp32
   # Stable execution knobs for the DEFAULT `diffbloch run refine` path: refine positions + ADPs
   # against the observed intensities, Adam at the private abiraterone learning rate. This is the
   # boring config-knobs default; it composes no hard constraints. Hydrogen *riding* (deriving each H

--- a/examples/experiments/lta/experiment.yaml
+++ b/examples/experiments/lta/experiment.yaml
@@ -24,6 +24,7 @@ preprocess:
     g_max: 2.25
     sg_max: 0.01
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/experiments/quartz-checkpoint/experiment.yaml
+++ b/examples/experiments/quartz-checkpoint/experiment.yaml
@@ -38,6 +38,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/experiments/quartz/experiment.yaml
+++ b/examples/experiments/quartz/experiment.yaml
@@ -38,6 +38,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/papers/malik-2026-hybrid-physics-ml/experiments/cspbbr3-experimental/experiment.yaml
+++ b/examples/papers/malik-2026-hybrid-physics-ml/experiments/cspbbr3-experimental/experiment.yaml
@@ -36,6 +36,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/papers/malik-2026-hybrid-physics-ml/experiments/cspbbr3-synthetic/experiment.yaml
+++ b/examples/papers/malik-2026-hybrid-physics-ml/experiments/cspbbr3-synthetic/experiment.yaml
@@ -39,6 +39,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/papers/malik-2026-hybrid-physics-ml/experiments/paracetamol-experimental/experiment.yaml
+++ b/examples/papers/malik-2026-hybrid-physics-ml/experiments/paracetamol-experimental/experiment.yaml
@@ -28,6 +28,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/papers/malik-2026-hybrid-physics-ml/experiments/paracetamol-synthetic/experiment.yaml
+++ b/examples/papers/malik-2026-hybrid-physics-ml/experiments/paracetamol-synthetic/experiment.yaml
@@ -28,6 +28,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/papers/malik-2026-hybrid-physics-ml/experiments/quartz-experimental/experiment.yaml
+++ b/examples/papers/malik-2026-hybrid-physics-ml/experiments/quartz-experimental/experiment.yaml
@@ -28,6 +28,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/papers/malik-2026-hybrid-physics-ml/experiments/quartz-synthetic/experiment.yaml
+++ b/examples/papers/malik-2026-hybrid-physics-ml/experiments/quartz-synthetic/experiment.yaml
@@ -28,6 +28,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation


### PR DESCRIPTION
Set refinement.precision to fp32 in example experiment configs so example refines use the faster coarse solve path by default while the schema default remains fp64 for existing users.