### PR TITLE
Settle quickstart commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,17 @@ just check        # lint + typecheck + unit tests
 just docs-serve   # live API docs
 just anchor       # the quartz physics anchors (opt-in e2e)
 
-# Score the worked quartz example (faithful coupled recipe, mean R_obs = 0.0506):
-diffbloch run infer examples/experiments/quartz-checkpoint   # instant — ships a frozen checkpoint
-diffbloch run infer examples/experiments/quartz              # ~6–16 min — fits from scratch
+# Validate a config before launching a longer job:
+diffbloch validate examples/experiments/quartz-checkpoint/experiment.yaml
+
+# Simulate and score without changing parameters:
+diffbloch run infer examples/experiments/quartz-checkpoint
+
+# Run the optimizer and update trainable structural parameters:
+diffbloch run refine examples/experiments/quartz
+
+# Start refinement faster from the bundled quartz preprocessing checkpoint:
+diffbloch run refine examples/experiments/quartz-checkpoint
 ```
 
 See `examples/experiments/quartz/README.md` for the worked example and its expected residual.

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,46 +102,35 @@ objects you care about.
 
 ### CLI and examples
 
-For day-to-day use, diffBloch ships with a [CLI](api/app.md) that has sane defaults for both
-preprocessing and the refinement loop, and can be run out of the box against bundled compounds such
-as quartz, abiraterone, LTA, and CsPbBr3. To run the small quartz example end to end — including
-preprocessing and refinement — point the CLI at the ordinary quartz experiment directory:
-
-```bash
-diffbloch run refine examples/experiments/quartz
-```
-
-For a quicker first run, use a checkpointed example such as `quartz-checkpoint`, which already
-includes `plan.npz` and `plan.lock`, so the CLI can skip preprocessing and start from the reusable
-`Plan`:
-
-```bash
-diffbloch run refine examples/experiments/quartz-checkpoint
-```
-
-For a larger compound, run on an accelerator when available:
-
-```bash
-diffbloch run refine examples/experiments/abiraterone-checkpoint --device cuda
-```
+For day-to-day use, diffBloch ships with a [CLI](api/app.md) that has sane defaults for
+preprocessing, inference, and refinement. The bundled `examples/experiments` directories are baked-in
+demonstration runs; [`examples/papers`](https://github.com/Differentiable-Electron-Crystallography/diffBloch/tree/main/examples/papers)
+shows more advanced composition patterns for research workflows.
 
 The examples choose `refinement.precision: fp32` for faster iteration; switch that field to `fp64`
 for the conservative highest-precision refinement path.
 
-It also supports scientific research workflows for power users who need to compose their own
-pipelines, constraints, penalties, or model components. To get started with those patterns, review
-[`examples/papers`](https://github.com/Differentiable-Electron-Crystallography/diffBloch/tree/main/examples/papers),
-which shows more advanced usage than the default CLI path.
-
 ## Quickstart
 
-Run the small quartz example end to end:
+Validate a config before launching a longer job:
+
+```bash
+diffbloch validate examples/experiments/quartz-checkpoint/experiment.yaml
+```
+
+Simulate and score the settled quartz checkpoint without changing parameters:
+
+```bash
+diffbloch run infer examples/experiments/quartz-checkpoint
+```
+
+Run the small quartz example end to end, including preprocessing and refinement:
 
 ```bash
 diffbloch run refine examples/experiments/quartz
 ```
 
-Start faster from the bundled quartz preprocessing checkpoint:
+Start refinement faster from the bundled quartz preprocessing checkpoint:
 
 ```bash
 diffbloch run refine examples/experiments/quartz-checkpoint
@@ -153,13 +142,12 @@ Run a larger checkpointed compound on CUDA:
 diffbloch run refine examples/experiments/abiraterone-checkpoint --device cuda
 ```
 
-Use `infer` when you want to simulate and score a settled plan without changing parameters. Use
-`refine` when you want to run the optimization loop and update the structural parameters. Run
-`diffbloch validate <experiment.yaml>` to check an experiment config before launching a longer job.
+Use `infer` to run the forward simulation and scoring pass over a settled `Plan`; it does not update
+structural parameters. Use `refine` to run the optimization loop, repeatedly simulating, scoring,
+and updating the selected trainable structural parameters.
 
 Python users can compose preprocessing steps, constraints, penalties, and refinement problems
-directly with the public API; the CLI is the friendly default runner, not the only path. See
-`examples/papers` for more advanced composition patterns.
+directly with the public API; the CLI is the friendly default runner, not the only path.
 
 ## API
 


### PR DESCRIPTION
## Summary

This PR settles the homepage and README quickstart commands around the current CLI surface. It makes the difference between `infer` and `refine` explicit, adds a concrete `infer` example, and frames the bundled experiment directories as demonstration runs rather than reusable research templates.

## What changed

### Quickstart command sequence

- Added a concrete config-validation command before longer runs:
  - `diffbloch validate examples/experiments/quartz-checkpoint/experiment.yaml`
- Added a concrete inference command:
  - `diffbloch run infer examples/experiments/quartz-checkpoint`
- Kept refinement examples for both the full quartz run and checkpointed quartz run:
  - `diffbloch run refine examples/experiments/quartz`
  - `diffbloch run refine examples/experiments/quartz-checkpoint`
- Kept the docsite CUDA example for the larger abiraterone checkpoint.

This sequence gives new users the intended ramp: validate config, score a settled checkpoint without mutation, then run actual refinement.

### Clarified `infer` vs `refine`

The homepage now states that `infer` runs the forward simulation and scoring pass over a settled `Plan` and does not update structural parameters. `refine` is described as the optimization loop that repeatedly simulates, scores, and updates selected trainable structural parameters.

### Clarified examples positioning

The docsite no longer implies the top-level `examples/experiments` directories are the primary copy-and-modify workflow examples. It now describes them as baked-in demonstration runs and points users to `examples/papers` for more advanced composition/research patterns.

## Architecture & data flow

```mermaid
flowchart TD
    A[experiment.yaml] --> B[diffbloch validate]
    B --> C{Choose action}
    C -->|score only| D[diffbloch run infer]
    C -->|optimize| E[diffbloch run refine]
    D --> F[reuse/build settled Plan]
    E --> F
    F --> G[Bloch forward simulation]
    G --> H[score calculated vs observed intensities]
    H -->|infer| I[report metrics only]
    H -->|refine| J[optimizer step]
    J --> K[updated trainable structural parameters]
    K --> G
```

## Design decisions & tradeoffs

- **Decision**: Put `infer` before `refine` in the quickstart.
  - **Alternatives considered**: Lead with refinement only, as before, or include only generic `<experiment_dir>` placeholders.
  - **Tradeoff**: The quickstart is slightly longer, but it teaches the cheaper/safe scoring path before the mutating optimization path.
  - **Rationale**: The distinction was unclear enough to prompt the question “is infer just 1 optim loop?” A concrete command plus a plain-language distinction should prevent that confusion.

- **Decision**: Use `quartz-checkpoint` for the `infer` example.
  - **Alternatives considered**: Use non-checkpointed `quartz` for all examples.
  - **Tradeoff**: The example relies on bundled checkpoint artifacts, but it is much faster and better suited to a first scoring run.
  - **Rationale**: `infer` is most useful as a quick “score this settled state” command, and the checkpointed quartz directory demonstrates that directly.

- **Decision**: Describe `examples/experiments` as baked-in demonstrations and `examples/papers` as advanced composition patterns.
  - **Alternatives considered**: Continue presenting all examples as copyable starting points.
  - **Tradeoff**: The wording is more precise but less broadly promotional.
  - **Rationale**: The top-level experiment examples are primarily committed preprocess/refinement demonstrations; over-selling them as reusable templates creates the wrong expectation.

## Honest assessment

1. **What**: The README quickstart still mixes developer setup commands (`just install`, `just check`, `just docs-serve`, `just anchor`) with end-user CLI commands in one fenced block.
   - **Where**: `README.md`, `## Quickstart`.
   - **Why it's wrong**: It conflates contributor workflow with package usage. A new scientific user may not know whether they should run `just check` before using `diffbloch`.
   - **What right looks like**: Split into “Developer setup” and “Run an experiment” subsections, or move contributor commands below the user-facing commands.
   - **Severity**: Tech debt to track.

2. **What**: The quickstart examples are still manually duplicated between `README.md` and `docs/index.md`.
   - **Where**: `README.md` quickstart and `docs/index.md` quickstart.
   - **Why it's wrong**: Duplication invites drift; this PR already had to update both places by hand.
   - **What right looks like**: Generate the README quickstart from a shared snippet, or keep the full quickstart only on the docsite and make README link to it.
   - **Severity**: Fix soon after if documentation churn continues.

3. **What**: The `infer` example is documented as safe/non-mutating but the text does not spell out whether preprocessing checkpoints may still be built/refreshed depending on flags and cache state.
   - **Where**: `docs/index.md`, infer/refine distinction.
   - **Why it's wrong**: “Does not update structural parameters” is accurate, but users may infer that no artifacts can ever be written by `infer`, which is not necessarily the same as “no parameter updates.”
   - **What right looks like**: Add a dedicated CLI behavior page explaining checkpoint write/reuse semantics for `infer`, `preprocess`, and `refine`, including `--no-checkpoint` and `--refresh`.
   - **Severity**: Tech debt to track.

## File-by-file changes

| File | Change |
|---|---|
| `README.md` | Replaced the old inference-only quartz quickstart with validation, infer, full refine, and checkpointed refine commands. |
| `docs/index.md` | Consolidated the CLI/examples section, added explicit quickstart commands, clarified `infer` vs `refine`, and corrected examples positioning. |

## Testing

- Ran the strict documentation build:
  - `uv run mkdocs build --strict`
- Ran the documented validation command:
  - `uv run diffbloch validate examples/experiments/quartz-checkpoint/experiment.yaml`

No code behavior changed; this is documentation-only.
