### PR TITLE
Clarify the homepage architecture overview

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,12 +13,80 @@ map inspectable, reproducible, and safe to evolve, and lives *around* the core, 
 
 ## Status
 
-The 2.0 package is a from-scratch, stepwise port of the research codebase, now feature-complete
-through the full inference recipe: config + IO at the boundary, the differentiable Bloch-wave core,
-the refinement engine, the composable `Plan → Plan` preprocess pipeline (beam selection,
-orientation/thickness fits, rocking-curve integration, mosaicity, convergence sweeps), typed
-observability with pluggable logger backends, and the thin `diffbloch` CLI. The physics is pinned
-end-to-end by the opt-in quartz anchor e2e tests.
+diffBloch starts with a deterministic Bloch-wave simulation, then exposes selected simulation
+inputs as differentiable parameters. In PyTorch terms, those parameters sit inside an optimization
+loop: each pass simulates diffraction from the current structure, compares the calculated beams with
+an observed diffraction pattern, and uses gradients to improve the inputs so the simulation moves
+towards the experiment. The differentiable parameters are structural quantities — primarily
+asymmetric-unit (ASU) atom coordinates, with ADPs, occupancies, and structure factors available as
+refinable groups.
+
+The surrounding orchestration is deliberately a shell around that stable, physics-grounded
+deterministic simulation. Its central layer is preprocessing, which produces a `Plan`: the immutable
+geometry and data context the simulator will consume — shared structure-factor support, per-rotation
+orientations, beam sets, rocking-curve tilts, observed patterns, alignments, and fitted nuisance
+values such as thickness. The `Plan` is not the structure being refined; it is the settled scaffold
+around the differentiable structural parameters that enter the optimization loop. Preprocessing is a
+composable `Plan → Plan` pipeline: its steps select the solve beams, build per-orientation plans,
+integrate rocking-curve tilts, apply mosaicity, fit orientation and thickness against
+simulation/observation agreement, optionally sweep numerical coverage/convergence knobs, and settle
+coupled beam unions for the final forward model. Because this settled `Plan` is expensive and
+reusable, diffBloch checkpoints it as `plan.npz` plus a lock file, so later inference or refinement
+runs can resume from the same validated preprocessing state instead of recomputing it. Config, IO,
+logging, checkpointing, and the CLI wrap that pipeline so the workflow stays reproducible and
+inspectable without becoming part of the scientific core.
+
+diffBloch is driven by two input files: experimental diffraction data processed by
+[PETS2](https://pets.fzu.cz/) into `.cif_pets`, and a starting crystal structure as a standard
+`.cif`. Because the simulator makes concrete assumptions about the shapes, units, indices, and
+crystallographic meaning in those files, diffBloch does not pass parser output directly into the
+numerical core. It reads CIF/PETS data into typed [Pydantic](https://docs.pydantic.dev/) models
+first, so invalid or unsupported input fails at the boundary with explicit validation errors.
+
+| File | Role |
+|---|---|
+| `experiment.yaml` | Experiment config and references to the input files. |
+| `structure.cif` | Starting crystal structure. |
+| `observations.cif_pets` | Processed experimental diffraction observations. |
+| `experiment.lock` | Content identity for the input CIF/PETS files. |
+| `plan.npz` / `plan.lock` | Reusable preprocessing checkpoint and its provenance lock. |
+
+To make refinements reproducible across the expensive preprocessing boundary, diffBloch records the
+identity of the input CIFs and the preprocessing recipe. `experiment.lock` pins the structure and
+observation files by content hash; `plan.lock` then ties a `plan.npz` checkpoint to that input lock,
+the resolved preprocess-determining config, the ordered preprocess steps, the producing code
+version, and the checkpoint artifact hash. This gives diffBloch-driven inference and refinement runs
+a verifiable starting point: a reused checkpoint is known to match the inputs and preprocessing that
+produced it, rather than being an unlabelled intermediate file.
+
+As the pipeline runs, diffBloch emits typed observability events for preprocessing, coupling,
+inference, and refinement progress. The default CLI prints those events through a console logger,
+and the same event stream can be sent to CSV, Weights & Biases, or Comet; writing another logger is
+just a matter of implementing the small logger protocol for the event objects you care about.
+
+```mermaid
+flowchart LR
+    Inputs[.cif + .cif_pets + config] --> Records[typed records]
+    Records --> Plan[preprocessed Plan]
+    Plan --> Sim[deterministic Bloch-wave simulation]
+    Params[differentiable structural parameters] --> Sim
+    Sim --> Loss[R-loss vs observed pattern]
+    Loss --> Gradients[gradients]
+    Gradients --> Params
+```
+
+For day-to-day use, diffBloch ships with a CLI that has sane defaults for both preprocessing and the
+refinement loop, and can be run out of the box against bundled compounds such as quartz,
+abiraterone, LTA, and CsPbBr3. The examples choose `refinement.precision: fp32` for faster
+iteration; switch that field to `fp64` for the conservative highest-precision refinement path.
+
+```bash
+diffbloch run refine examples/experiments/quartz-checkpoint
+```
+
+It also supports scientific research workflows for power users who need to compose their own
+pipelines, constraints, penalties, or model components. To get started with those patterns, review
+`examples/papers`, which shows more advanced usage than the default CLI path.
 
 ## Quickstart
 
@@ -29,8 +97,12 @@ diffbloch run refine <experiment_dir>  # gradient-refine the structure against t
 diffbloch run pack <run_dir>           # export a run directory (zip/tar/BagIt/RO-Crate)
 ```
 
-Python users compose their own preprocess with the public API (`from_experiment` + the `preprocess`
-steps + `run_inference`); the CLI is the friendly default runner, not the only path.
+Use `infer` when you want to simulate and score a settled plan without changing parameters. Use
+`refine` when you want to run the optimization loop and update the structural parameters.
+
+Python users can compose preprocessing steps, constraints, penalties, and refinement problems
+directly with the public API; the CLI is the friendly default runner, not the only path. See
+`examples/papers` for more advanced composition patterns.
 
 ## API
 


### PR DESCRIPTION
## Summary

This PR rewrites the homepage status section as a warmer architecture overview instead of a terse feature-completeness inventory. It explains diffBloch's core pattern — deterministic Bloch-wave simulation wrapped in a differentiable optimization loop — and situates preprocessing, typed IO/config, checkpoint locks, observability, and the CLI around that core.

## What changed

### Homepage architecture narrative

`docs/index.md` now describes diffBloch as starting from a deterministic Bloch-wave simulation whose selected inputs are exposed as differentiable structural parameters. The prose explains the PyTorch optimization loop in user-facing terms: simulate diffraction from the current structure, compare calculated beams against observed diffraction data, and use gradients to improve the structural inputs.

### `Plan` and preprocessing are defined up front

The old status paragraph listed pipeline features without defining the central `Plan` object. The new text defines a `Plan` as the immutable geometry/data scaffold consumed by the simulator — structure-factor support, per-rotation orientations, beam sets, rocking-curve tilts, observed patterns, alignments, and fitted nuisance values such as thickness. It also clarifies that the `Plan` is not the refined structure itself; it is the settled context around the differentiable structural parameters.

The preprocessing paragraph now describes the composable `Plan → Plan` pipeline and names its major responsibilities: beam selection, per-orientation plan building, rocking-curve integration, mosaicity, orientation/thickness fitting, optional coverage/convergence sweeps, and coupled beam unions.

### Typed IO/config and reproducibility locks

The homepage now explains the two primary input files:

- a starting crystal structure as `.cif`;
- experimental diffraction observations processed through PETS2 into `.cif_pets`.

It adds a small input/artifact table covering `experiment.yaml`, input CIF/PETS files, `experiment.lock`, and `plan.npz` / `plan.lock`. It also describes how `experiment.lock` and `plan.lock` give inference/refinement runs a verifiable preprocessing starting point by tying checkpoints to input hashes, resolved preprocess config, ordered preprocess steps, code version, and artifact hash.

### Observability and logger model

The page now calls out typed observability events and the logger surface: console logging by default, CSV/W&B/Comet support, and the small custom logger protocol for power users.

### CLI and examples guidance

The page now gives a concrete one-liner:

```bash
diffbloch run refine examples/experiments/quartz-checkpoint
```

It notes that examples opt into `refinement.precision: fp32` for faster iteration, and that users can switch to `fp64` for the conservative high-precision refine path. It also distinguishes `infer` from `refine` and points power users at `examples/papers` for more advanced composition patterns.

## Architecture & data flow

```mermaid
flowchart LR
    Inputs[.cif + .cif_pets + config] --> Records[typed records]
    Records --> Plan[preprocessed Plan]
    Plan --> Sim[deterministic Bloch-wave simulation]
    Params[differentiable structural parameters] --> Sim
    Sim --> Loss[R-loss vs observed pattern]
    Loss --> Gradients[gradients]
    Gradients --> Params
```

The homepage now uses this same diagram to show the core loop and where the preprocessing output (`Plan`) sits relative to the differentiable structural parameters.

## Design decisions & tradeoffs

### Decision: replace the old status inventory with an architecture explanation

- **Alternatives considered**: Keep the status section as a feature checklist and add architecture elsewhere.
- **Tradeoff**: The homepage is now longer. In return, first-time readers get the conceptual model immediately rather than a dense list of modules.
- **Rationale**: The old section was accurate but too curt; it did not explain why these pieces exist or how they compose around the scientific core.

### Decision: define `Plan` in prose rather than linking away immediately

- **Alternatives considered**: Link to API docs and leave the homepage shorter.
- **Tradeoff**: Slight duplication with API docs. In return, the central vocabulary is defined before it appears in the quickstart/API guidance.
- **Rationale**: `Plan` is a project-specific abstraction. New users should not have to infer it from API names.

### Decision: describe checkpoint locks carefully instead of claiming full reproducibility

- **Alternatives considered**: Say locks “guarantee reproducible refinements.”
- **Tradeoff**: The wording is less punchy. In return, it avoids overclaiming optimizer determinism across hardware/threading/precision differences.
- **Rationale**: The locks verify input/preprocess/checkpoint identity. That is a strong and useful guarantee, but not the same as global numerical determinism.

### Decision: disclose example `fp32` precision on the homepage

- **Alternatives considered**: Leave precision details to examples or config docs.
- **Tradeoff**: Adds implementation detail to the front page. In return, users copying examples understand that they are choosing a speed/precision tradeoff.
- **Rationale**: Examples now opt into `fp32`; the homepage one-liner points directly at an example, so the tradeoff should be visible there.

## Honest assessment

### 1. The homepage is now doing a lot

- **What**: The status section now covers core physics, preprocessing, input files, locks, observability, examples, and power-user workflows.
- **Where**: `docs/index.md`, under `## Status`.
- **Why it's wrong**: A homepage should be concise. This section risks becoming a mini whitepaper rather than a landing page.
- **What right looks like**: Split the material into a short homepage plus dedicated “Architecture”, “Inputs”, and “Reproducibility” pages, then link to those from the homepage.
- **Severity**: fix soon after if the docs continue to grow.

### 2. PETS2 linkage may need a more specific canonical URL

- **What**: The link uses `https://pets.fzu.cz/`.
- **Where**: `docs/index.md`, input paragraph.
- **Why it's wrong**: This may be the project landing page rather than the best durable PETS2 software/reference URL.
- **What right looks like**: Confirm the canonical PETS2 URL/citation and link directly to that page or add a reference in `REFERENCES.md`.
- **Severity**: tech debt to track.

### 3. Logger prose mentions W&B/Comet without install guidance

- **What**: The homepage says the event stream can be sent to Weights & Biases or Comet, but does not mention optional extras or setup.
- **Where**: `docs/index.md`, observability paragraph.
- **Why it's wrong**: Users may expect these integrations to work without installing extras or configuring credentials.
- **What right looks like**: Link to observability/API docs or add a short note such as “install the relevant optional extra and configure the backend credentials.”
- **Severity**: tech debt to track.

### 4. “Deep learning loop” is translated as PyTorch optimization loop, but not named precisely

- **What**: The docs say “optimization loop” rather than naming a specific ML-land abstraction such as `torch.optim`.
- **Where**: `docs/index.md`, first status paragraph.
- **Why it's wrong**: Readers familiar with PyTorch may want the exact mechanism.
- **What right looks like**: Add a short API-level page showing `RefinementModel`, `run_refinement_model`, and `torch.optim` interaction.
- **Severity**: tech debt to track.

## File-by-file changes

| File | Change |
|---|---|
| `docs/index.md` | Replaces the terse status paragraph with an architecture-oriented overview covering the differentiable simulation loop, `Plan`, preprocessing, typed IO, reproducibility locks, observability/loggers, CLI usage, example precision, and Python power-user paths. |

## Testing

Docs build was run successfully:

```bash
uv run mkdocs build --strict
```

No unit tests were run because this PR changes only homepage prose.

## Migration & compatibility

No runtime behavior changes. Documentation only.
