### PR TITLE
Refine the homepage overview structure

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,49 @@
+# Architecture
+
+DiffBloch is organized around one stable scientific centre: a deterministic Bloch-wave simulation.
+The surrounding layers prepare inputs, build reusable geometry, run optimization, and report
+progress without making those concerns part of the numerical core.
+
+## Core pattern
+
+The core flow is:
+
+1. `.cif` + `.cif_pets` + config are parsed into typed records.
+2. Preprocessing turns those records into a reusable `Plan`.
+3. The `Plan` and differentiable structural parameters feed the deterministic Bloch-wave simulation.
+4. The simulated pattern is compared with the observed pattern as an R-loss.
+5. Gradients from that loss update the differentiable structural parameters, then the loop repeats.
+
+## Layers
+
+| Layer | Role |
+|---|---|
+| [IO](api/io.md) | Parse CIF/PETS files into validated typed records. |
+| [Config](api/config.md) | Validate experiment settings and lock input/checkpoint identity. |
+| [Preprocess](api/preprocess.md) | Build and improve the immutable `Plan` the simulator consumes. |
+| [Core](api/core.md) | Deterministic crystallographic and Bloch-wave numerical kernels. |
+| [Params](api/params.md) | Differentiable structural parameters and physical constraints. |
+| [Engine](api/engine.md) | Combine `Plan` + parameters, simulate, score, and refine. |
+| [Observability](api/observability.md) | Emit typed events without coupling the core to logger backends. |
+| [App](api/app.md) | CLI and default orchestration around the reusable API. |
+
+## API shape
+
+This is the high-level shape used by the CLI internally. It is intentionally shown as API shape
+rather than a full script because real runs need an experiment directory, locks, and preprocessing
+configuration.
+
+```python
+from diffBloch.app.program import refine_experiment, run_experiment
+
+# Simulate/score a checkpointed experiment.
+inference = run_experiment("examples/experiments/quartz-checkpoint")
+print(inference.mean_r_obs)
+
+# Run the refinement loop against the same settled Plan.
+refined = refine_experiment("examples/experiments/quartz-checkpoint")
+print(refined.best_loss)
+```
+
+For lower-level composition, use the public `preprocess` and `engine` APIs directly; see
+[Preprocessing](preprocessing.md) and [Refinement](refinement.md).

--- a/docs/beams-and-scoring.md
+++ b/docs/beams-and-scoring.md
@@ -1,0 +1,51 @@
+# Beams and scoring
+
+DiffBloch keeps several hkl sets separate because they answer different questions.
+
+| Set | Meaning |
+|---|---|
+| Solve beams | The beam basis used in the Bloch solve. |
+| Scored hkl | Reflections included in the objective/scoring comparison. |
+| Observed hkl | Reflections present in the PETS observations. |
+| Matched hkl | Reflections aligned between calculated and observed patterns. |
+| Structure-factor hkl | The support grid where `Fgb` is tabulated. |
+
+Keeping these separate matters because a good solve basis is not always the same as the set of
+reflections used to score the model. Coupled rocking-curve solves add another distinction: each tilt
+segment may use a per-segment beam union, while the final pattern is reassembled onto a combined
+union beam axis.
+
+## API example: scoring a checkpointed plan
+
+```python
+from pathlib import Path
+
+from diffBloch.config import load_config
+from diffBloch.io import read_structure
+from diffBloch.preprocess import read_plan, score_orientations
+from diffBloch.preprocess.experiment import RefinementSetup
+
+root = Path("examples/experiments/quartz-checkpoint")
+cfg = load_config(root / "experiment.yaml")
+plan = read_plan(root / "plan.npz")
+structure = read_structure(root / cfg.inputs.structure)
+refinement = RefinementSetup.from_structure(structure)
+
+scores = score_orientations(plan, refinement, method=cfg.solver.refine)
+print(len(scores), float(scores[0]))
+```
+
+## API shape: beam selection
+
+```python
+from diffBloch.preprocess import build_orientation_plans, pipeline, select_beams
+from diffBloch.specs import BeamSelection
+
+prepare = pipeline([
+    select_beams(BeamSelection()),
+    build_orientation_plans(),
+])
+```
+
+See also the `solve-set-vs-scored-set` design decision in the context docs for the detailed
+rationale behind the split.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,67 @@
+# Examples
+
+The repository ships runnable experiment directories under `examples/`. The top-level
+`examples/experiments` entries are mostly baked-in demonstration runs: small or checkpointed
+experiments that exercise preprocessing, inference, and refinement paths. For layouts intended to be
+studied, copied, and modified as research starting points, use `examples/papers`.
+
+## Quick examples
+
+### Quartz, end to end
+
+Runs preprocessing and refinement from the ordinary quartz example directory.
+
+```bash
+diffbloch run refine examples/experiments/quartz
+```
+
+### Quartz, checkpointed
+
+Starts from a committed `plan.npz` + `plan.lock`, so it skips preprocessing and reaches refinement
+quickly.
+
+```bash
+diffbloch run refine examples/experiments/quartz-checkpoint
+```
+
+### Abiraterone, checkpointed on CUDA
+
+A larger compound; use an accelerator when available.
+
+```bash
+diffbloch run refine examples/experiments/abiraterone-checkpoint --device cuda
+```
+
+## Example precision
+
+The example YAMLs choose:
+
+```yaml
+refinement:
+  precision: fp32
+```
+
+That makes example refines faster and lighter. Switch to `fp64` for the conservative
+highest-precision refinement path.
+
+## Catalog
+
+| Example | Purpose |
+|---|---|
+| `examples/experiments/quartz` | Small full run from input files through preprocessing and refinement. |
+| `examples/experiments/quartz-checkpoint` | Fast-start quartz run from a committed preprocess checkpoint. |
+| `examples/experiments/abiraterone-checkpoint` | Larger molecular example; good CUDA/refine demonstration. |
+| `examples/experiments/lta` | Larger zeolite example. |
+| `examples/papers/...` | Advanced research/composition examples. |
+
+## Python API example
+
+```python
+from diffBloch.app.program import run_experiment
+
+result = run_experiment("examples/experiments/quartz-checkpoint")
+print(result.n_evaluated, result.mean_r_obs)
+```
+
+For advanced Python workflows, see
+[`examples/papers`](https://github.com/Differentiable-Electron-Crystallography/diffBloch/tree/main/examples/papers).

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,37 +11,40 @@ scalar R-loss**, minimised by gradient descent so that simulated and observed di
 intensities agree. Everything else — parsing, config, logging, orchestration — exists to make that
 map inspectable, reproducible, and safe to evolve, and lives *around* the core, never inside it.
 
-## Status
+## Overview
 
-diffBloch starts with a deterministic Bloch-wave simulation, then exposes selected simulation
-inputs as differentiable parameters. In PyTorch terms, those parameters sit inside an optimization
-loop: each pass simulates diffraction from the current structure, compares the calculated beams with
-an observed diffraction pattern, and uses gradients to improve the inputs so the simulation moves
-towards the experiment. The differentiable parameters are structural quantities — primarily
-asymmetric-unit (ASU) atom coordinates, with ADPs, occupancies, and structure factors available as
-refinable groups.
+### Core simulation and refinement
 
-The surrounding orchestration is deliberately a shell around that stable, physics-grounded
-deterministic simulation. Its central layer is preprocessing, which produces a `Plan`: the immutable
-geometry and data context the simulator will consume — shared structure-factor support, per-rotation
-orientations, beam sets, rocking-curve tilts, observed patterns, alignments, and fitted nuisance
-values such as thickness. The `Plan` is not the structure being refined; it is the settled scaffold
-around the differentiable structural parameters that enter the optimization loop. Preprocessing is a
-composable `Plan → Plan` pipeline: its steps select the solve beams, build per-orientation plans,
-integrate rocking-curve tilts, apply mosaicity, fit orientation and thickness against
-simulation/observation agreement, optionally sweep numerical coverage/convergence knobs, and settle
-coupled beam unions for the final forward model. Because this settled `Plan` is expensive and
-reusable, diffBloch checkpoints it as `plan.npz` plus a lock file, so later inference or refinement
-runs can resume from the same validated preprocessing state instead of recomputing it. Config, IO,
-logging, checkpointing, and the CLI wrap that pipeline so the workflow stays reproducible and
-inspectable without becoming part of the scientific core.
+The [core](api/core.md) starts with a deterministic Bloch-wave simulation, then the
+[refinement engine](api/engine.md) exposes selected simulation inputs as differentiable
+[parameters](api/params.md). In PyTorch terms, those parameters sit inside an optimization loop:
+each pass simulates diffraction from the current structure, compares the calculated beam intensities
+with the experimental observations, and uses gradients to improve the inputs so the simulated
+diffraction pattern tends towards congruence with the experiment. The Ewald-sphere geometry
+determines which reciprocal-lattice beams are excited and scored; the refinement objective then
+compares their calculated and observed intensities. The differentiable parameters are structural
+quantities — primarily asymmetric-unit (ASU) atom coordinates, with ADPs, occupancies, and structure
+factors available as refinable groups.
+
+### Core flow
+
+The core flow is:
+
+1. `.cif` + `.cif_pets` + config are parsed into typed records.
+2. Preprocessing turns those records into a reusable `Plan`.
+3. The `Plan` and differentiable structural parameters feed the deterministic Bloch-wave simulation.
+4. The simulated pattern is compared with the observed pattern as an R-loss.
+5. Gradients from that loss update the differentiable structural parameters, then the loop repeats.
+
+### Inputs and typed records
 
 diffBloch is driven by two input files: experimental diffraction data processed by
 [PETS2](https://pets.fzu.cz/) into `.cif_pets`, and a starting crystal structure as a standard
 `.cif`. Because the simulator makes concrete assumptions about the shapes, units, indices, and
 crystallographic meaning in those files, diffBloch does not pass parser output directly into the
-numerical core. It reads CIF/PETS data into typed [Pydantic](https://docs.pydantic.dev/) models
-first, so invalid or unsupported input fails at the boundary with explicit validation errors.
+numerical core. It reads CIF/PETS data into typed [Pydantic](https://docs.pydantic.dev/)
+[IO models](api/io.md) first, so invalid or unsupported input fails at the boundary with explicit
+validation errors.
 
 | File | Role |
 |---|---|
@@ -51,6 +54,8 @@ first, so invalid or unsupported input fails at the boundary with explicit valid
 | `experiment.lock` | Content identity for the input CIF/PETS files. |
 | `plan.npz` / `plan.lock` | Reusable preprocessing checkpoint and its provenance lock. |
 
+### Reproducibility locks
+
 To make refinements reproducible across the expensive preprocessing boundary, diffBloch records the
 identity of the input CIFs and the preprocessing recipe. `experiment.lock` pins the structure and
 observation files by content hash; `plan.lock` then ties a `plan.npz` checkpoint to that input lock,
@@ -59,46 +64,98 @@ version, and the checkpoint artifact hash. This gives diffBloch-driven inference
 a verifiable starting point: a reused checkpoint is known to match the inputs and preprocessing that
 produced it, rather than being an unlabelled intermediate file.
 
-As the pipeline runs, diffBloch emits typed observability events for preprocessing, coupling,
-inference, and refinement progress. The default CLI prints those events through a console logger,
-and the same event stream can be sent to CSV, Weights & Biases, or Comet; writing another logger is
-just a matter of implementing the small logger protocol for the event objects you care about.
+### Preprocessing and `Plan`
 
-```mermaid
-flowchart LR
-    Inputs[.cif + .cif_pets + config] --> Records[typed records]
-    Records --> Plan[preprocessed Plan]
-    Plan --> Sim[deterministic Bloch-wave simulation]
-    Params[differentiable structural parameters] --> Sim
-    Sim --> Loss[R-loss vs observed pattern]
-    Loss --> Gradients[gradients]
-    Gradients --> Params
+The surrounding orchestration is deliberately a shell around that stable, physics-grounded
+deterministic simulation. Its central layer is [preprocessing](api/preprocess.md), which produces a
+`Plan`: the immutable geometry and data context the simulator will consume — shared
+structure-factor support, per-rotation orientations, beam sets, rocking-curve tilts, observed
+patterns, alignments, and fitted nuisance values such as thickness. The `Plan` is not the structure
+being refined; it is the settled scaffold around the differentiable structural parameters that enter
+the optimization loop.
+
+Preprocessing is a composable `Plan → Plan` pipeline. Any function with that shape can become a
+pipeline step: it receives a `Plan`, does one focused piece of work, and returns an updated `Plan`.
+As a rule, each step should do one thing. For example, the rocking-curve integration step takes the
+current per-rotation plans, expands each orientation into sampled virtual tilts across the
+integration semiangle, builds the corresponding tilt geometry, and returns a new `Plan` whose
+orientations carry those tilts for the forward model. Other steps select solve beams, build
+per-orientation plans, apply mosaicity, fit orientation and thickness against
+simulation/observation agreement, optionally sweep numerical coverage/convergence knobs, and settle
+coupled beam unions. The pipeline also provides higher-level composition utilities, such as
+`iterate_until` and `Fork`, for repeated steps, conditional branching, and optimization-style steps
+that improve `Plan` values before the final refinement loop begins.
+
+Because this settled `Plan` is expensive and reusable, diffBloch checkpoints it as `plan.npz` plus a
+lock file, so later inference or refinement runs can resume from the same validated preprocessing
+state instead of recomputing it. [Config](api/config.md), [IO](api/io.md), logging, checkpointing,
+and the [CLI](api/app.md) wrap that pipeline so the workflow stays reproducible and inspectable
+without becoming part of the scientific core.
+
+### Observability
+
+As the pipeline runs, diffBloch emits typed [observability](api/observability.md) events for
+preprocessing, coupling, inference, and refinement progress. The default CLI prints those events
+through a console logger, and the same event stream can be sent to CSV, Weights & Biases, or Comet;
+writing another logger is just a matter of implementing the small logger protocol for the event
+objects you care about.
+
+### CLI and examples
+
+For day-to-day use, diffBloch ships with a [CLI](api/app.md) that has sane defaults for both
+preprocessing and the refinement loop, and can be run out of the box against bundled compounds such
+as quartz, abiraterone, LTA, and CsPbBr3. To run the small quartz example end to end — including
+preprocessing and refinement — point the CLI at the ordinary quartz experiment directory:
+
+```bash
+diffbloch run refine examples/experiments/quartz
 ```
 
-For day-to-day use, diffBloch ships with a CLI that has sane defaults for both preprocessing and the
-refinement loop, and can be run out of the box against bundled compounds such as quartz,
-abiraterone, LTA, and CsPbBr3. The examples choose `refinement.precision: fp32` for faster
-iteration; switch that field to `fp64` for the conservative highest-precision refinement path.
+For a quicker first run, use a checkpointed example such as `quartz-checkpoint`, which already
+includes `plan.npz` and `plan.lock`, so the CLI can skip preprocessing and start from the reusable
+`Plan`:
 
 ```bash
 diffbloch run refine examples/experiments/quartz-checkpoint
 ```
 
+For a larger compound, run on an accelerator when available:
+
+```bash
+diffbloch run refine examples/experiments/abiraterone-checkpoint --device cuda
+```
+
+The examples choose `refinement.precision: fp32` for faster iteration; switch that field to `fp64`
+for the conservative highest-precision refinement path.
+
 It also supports scientific research workflows for power users who need to compose their own
 pipelines, constraints, penalties, or model components. To get started with those patterns, review
-`examples/papers`, which shows more advanced usage than the default CLI path.
+[`examples/papers`](https://github.com/Differentiable-Electron-Crystallography/diffBloch/tree/main/examples/papers),
+which shows more advanced usage than the default CLI path.
 
 ## Quickstart
 
+Run the small quartz example end to end:
+
 ```bash
-diffbloch validate experiment.yaml     # validate an experiment config
-diffbloch run infer <experiment_dir>   # score every rotation (console log on; --quiet to silence, --csv PATH for a CSV sink)
-diffbloch run refine <experiment_dir>  # gradient-refine the structure against the data (reuses the checkpoint)
-diffbloch run pack <run_dir>           # export a run directory (zip/tar/BagIt/RO-Crate)
+diffbloch run refine examples/experiments/quartz
+```
+
+Start faster from the bundled quartz preprocessing checkpoint:
+
+```bash
+diffbloch run refine examples/experiments/quartz-checkpoint
+```
+
+Run a larger checkpointed compound on CUDA:
+
+```bash
+diffbloch run refine examples/experiments/abiraterone-checkpoint --device cuda
 ```
 
 Use `infer` when you want to simulate and score a settled plan without changing parameters. Use
-`refine` when you want to run the optimization loop and update the structural parameters.
+`refine` when you want to run the optimization loop and update the structural parameters. Run
+`diffbloch validate <experiment.yaml>` to check an experiment config before launching a longer job.
 
 Python users can compose preprocessing steps, constraints, penalties, and refinement problems
 directly with the public API; the CLI is the friendly default runner, not the only path. See

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -1,0 +1,60 @@
+# Inputs and experiment directories
+
+A diffBloch run starts from an experiment directory. The directory contains a small YAML config, a
+starting crystal structure, processed diffraction observations, and lock/checkpoint artifacts when
+available.
+
+## Required inputs
+
+| File | Role |
+|---|---|
+| `experiment.yaml` | Experiment config and relative references to the input files. |
+| `structure.cif` | Starting crystal structure. |
+| `observations.cif_pets` | Experimental diffraction observations processed by [PETS2](https://pets.fzu.cz/). |
+| `experiment.lock` | Content identity for the input CIF/PETS files. |
+
+Checkpointed examples also include:
+
+| File | Role |
+|---|---|
+| `plan.npz` | Serialized preprocessed `Plan`. |
+| `plan.lock` | Provenance lock tying the checkpoint to inputs, config, recipe, code version, and artifact hash. |
+
+## Typed IO boundary
+
+DiffBloch does not pass parser output directly into numerical kernels. It parses CIF/PETS inputs
+into typed Pydantic records first, so unsupported shapes, units, missing fields, or invalid values
+fail at the boundary.
+
+The public records are:
+
+- `StructureRecord`
+- `ObservationRecord`
+- `AdpRecord`
+
+## API example
+
+This example is runnable against the bundled quartz checkpoint.
+
+```python
+from pathlib import Path
+
+from diffBloch.config import load_experiment
+from diffBloch.io import read_observations, read_structure
+
+root = Path("examples/experiments/quartz-checkpoint")
+cfg, experiment_lock = load_experiment(root)
+
+structure = read_structure(root / cfg.inputs.structure)
+observations = read_observations(root / cfg.inputs.observations)
+
+print(cfg.name)
+print(structure.frac_positions.shape)
+print(observations.hkl.shape)
+```
+
+Validate a config from the CLI before launching a longer job:
+
+```bash
+diffbloch validate examples/experiments/quartz-checkpoint/experiment.yaml
+```

--- a/docs/model-composition.md
+++ b/docs/model-composition.md
@@ -1,0 +1,59 @@
+# Model composition
+
+The default CLI path runs a simple single-stage refinement. Power users can compose the refinement
+problem directly in Python when they need molecular constraints, penalties, or model components.
+
+## Taxonomy
+
+| Concept | Meaning |
+|---|---|
+| Crystallographic constraints | Always-on transforms in `params.constrain`, such as site-symmetry position projection and ADP constraints. |
+| Constraint transforms | Hard molecular constraints applied to the physical state before diffraction, such as hydrogen riding. |
+| Penalties | Soft additive objective terms, such as bond-length penalties. |
+| Components | Trainable model pieces that can feed forward-context values, such as apparent thickness. |
+
+## API shape
+
+This is the lower-level composition shape. The exact constraint/penalty construction depends on the
+structure and the scientific question, so treat the middle block as an example pattern.
+
+```python
+from pathlib import Path
+
+from diffBloch.config import load_config
+from diffBloch.engine import build_refinement_model, build_refinement_problem, run_refinement_model
+from diffBloch.engine.constraints import with_hydrogen_riding
+from diffBloch.io import read_structure
+from diffBloch.preprocess import build_engine, read_plan
+from diffBloch.preprocess.experiment import RefinementSetup
+
+root = Path("examples/experiments/abiraterone-checkpoint")
+cfg = load_config(root / "experiment.yaml")
+structure = read_structure(root / cfg.inputs.structure, load_hydrogens=True)
+refinement = RefinementSetup.from_structure(structure)
+plan = read_plan(root / "plan.npz")
+
+engine = build_engine(plan, refinement, precision=cfg.refinement.precision)
+
+# API shape: add hard constraints/penalties/components before running.
+trainable, constraints = with_hydrogen_riding(
+    structure,
+    cfg.refinement.trainable.to_spec(),
+)
+model = build_refinement_model(initial=refinement.params, constraints=constraints)
+problem = build_refinement_problem()
+
+result = run_refinement_model(
+    engine,
+    model,
+    problem,
+    trainable=trainable,
+    steps=2,
+    optimizer=cfg.refinement.optimizer.name,
+    lr=cfg.refinement.optimizer.lr,
+)
+```
+
+See
+[`examples/papers`](https://github.com/Differentiable-Electron-Crystallography/diffBloch/tree/main/examples/papers)
+for fuller research examples.

--- a/docs/observability-guide.md
+++ b/docs/observability-guide.md
@@ -1,0 +1,67 @@
+# Observability and loggers
+
+DiffBloch reports progress by emitting typed events. A logger is any object with one method:
+
+```python
+def report(event): ...
+```
+
+The scientific core hands loggers plain event objects; logger backends decide whether to print,
+write CSV rows, or send values to an experiment tracker.
+
+## Built-in loggers
+
+| Logger | Role |
+|---|---|
+| `ConsoleLogger` | Default CLI live progress stream. |
+| `CSVLogger` | Long-format CSV rows: `channel, step, metric, value`. |
+| `WandbLogger` | Optional Weights & Biases backend. |
+| `CometLogger` | Optional Comet ML backend. |
+| `MultiLogger` | Fan-out to several loggers. |
+| `RecordingLogger` | In-memory test/debug sink. |
+
+The third-party logger modules import their SDKs lazily, so the base package does not require W&B
+or Comet unless you use those backends.
+
+## API example: console + CSV
+
+```python
+from pathlib import Path
+
+from diffBloch.app.loggers import CSVLogger, ConsoleLogger
+from diffBloch.app.program import run_experiment
+from diffBloch.observability import MultiLogger
+
+logger = MultiLogger((
+    ConsoleLogger(),
+    CSVLogger(Path("quartz-events.csv")),
+))
+
+result = run_experiment("examples/experiments/quartz-checkpoint", logger=logger)
+print(result.mean_r_obs)
+```
+
+## API example: custom logger
+
+```python
+from dataclasses import dataclass, field
+
+from diffBloch.observability import Event
+
+@dataclass
+class LastEventLogger:
+    last: Event | None = None
+
+    def report(self, event: Event) -> None:
+        self.last = event
+```
+
+## Event shape
+
+Every event exposes:
+
+- `channel` — e.g. `rotation`, `coupling`, `refinement`;
+- `step` — a rotation index, refinement iteration, or `None` for run-level summaries;
+- `measurements` — numeric values suitable for plotting or logging.
+
+See the [observability API](api/observability.md) for the event classes.

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -1,0 +1,112 @@
+# Preprocessing and `Plan`
+
+Preprocessing builds the immutable `Plan` consumed by inference and refinement. A `Plan` is not the
+structure being refined; it is the settled geometry and data scaffold around the differentiable
+structural parameters.
+
+A `Plan` carries things such as:
+
+- shared structure-factor support;
+- per-rotation orientations;
+- solve beam sets;
+- rocking-curve tilts;
+- observed patterns and alignments;
+- fitted nuisance values such as per-rotation thickness;
+- coupled beam-union geometry when coupling is enabled.
+
+## `Plan -> Plan` steps
+
+Preprocessing is a composable `Plan -> Plan` pipeline. Any function with that shape can be a step:
+it receives a `Plan`, does one focused piece of work, and returns an updated `Plan`.
+
+Real steps include:
+
+- `select_beams`
+- `build_orientation_plans`
+- `integrate_rocking_curve`
+- `mosaicity`
+- `fit_orientation`
+- `fit_thickness`
+- `couple_beams`
+- `converge_numerics`
+
+The pipeline also provides composition helpers such as `iterate_until` and `Fork` for repeated,
+conditional, or branching preprocess logic. More advanced steps use the same contract: convergence
+sweeps repeatedly improve numerical plan values, while `fit_orientation` and `fit_thickness` score
+candidate plans and return the best updated `Plan`.
+
+## API example: loading a checkpointed `Plan`
+
+```python
+from diffBloch.preprocess import read_plan, require_built_plans
+
+plan = read_plan("examples/experiments/quartz-checkpoint/plan.npz")
+orientations = require_built_plans(plan)
+
+print(len(orientations))
+print(plan.grid.grid_hkl.shape)
+```
+
+## API example: composing simple steps
+
+This example shows the composition shape. It is intentionally small; the full faithful recipe also
+captures refinement setup, coupling policy, device/precision choices, and logging.
+
+```python
+from diffBloch.preprocess import build_orientation_plans, pipeline, select_beams
+from diffBloch.specs import BeamSelection
+
+prepare = pipeline([
+    select_beams(BeamSelection()),
+    build_orientation_plans(),
+])
+
+# prepared_plan = prepare(candidate_plan)
+```
+
+## API shape: `Fork` and `iterate_until`
+
+`Fork` chooses one of two step lists from the immutable grid, so the chosen recipe can still be
+resolved before checkpointing. `iterate_until` wraps a repeated `Plan -> Plan` improvement behind the
+same step shape.
+
+```python
+from diffBloch.preprocess import fork, identity, iterate_until
+
+large_cell_branch = fork(
+    lambda grid: grid.cell_volume > 1000.0,
+    when_true=[identity()],   # e.g. coarse/faster steps for large cells
+    when_false=[identity()],  # e.g. exact/default steps for small cells
+)
+
+repeat_until_stable = iterate_until(
+    identity(),
+    until=lambda previous, current: previous is current,
+    max_iterations=1,
+)
+```
+
+For real convergence, prefer the provided convergence steps and driver rather than the trivial
+`identity` placeholders above.
+
+## API shape: from records to an initial `Plan`
+
+```python
+from pathlib import Path
+
+from diffBloch.config import load_experiment
+from diffBloch.io import read_observations, read_structure
+from diffBloch.preprocess import from_experiment
+
+root = Path("examples/experiments/quartz-checkpoint")
+cfg, _lock = load_experiment(root)
+structure = read_structure(root / cfg.inputs.structure)
+observations = read_observations(root / cfg.inputs.observations)
+
+setup = from_experiment(structure, observations, cfg)
+initial_plan = setup.plans.combined
+refinement_setup = setup.refinement
+
+print(len(initial_plan.orientations))
+print(refinement_setup.params.asu_positions.shape)
+```

--- a/docs/refinement.md
+++ b/docs/refinement.md
@@ -1,0 +1,93 @@
+# Refinement
+
+Refinement is the optimization loop around the deterministic Bloch-wave simulation. It holds a
+settled `Plan` fixed, exposes selected structural quantities as differentiable parameters, simulates
+diffraction, compares calculated and observed intensities, and updates the parameters with a PyTorch
+optimizer.
+
+## `infer` vs `refine`
+
+- `infer` simulates and scores a settled plan. It does not update parameters.
+- `refine` runs the optimization loop and updates differentiable structural parameters.
+
+## Refinable groups
+
+The default config exposes whole-group selections for:
+
+- ASU positions;
+- ADPs;
+- occupancies;
+- structure factors (`Fgb`).
+
+The schema default keeps positions and ADPs trainable, and leaves occupancies and `Fgb` frozen.
+
+## Precision
+
+`refinement.precision` controls the Bloch solve precision used by the app refinement path:
+
+```yaml
+refinement:
+  precision: fp32  # faster/lower-memory solve path
+```
+
+The schema default is `fp64` for the conservative complex128 path. The bundled examples opt into
+`fp32` for faster iteration. This knob downcasts the solve path; it does not make every trainable
+parameter or every structure-factor calculation float32.
+
+## CLI examples
+
+```bash
+# Full quartz run, including preprocessing.
+diffbloch run refine examples/experiments/quartz
+
+# Faster start from a committed preprocessing checkpoint.
+diffbloch run refine examples/experiments/quartz-checkpoint
+
+# Larger checkpointed example on CUDA.
+diffbloch run refine examples/experiments/abiraterone-checkpoint --device cuda
+```
+
+## API example: default app refinement
+
+```python
+from diffBloch.app.program import refine_experiment
+
+result = refine_experiment("examples/experiments/quartz-checkpoint")
+
+print(result.losses.shape)
+print(result.best_step, result.best_loss)
+```
+
+## API shape: lower-level composition
+
+This is the lower-level shape used when power users need custom constraints, penalties, or model
+components.
+
+```python
+from pathlib import Path
+
+from diffBloch.config import load_config
+from diffBloch.engine import build_refinement_model, build_refinement_problem, run_refinement_model
+from diffBloch.preprocess import build_engine, read_plan
+from diffBloch.preprocess.experiment import RefinementSetup
+from diffBloch.io import read_structure
+
+root = Path("examples/experiments/quartz-checkpoint")
+cfg = load_config(root / "experiment.yaml")
+plan = read_plan(root / "plan.npz")
+structure = read_structure(root / cfg.inputs.structure)
+refinement = RefinementSetup.from_structure(structure)
+
+engine = build_engine(plan, refinement, precision="fp32")
+model = build_refinement_model(initial=refinement.params)
+problem = build_refinement_problem()
+
+result = run_refinement_model(
+    engine,
+    model,
+    problem,
+    trainable=cfg.refinement.trainable.to_spec(),
+    steps=2,
+)
+print(result.best_loss)
+```

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -1,0 +1,72 @@
+# Reproducibility and checkpoints
+
+DiffBloch separates input identity from generated artifacts.
+
+- `experiment.lock` pins the input structure and observation files by content hash.
+- `plan.lock` ties a `plan.npz` checkpoint to the input lock, resolved preprocess-determining config,
+  ordered preprocess recipe, producing code version, and checkpoint artifact hash.
+
+This gives inference and refinement a verifiable starting point: a reused `plan.npz` is known to
+match the inputs and preprocessing recipe that produced it.
+
+## What this guarantees
+
+A valid preprocess checkpoint verifies:
+
+- the input CIF/PETS files match their lock;
+- the current preprocess-determining config matches the checkpoint lock;
+- the requested recipe is compatible with the checkpoint recipe;
+- the checkpoint artifact has not been silently changed.
+
+## What this does not guarantee
+
+The locks do not claim hardware-independent optimizer determinism. Device, thread scheduling,
+precision, and optimizer implementation details can still affect floating-point trajectories,
+especially for refinement. The lock guarantees the identity of the preprocessed starting point.
+
+## API example
+
+```python
+from pathlib import Path
+
+from diffBloch.config import (
+    code_version,
+    config_digest,
+    load_experiment,
+    preprocess_lock_status,
+    read_preprocess_lock,
+    sha256_file,
+)
+from diffBloch.preprocess import read_plan
+
+root = Path("examples/experiments/quartz-checkpoint")
+cfg, _experiment_lock = load_experiment(root)
+plan = read_plan(root / "plan.npz")
+lock = read_preprocess_lock(root / "plan.lock")
+
+status = preprocess_lock_status(
+    lock,
+    experiment_lock_sha256=sha256_file(root / "experiment.lock"),
+    config_digest=config_digest(cfg),
+    recipe=lock.recipe,
+    code_version=code_version(),
+    plan_path=root / "plan.npz",
+    root=root,
+)
+
+print(status)  # "reuse", "resume", or "stale"
+```
+
+## CLI example
+
+Run preprocessing and write/reuse the checkpoint:
+
+```bash
+diffbloch run preprocess examples/experiments/quartz-checkpoint
+```
+
+Run refinement from a checkpointed plan:
+
+```bash
+diffbloch run refine examples/experiments/quartz-checkpoint
+```

--- a/docs/rocking-curve.md
+++ b/docs/rocking-curve.md
@@ -1,0 +1,46 @@
+# Rocking curve, mosaicity, and coupling
+
+A rotation electron-diffraction frame integrates intensity while the crystal rocks through a small
+angular range. DiffBloch models this by expanding each orientation into sampled virtual tilts,
+solving those tilt sub-orientations, and reducing the tilt intensities into one calculated pattern.
+
+## Pieces
+
+| Piece | Role |
+|---|---|
+| `RockingCurve` | Number of tilt samples and shared integration geometry. |
+| `integrate_rocking_curve` | `Plan -> Plan` step that adds virtual tilt sub-orientations. |
+| `Mosaicity` / `mosaicity` | Moving-average broadening over the tilt axis. |
+| `TiltSegmentUnion` / `couple_beams` | Coupled per-segment beam unions for rocking-curve solves. |
+
+## API example: composing rocking-curve steps
+
+```python
+from diffBloch.preprocess import integrate_rocking_curve, mosaicity, pipeline
+from diffBloch.specs import Mosaicity, RockingCurve
+
+prepare_rocking_curve = pipeline([
+    integrate_rocking_curve(RockingCurve(sampling=42)),
+    mosaicity(Mosaicity(window=5)),
+])
+
+# updated_plan = prepare_rocking_curve(built_plan)
+```
+
+## API shape: coupling
+
+Coupling is an optional `Plan -> Plan` step. It should come after tilt-independent steps that need
+plain orientation plans.
+
+```python
+from diffBloch.preprocess import couple_beams
+from diffBloch.specs import TiltSegmentUnion
+
+couple = couple_beams(TiltSegmentUnion(n_splits=12, g_max=2.25, sg_max=0.01))
+
+# coupled_plan = couple(plan_with_rocking_curve_tilts)
+```
+
+The default app recipe uses the same underlying policy for faithful per-trial coupling during
+orientation fitting; `couple_beams` is the explicit composable step when callers want to settle a
+coupled plan themselves.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,17 @@ plugins:
 
 nav:
   - Home: index.md
+  - Guides:
+      - Architecture: architecture.md
+      - Inputs: inputs.md
+      - Preprocessing: preprocessing.md
+      - Reproducibility: reproducibility.md
+      - Refinement: refinement.md
+      - Observability: observability-guide.md
+      - Examples: examples.md
+      - Model composition: model-composition.md
+      - Beams and scoring: beams-and-scoring.md
+      - Rocking curve and coupling: rocking-curve.md
   - API:
       - Config: api/config.md
       - IO: api/io.md


### PR DESCRIPTION
## Summary

This follow-up PR applies the homepage refinements that landed after the previous docs PR was merged. It organizes the overview into linked subsections, removes the Mermaid diagram from the docsite page because the current theme does not render it, and sharpens the CLI examples around end-to-end quartz, checkpoint reuse, and CUDA for larger compounds.

## What changed

### Overview section renamed and structured

- Renamed `## Status` to `## Overview`.
- Split the long homepage narrative into clean subsections:
  - Core simulation and refinement
  - Preprocessing and `Plan`
  - Inputs and typed records
  - Reproducibility locks
  - Observability
  - Core flow
  - CLI and examples
- Added links from each conceptual area to the corresponding API docs where appropriate.

### Core simulation wording refined

The first overview paragraph now states the core pattern more directly:

- deterministic Bloch-wave simulation lives in the core;
- selected simulation inputs are exposed as differentiable parameters through the refinement engine;
- gradients improve structural quantities so calculated beam intensities tend toward agreement with observations;
- the Ewald-sphere geometry determines which reciprocal-lattice beams are excited/scored, while the objective compares intensities.

### Preprocessing / `Plan → Plan` explanation expanded

The preprocessing section now explains that any `Plan -> Plan` function can be composed as a preprocessing step. It also clarifies the “one focused thing per step” convention and gives rocking-curve integration as a concrete example of a step that receives a `Plan`, expands orientations into virtual tilts, builds tilt geometry, and returns an updated `Plan`.

### Inputs, locks, and observability linked

- Links added to `api/config.md`, `api/io.md`, `api/preprocess.md`, `api/observability.md`, `api/app.md`, `api/core.md`, `api/engine.md`, and `api/params.md`.
- `examples/papers` is linked to the GitHub tree for power-user workflows.
- Observability prose now points to the observability API and mentions console, CSV, W&B, Comet, and custom logger implementations.

### Mermaid removed from homepage content

The previous homepage body used a Mermaid fenced block, but the current MkDocs/shadcn configuration does not render Mermaid. This PR replaces it with a plain Markdown numbered “core flow” list.

### Quickstart restated as concrete examples

The Quickstart now mirrors the examples shown earlier on the page:

```bash
diffbloch run refine examples/experiments/quartz

diffbloch run refine examples/experiments/quartz-checkpoint

diffbloch run refine examples/experiments/abiraterone-checkpoint --device cuda
```

It also keeps the distinction between `infer` and `refine`, and mentions `diffbloch validate <experiment.yaml>` before longer jobs.

## Architecture & data flow

```mermaid
flowchart TD
    CIF[structure.cif] --> IO[typed IO models]
    PETS[observations.cif_pets] --> IO
    Config[experiment.yaml] --> IO
    IO --> Preprocess[Plan to Plan preprocessing]
    Preprocess --> Plan[settled Plan / checkpoint]
    Params[differentiable structural params] --> Engine[refinement engine]
    Plan --> Engine
    Engine --> Sim[deterministic Bloch-wave simulation]
    Sim --> Loss[R-loss vs observed intensities]
    Loss --> Gradients[gradients]
    Gradients --> Params
    Engine --> Events[typed observability events]
```

## Design decisions & tradeoffs

### Decision: use subsections instead of one long overview block

- **Alternatives considered**: Keep the overview as prose-only paragraphs.
- **Tradeoff**: More headings make the homepage longer visually, but each concept now maps cleanly to a docs/API area.
- **Rationale**: The previous homepage was accurate but hard to scan. The new structure lets new readers find the core, preprocessing, IO, locks, observability, and CLI examples independently.

### Decision: replace Mermaid with a Markdown list in the actual page

- **Alternatives considered**: Enable Mermaid support in MkDocs.
- **Tradeoff**: A numbered list is less visually rich than a diagram. In return, it renders correctly under the current shadcn theme without changing docs dependencies or markdown extensions.
- **Rationale**: This PR is a homepage content pass, not a docs build-system change.

### Decision: make the Quickstart example-driven

- **Alternatives considered**: Keep a generic command reference with placeholders.
- **Tradeoff**: The Quickstart is less exhaustive as a command list. In return, it gives copy-pasteable commands that are known to exist in the repository.
- **Rationale**: The homepage already links to the API and CLI docs; the front page should get users to a working run quickly.

## Honest assessment

### 1. The homepage is still carrying too much architecture detail

- **What**: The homepage now has clear subsections, but it still explains architecture, IO, locks, observability, and examples all in one file.
- **Where**: `docs/index.md`.
- **Why it's wrong**: Homepages should orient, not replace dedicated architecture docs.
- **What right looks like**: Split this into separate `architecture.md`, `inputs.md`, and `reproducibility.md` pages, leaving the homepage as a shorter overview with links.
- **Severity**: tech debt to track.

### 2. The W&B/Comet sentence still lacks installation guidance

- **What**: The homepage mentions Weights & Biases and Comet but does not say these require optional dependencies and backend credentials.
- **Where**: `docs/index.md`, Observability subsection.
- **Why it's wrong**: Users may assume all logger backends work immediately after base install.
- **What right looks like**: Link to a logger setup page or add a short note about optional extras.
- **Severity**: fix soon after.

### 3. PETS2 URL should be confirmed

- **What**: The docs link PETS2 to `https://pets.fzu.cz/`.
- **Where**: `docs/index.md`, Inputs and typed records subsection.
- **Why it's wrong**: It may be a landing page rather than the most precise durable PETS2 software/citation URL.
- **What right looks like**: Confirm the canonical project URL/citation and link to it consistently.
- **Severity**: tech debt to track.

### 4. The quickstart full quartz command can take a while

- **What**: `diffbloch run refine examples/experiments/quartz` includes preprocessing from scratch.
- **Where**: `docs/index.md`, CLI and Quickstart examples.
- **Why it's wrong**: A new user may expect it to be instant because it is the first command shown.
- **What right looks like**: Add an approximate runtime note or put the checkpointed command first for fastest feedback.
- **Severity**: minor; deliberate for now because the user specifically wanted the end-to-end quartz run shown before the checkpointed example.

## File-by-file changes

| File | Change |
|---|---|
| `docs/index.md` | Refines the homepage overview into linked subsections, expands the preprocessing `Plan -> Plan` explanation, replaces the Mermaid block with a Markdown list, and updates CLI/Quickstart examples. |

## Testing

Built the docs successfully:

```bash
uv run mkdocs build --strict
```

No unit tests were run because this is documentation-only.

## Migration & compatibility

No runtime changes. Documentation only.
