### PR TITLE
Opt examples into fp32 refinement precision

### DIFF
--- a/examples/experiments/abiraterone-checkpoint/experiment.yaml
+++ b/examples/experiments/abiraterone-checkpoint/experiment.yaml
@@ -45,6 +45,7 @@ preprocess:
     sg_max: 0.02
 
 refinement:
+  precision: fp32
   # Stable execution knobs for the DEFAULT `diffbloch run refine` path: refine positions + ADPs
   # against the observed intensities, Adam at the private abiraterone learning rate. This is the
   # boring config-knobs default; it composes no hard constraints. Hydrogen *riding* (deriving each H

--- a/examples/experiments/lta/experiment.yaml
+++ b/examples/experiments/lta/experiment.yaml
@@ -24,6 +24,7 @@ preprocess:
     g_max: 2.25
     sg_max: 0.01
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/experiments/quartz-checkpoint/experiment.yaml
+++ b/examples/experiments/quartz-checkpoint/experiment.yaml
@@ -38,6 +38,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/experiments/quartz/experiment.yaml
+++ b/examples/experiments/quartz/experiment.yaml
@@ -38,6 +38,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/papers/malik-2026-hybrid-physics-ml/experiments/cspbbr3-experimental/experiment.yaml
+++ b/examples/papers/malik-2026-hybrid-physics-ml/experiments/cspbbr3-experimental/experiment.yaml
@@ -36,6 +36,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/papers/malik-2026-hybrid-physics-ml/experiments/cspbbr3-synthetic/experiment.yaml
+++ b/examples/papers/malik-2026-hybrid-physics-ml/experiments/cspbbr3-synthetic/experiment.yaml
@@ -39,6 +39,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/papers/malik-2026-hybrid-physics-ml/experiments/paracetamol-experimental/experiment.yaml
+++ b/examples/papers/malik-2026-hybrid-physics-ml/experiments/paracetamol-experimental/experiment.yaml
@@ -28,6 +28,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/papers/malik-2026-hybrid-physics-ml/experiments/paracetamol-synthetic/experiment.yaml
+++ b/examples/papers/malik-2026-hybrid-physics-ml/experiments/paracetamol-synthetic/experiment.yaml
@@ -28,6 +28,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/papers/malik-2026-hybrid-physics-ml/experiments/quartz-experimental/experiment.yaml
+++ b/examples/papers/malik-2026-hybrid-physics-ml/experiments/quartz-experimental/experiment.yaml
@@ -28,6 +28,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation

--- a/examples/papers/malik-2026-hybrid-physics-ml/experiments/quartz-synthetic/experiment.yaml
+++ b/examples/papers/malik-2026-hybrid-physics-ml/experiments/quartz-synthetic/experiment.yaml
@@ -28,6 +28,7 @@ preprocess:
     sg_max: 0.01
 
 refinement:
+  precision: fp32
   split:
     train: all_except_validation
     validation: every_10th_rotation


### PR DESCRIPTION
## Summary

The precision-config PR was merged before the examples update landed, so this follow-up applies only the example YAML opt-in. All checked-in example experiments now set `refinement.precision: fp32` so example refines use the faster coarse solve path by default while the schema default remains conservative (`fp64`).

## What changed

### Example experiment configs opt into fp32 refinement

Added this field under each example `refinement:` block:

```yaml
refinement:
  precision: fp32
```

Affected example groups:

- `examples/experiments/*`
- `examples/papers/malik-2026-hybrid-physics-ml/experiments/*`

No source code changes are included in this PR. The merged schema already supports `refinement.precision`.

## Architecture & data flow

```mermaid
flowchart TD
    ExampleYAML[Example experiment.yaml\nrefinement.precision: fp32]
    ExampleYAML --> Config[load_config / ExperimentConfig]
    Config --> Refine[refine_experiment]
    Refine --> Engine[build_engine precision=fp32]
    Engine --> Solver[propagate]
    Solver --> Complex64[complex64 / float32 solve path]
```

## Design decisions & tradeoffs

### Decision: examples opt in, schema default stays fp64

- **Decision**: Set `refinement.precision: fp32` in examples rather than changing the global schema default.
- **Alternatives considered**: Make fp32 the default for all refines, or leave examples implicit.
- **Tradeoff**: Examples now prioritize speed and lower memory over maximum decimal precision. Existing user configs remain on fp64 unless they explicitly opt in.
- **Rationale**: Examples are often used for quick iteration and demonstration, so they should take the faster path. The library default should remain conservative because fp32 can alter optimizer trajectories.

## Honest assessment

### 1. Examples can be mistaken for scientific defaults

- **What**: Every example now opts into fp32.
- **Where**: `examples/**/experiment.yaml`.
- **Why it's wrong**: Users may copy examples and assume fp32 is the recommended final-refinement precision, even though it is a speed/precision tradeoff.
- **What right looks like**: Add docs explaining that examples choose fp32 for faster iteration and that fp64 remains the conservative final-refine default.
- **Severity**: tech debt to track.

### 2. No example README text was updated

- **What**: The YAML files changed, but adjacent README/docs text does not call out the precision choice.
- **Where**: `examples/experiments/*/README.md` where present, and broader docs.
- **Why it's wrong**: A silent config change makes the examples faster but less self-explanatory.
- **What right looks like**: Add a short note in example docs describing `refinement.precision` and when to switch back to `fp64`.
- **Severity**: fix soon after.

## File-by-file changes

| File | Change |
|---|---|
| `examples/experiments/abiraterone-checkpoint/experiment.yaml` | Adds `refinement.precision: fp32`. |
| `examples/experiments/lta/experiment.yaml` | Adds `refinement.precision: fp32`. |
| `examples/experiments/quartz-checkpoint/experiment.yaml` | Adds `refinement.precision: fp32`. |
| `examples/experiments/quartz/experiment.yaml` | Adds `refinement.precision: fp32`. |
| `examples/papers/malik-2026-hybrid-physics-ml/experiments/cspbbr3-experimental/experiment.yaml` | Adds `refinement.precision: fp32`. |
| `examples/papers/malik-2026-hybrid-physics-ml/experiments/cspbbr3-synthetic/experiment.yaml` | Adds `refinement.precision: fp32`. |
| `examples/papers/malik-2026-hybrid-physics-ml/experiments/paracetamol-experimental/experiment.yaml` | Adds `refinement.precision: fp32`. |
| `examples/papers/malik-2026-hybrid-physics-ml/experiments/paracetamol-synthetic/experiment.yaml` | Adds `refinement.precision: fp32`. |
| `examples/papers/malik-2026-hybrid-physics-ml/experiments/quartz-experimental/experiment.yaml` | Adds `refinement.precision: fp32`. |
| `examples/papers/malik-2026-hybrid-physics-ml/experiments/quartz-synthetic/experiment.yaml` | Adds `refinement.precision: fp32`. |

## Testing

Validated that every example config loads and resolves to `fp32`:

```bash
uv run python - <<'PY'
from pathlib import Path
from diffBloch.config import load_config
for path in sorted(Path('examples').rglob('experiment.yaml')):
    cfg = load_config(path)
    assert cfg.refinement.precision == 'fp32', path
PY
```

Relevant unit tests:

```bash
uv run pytest tests/unit/test_config.py tests/unit/test_refine_precision.py -q
# 29 passed
```

## Migration & compatibility

This changes only example behavior. Existing user configs are unaffected and still default to `fp64` unless they add `refinement.precision: fp32` themselves. Preprocess checkpoint identity remains unchanged because refinement execution knobs are outside `config_digest`.
