### PR TITLE
Docstring editorial pass over /src

### DIFF
--- a/docs/beams-and-scoring.md
+++ b/docs/beams-and-scoring.md
@@ -47,5 +47,6 @@ prepare = pipeline([
 ])
 ```
 
-See also the `solve-set-vs-scored-set` design decision in the context docs for the detailed
-rationale behind the split.
+The split matters most under coupled rocking-curve solves: the *solve* set expands to the
+per-segment beam union while the *scored* set stays pinned to the `select_beams` selection, so
+widening the solve basis never changes which reflections the objective compares.

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -49,7 +49,7 @@ print(plan.grid.grid_hkl.shape)
 
 ## API example: composing simple steps
 
-This example shows the composition shape. It is intentionally small; the full faithful recipe also
+This example shows the composition shape. It is intentionally small; the full default recipe also
 captures refinement setup, coupling policy, device/precision choices, and logging.
 
 ```python

--- a/docs/rocking-curve.md
+++ b/docs/rocking-curve.md
@@ -41,6 +41,6 @@ couple = couple_beams(SegmentedUnionCoupling(fixed_n_segments=12, g_max=2.25, sg
 # coupled_plan = couple(plan_with_rocking_curve_tilts)
 ```
 
-The default app recipe uses the same underlying policy for faithful per-trial coupling during
+The default app recipe uses the same underlying policy for per-trial coupling during
 orientation fitting; `couple_beams` is the explicit composable step when callers want to settle a
 coupled plan themselves.

--- a/src/diffBloch/app/__init__.py
+++ b/src/diffBloch/app/__init__.py
@@ -1,1 +1,1 @@
-"""Application entry points (CLI; sweep + orchestration adapters land later)."""
+"""Application entry points (the CLI and the default experiment runner)."""

--- a/src/diffBloch/app/cli.py
+++ b/src/diffBloch/app/cli.py
@@ -1,7 +1,8 @@
 """Thin command-line entry point.
 
-This is the orchestration / SLURM boundary (synthesis §18): a Dagster/Prefect op shells out to it,
-or a SLURM job runs it. Kept deliberately thin — it delegates to the library and holds no science.
+This is the orchestration / SLURM boundary: a workflow engine (e.g. Dagster or Prefect) shells out
+to it, or a SLURM job runs it. Kept deliberately thin — it delegates to the library and holds no
+science.
 """
 
 from __future__ import annotations
@@ -65,7 +66,7 @@ def _add_run_flags(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="cap the matrix_exp propagator block to N (N,N) operators (memory only, matches the "
         "unbounded solve to machine precision); default derives a memory-safe block per beam "
-        "count. Raise to fill a larger GPU, e.g. 1024 on an 80 GB A100",
+        "count. Raise to fill a larger GPU, e.g. 1024 on a high-memory accelerator",
     )
 
 

--- a/src/diffBloch/app/loggers/__init__.py
+++ b/src/diffBloch/app/loggers/__init__.py
@@ -10,7 +10,8 @@ dependency:
 - :class:`~diffBloch.app.loggers.wandb.WandbLogger` (``diffBloch.app.loggers.wandb``)
 - :class:`~diffBloch.app.loggers.comet.CometLogger` (``diffBloch.app.loggers.comet``)
 
-Writing your own backend is one method -- see the "extension" section of the logging tutorial.
+Writing your own backend is a single method: implement ``report(event)`` for the events you care
+about.
 """
 
 from __future__ import annotations
@@ -103,13 +104,13 @@ class FitAbortedError(RuntimeError):
 class EarlyAbortLogger:
     """Watch the per-rotation fit stream and abort a run that is not tracking the data.
 
-    A fit-quality guard for a long, oracle-less **from-scratch** fit -- e.g. LTA on the A100, where
-    no checkpoint is committed and there is no reference ``R_obs`` to pin against, so a mis-set-up
+    A fit-quality guard for a long, oracle-less **from-scratch** fit -- one with no committed
+    checkpoint and no reference ``R_obs`` to pin against, so a mis-set-up
     run (wrong energy / ``g_max``, bad data lineage) would otherwise burn its whole budget producing
     a bad answer. ``fit_orientation`` emits one :class:`~diffBloch.observability.OrientationFitted`
     per rotation as it finishes, carrying the scaling-optimised ``wr2`` at the fitted orientation. A
-    healthy run reaches a low ``wr2`` on essentially every rotation (measured quartz coupled ``wr2``
-    ~0.03-0.06); a fundamentally broken one stays high on all of them. This guard gives the run
+    healthy run reaches a low ``wr2`` on essentially every rotation; a fundamentally broken one stays
+    high on all of them. This guard gives the run
     ``patience`` rotations to show *at least one* orientation reaching ``wr2 <= wr2_ceiling``; if
     none does, it raises :class:`FitAbortedError`, unwinding the fit before the remaining rotations
     run. Pick ``wr2_ceiling`` generously (well above a healthy fit, well below a garbage one) so a

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -1,9 +1,9 @@
 """The default experiment runner the ``run infer`` CLI exposes.
 
-:func:`run_experiment` encodes the faithful default recipe as one ordered ``Plan -> Plan`` pipeline:
+:func:`run_experiment` encodes the default recipe as one ordered ``Plan -> Plan`` pipeline:
 plan-shaping (``select_beams`` -> ``integrate_rocking_curve`` -> ``mosaicity``) followed by
 parameter fitting (``fit_orientation`` -> ``fit_thickness``), then ``run_inference`` evaluates it --
-so a caller with an experiment directory gets the faithful result in one call. It is a
+so a caller with an experiment directory gets a full result in one call. It is a
 *convenience*, not the only path: every step is ordinary public API, so a Python user who wants a
 different composition composes their own ``pipeline([...])`` with ``from_experiment`` +
 ``run_inference`` directly. The CLI stays thin by delegating here and holds no science.
@@ -81,18 +81,17 @@ _PLAN_LOCK = "plan.lock"
 
 # Above this unit-cell volume the coupled orientation search runs its coarse pass in fp32 with the
 # gather integrity checks skipped (the large-cell fast path); at or below it the search stays the
-# exact fp64 path, byte-identical to the pre-fork recipe. The eigensolve is O(N^3) in the beam count
-# and N grows with cell volume, so the fp32 ~1.75x throughput win only pays off for large cells; a
+# exact fp64 path. The eigensolve is O(N^3) in the beam count
+# and N grows with cell volume, so the fp32 throughput win only pays off for large cells; a
 # small cell (quartz ~113 A^3) fits in seconds at fp64 and gains nothing from the coarser search.
-# A deliberately wide heuristic gap separates the known regimes -- quartz ~113 vs LTA/zeolites
+# A deliberately wide heuristic gap separates the known regimes -- quartz ~113 vs zeolites
 # ~1861 A^3 -- so classification is unambiguous; it is not a sharp physical boundary. Kept a code
 # constant, NOT a config field: a config field would enter config_digest and restale the committed
 # quartz checkpoint. It only selects which precision the *search* uses, and the fp64 terminal always
 # re-scores the found orientation, so the threshold never affects the reported score's fidelity.
 # It is NOT free of accuracy consequence, though: the coarse fp32 search can converge to a different
-# -- possibly worse -- basin than fp64 would on the bumpy coupled landscape, and the large branch
-# has no fp64 oracle in its own regime (LTA fp64 is ~hours CPU, CUDA-deferred), so that basin parity
-# is unverified until the A100 fp32-vs-fp64 check. A search-robustness trade, not a scoring one.
+# -- possibly worse -- basin than fp64 would on the bumpy coupled landscape. A search-robustness
+# trade, not a scoring one.
 _LARGE_CELL_THRESHOLD_A3 = 1000.0
 
 
@@ -110,15 +109,15 @@ def preprocess_experiment(
 
     The preprocess half of :func:`run_experiment` with the terminal scoring stripped off: it loads
     ``experiment.yaml`` (verifying the input lock), reads the structure + observations, builds the
-    geometry via ``from_experiment``, and runs the faithful integrated recipe -- returning the
+    geometry via ``from_experiment``, and runs the default integrated recipe -- returning the
     settled coupled :class:`~diffBloch.preprocess.plan.Plan` (fitted orientations, tilt-segment
     couplings, pinned scored sets). This is the entry point for callers who want *only* the
     calibrated Plan (to checkpoint it, or to drive their own downstream refinement) without paying
     for the terminal inference pass.
 
-    The recipe is the private's faithful pipeline, **per-trial beam coupling included** (the fit
-    re-derives the SOLVE union + SCORED set at every trial orientation -- the private's exact
-    objective). Its coupling policy, orientation-search bounds, thickness grid, and whether
+    The recipe includes **per-trial beam coupling** (the fit
+    re-derives the SOLVE union + SCORED set at every trial orientation). Its coupling policy,
+    orientation-search bounds, thickness grid, and whether
     hydrogens are loaded all come from config (``preprocess.coupling`` / ``preprocess.orientation``
     / ``preprocess.thickness`` / ``inputs.load_hydrogens``). A caller wanting a different
     composition (e.g. the cheaper tilt-independent fit) composes their own ``pipeline([...])`` with
@@ -137,18 +136,18 @@ def preprocess_experiment(
 
     ``workers`` (default 1, sequential) fans the per-rotation orientation search over a thread pool
     (rotations are independent). On a GPU run the per-trial cost is host-bound around a small
-    eigensolve, so overlapping rotations across cores is the main wall-clock lever (measured best
-    ~4 on the A100; gains flatten past that as the solves serialise on one CUDA stream). Like
+    eigensolve, so overlapping rotations across cores is the main wall-clock lever (a small worker
+    count is usually the sweet spot; gains flatten as the solves serialise on one GPU stream). Like
     ``device`` it is execution-only -- the results are identical to a sequential run and it does not
     enter the checkpoint lock. **Cap host threads to 1 when using it** --
     ``OMP_NUM_THREADS``/``MKL_NUM_THREADS``/``TORCH_NUM_THREADS`` (or ``torch.set_num_threads(1)``);
     in a pod torch/BLAS size their pools from the *node* core count, not the cgroup limit, so an
-    uncapped run oversubscribes the cores the workers need (measured: capping alone cut the LTA
-    per-trial ~1.4 s -> ~0.2 s, before any parallelism).
+    uncapped run oversubscribes the cores the workers need (capping alone can dominate the speedup,
+    before any parallelism).
 
     ``max_batch`` (default ``None``) caps the ``matrix_exp`` propagator block for the coupled fits.
     ``None`` lets each solve derive a memory-safe block from its beam count; raise it to fill a
-    larger accelerator (e.g. ``1024`` on an 80 GB A100). Execution-only (memory, bit-for-bit to
+    larger accelerator's memory budget. Execution-only (memory, bit-for-bit to
     machine precision), out of the checkpoint lock like ``device``/``workers``. See
     :func:`~diffBloch.engine.build_engine`.
     """
@@ -326,26 +325,26 @@ def _recipe_steps(
     workers: int = 1,
     max_batch: int | None = None,
 ) -> list[PlanStep]:
-    """The faithful default recipe as an inspectable step list (its provenance keys the lock).
+    """The default recipe as an inspectable step list (its provenance keys the lock).
 
-    The orientation fit runs under the private's per-trial coupling (:func:`_trial_coupling`) -- the
-    faithful objective. The tilt-independent fit is not offered here; compose it directly if needed.
+    The orientation fit runs under per-trial coupling (:func:`_trial_coupling`). The tilt-independent
+    fit is not offered here; compose it directly if needed.
 
     The fit tail is a :func:`~diffBloch.preprocess.fork` on unit-cell volume: a **large cell**
     (> ``_LARGE_CELL_THRESHOLD_A3``) takes the coarse fp32 search with the gather integrity checks
     skipped (``validate=False``, made sound by ``fit_orientation``'s coupled coverage guard); a
-    **small cell** takes the exact fp64 path, byte-identical to the pre-fork recipe. The predicate
+    **small cell** takes the exact fp64 path. The predicate
     reads only the pipeline-invariant grid, so :func:`~diffBloch.preprocess.resolve_recipe` compiles
     the fork to a flat branch before the lock sees it (the branch is fixed per experiment). fp32 /
     ``validate`` are execution-only and stay out of the step identity, so the resolved small-cell
-    branch keys identically to today -- the committed quartz checkpoint is untouched.
+    branch keys the same either way -- the committed quartz checkpoint is untouched.
 
     Both ``device`` and ``workers`` are execution-only -- neither alters the recipe identity.
     ``device`` is threaded to *both* fits (so the coupled eigensolve runs on the same accelerator as
     the terminal); ``workers`` fans only the orientation search (the run's long phase) over threads.
     ``max_batch`` (also execution-only) is threaded to both fits: it caps the ``matrix_exp``
     propagator block so a wide coupled segment x the thickness grid can't materialize the whole
-    propagator at once (the adaptive-union fit_thickness OOM); ``None`` picks a memory-safe block.
+    propagator at once; ``None`` picks a memory-safe block.
     """
     search = cfg.preprocess.orientation.to_search()
     thickness_grid = cfg.preprocess.thickness.to_grid()
@@ -387,7 +386,7 @@ def _recipe_steps(
                 orientation_fit(precision="fp32", validate=False),
                 thickness_fit(precision="fp32"),
             ],
-            when_false=[  # small cell: exact fp64, byte-identical to the pre-fork recipe
+            when_false=[  # small cell: exact fp64 path
                 orientation_fit(precision="fp64", validate=True),
                 thickness_fit(precision="fp64"),
             ],
@@ -398,7 +397,7 @@ def _recipe_steps(
 def _trial_coupling(cfg: ExperimentConfig) -> TrialCoupling:
     """Assemble the per-trial coupling from config; raise if the coupled fit has no policy.
 
-    Coupling is the faithful objective and carries no default (it determines the physics), so a
+    Coupling carries no default (it determines the physics), so a
     config that runs the coupled orientation fit must declare ``preprocess.coupling``. The SCORED
     set reuses the *same* Klar window as ``select_beams`` (so the two filters cannot disagree) and
     the config's ``g_max_refine`` as the scoring-resolution cap.
@@ -432,8 +431,8 @@ def _prepare(
     only when steps actually execute (a fresh or resumed run, not a full-reuse load).
     """
     # Compile any `fork` away against the base grid (invariant across every step), so the recipe the
-    # lock keys on is a flat, fork-free step list -- the fork is Applicative by construction, so its
-    # branch is fixed here, before running (see design/decisions/combinators-and-recipe-identity).
+    # lock keys on is a flat, fork-free step list -- the fork's shape is static by construction, so
+    # its branch is fixed here, before running.
     steps = list(resolve_recipe(steps, base.structure_factor_grid))
     records = step_records(steps)
     # A recipe with an unrecorded (opaque) step cannot be safely identified -> never checkpoint it.

--- a/src/diffBloch/config/manifest.py
+++ b/src/diffBloch/config/manifest.py
@@ -81,7 +81,8 @@ class PreprocessLock(BaseModel):
 
     A checkpoint is safe to reuse only when the current run matches on all four axes -- the input
     bytes, the resolved config, the software version, and the composed recipe -- AND the ``.npz``
-    verifies against ``plan``. The recipe axis is the piece the earlier cache attempt omitted;
+    verifies against ``plan``. The recipe axis distinguishes checkpoints built from the same inputs
+    and config by different step sequences;
     ``code_version`` is the software-implementation axis the recipe (step shape + params) cannot
     capture. The full ``code_version`` string (``__version__+g<sha>[.dirty]``) is recorded here as a
     build stamp, but the reuse gate compares only its release ``__version__`` (see

--- a/src/diffBloch/config/schema.py
+++ b/src/diffBloch/config/schema.py
@@ -32,7 +32,7 @@ from diffBloch.specs import (
 # The preprocess config classes below are 1:1 YAML edges over their value-types; their field
 # defaults derive from these default instances so the boundary value cannot drift from the
 # value-type it parses into. The value-type in ``specs`` is the single source of truth for both the
-# default value and its validation rules (e.g. the quartz-calibrated ``max_iterations`` lives once,
+# default value and its validation rules (e.g. the calibrated ``max_iterations`` lives once,
 # in ``HexagonalSearch``).
 _HEXAGONAL_SEARCH_DEFAULTS = HexagonalSearch()
 _THICKNESS_GRID_DEFAULTS = ThicknessGrid()
@@ -43,9 +43,8 @@ class _StrictConfig(BaseModel):
 
     ``extra="forbid"`` turns an unrecognised key into a load-time ``ValidationError`` instead of
     pydantic's default silent drop. Without it, a stale or misspelled key (or a field removed from
-    the schema but left in a YAML) is ignored unnoticed -- the exact hole that let the dead
-    ``g_max_sf`` / ``sg_max`` keys linger in the fixtures. It is the Ecto-``cast`` / NimbleOptions
-    allowlist: config carries only what a consumer reads, enforced at parse time. It does not catch
+    the schema but left in a YAML) is ignored unnoticed. It is an allowlist: config carries only
+    what a consumer reads, enforced at parse time. It does not catch
     a *declared* field with no reader (whole-program analysis would); pairs with keeping each config
     block close to the value-type its fields feed.
     """
@@ -66,14 +65,14 @@ class SolverConfig(_StrictConfig):
 
 
 class NumericsConfig(_StrictConfig):
-    """Stage-3 numerical-accuracy controls, frozen into the simulation spec.
+    """Numerical-accuracy controls, frozen into the simulation spec.
 
     ``g_max_refine`` (seed beam-pool / scoring-resolution radius) is a grid primitive consumed
     directly. The structure-factor support grid is *not* a config field: it is derived as ``2x`` the
     solve cutoff (the ``preprocess.coupling`` radius, or ``g_max_refine`` when a run is
     tilt-independent), because a beam set bounded by ``|g| <= cutoff`` produces ``F(g - h)`` terms
     reaching ``2 * cutoff`` -- so declaring both cutoff and support would let them contradict
-    (the ``diffBloch_private`` #154 model: one beam cutoff, support derived). ``rsg`` / ``dsg`` are
+    (one beam cutoff, support derived). ``rsg`` / ``dsg`` are
     the Klar beam-selection cutoffs and ``rocking_curve_sampling`` the tilt count -- the parts of
     :class:`BeamSelection` / :class:`RockingCurve` those value-types do *not* share. ``integration``
     is the shared :class:`IntegrationGeometry` (one physical angle + geometry feeding both), carried
@@ -130,8 +129,8 @@ class SampleConfig(_StrictConfig):
 class DataSplitConfig(_StrictConfig):
     """Required train/validation split declaration.
 
-    The concrete selector language is intentionally small for Stage 1: it records the fixed split
-    policy that later dataset code will materialize into ``data_used``.
+    The concrete selector language is intentionally small: it records the fixed split
+    policy that dataset code materializes into ``data_used``.
     """
 
     train: str = "all_except_validation"
@@ -142,11 +141,11 @@ class ObjectiveConfig(_StrictConfig):
     """The differentiable data loss for the default refinement path.
 
     ``data_term`` parses (via :meth:`to_loss`) into the
-    :data:`~diffBloch.engine.forward.LossFn` ``build_engine`` consumes. Only implemented terms are
-    admissible (a Poisson NLL and a Gauss-Newton least-squares backend are deferred). Only knobs the
-    default path actually consumes live here -- outlier rejection, penalty/nuisance weighting, and
-    gradient-norm reporting are deferred until wired, not accepted-but-ignored (cf. penalties, which
-    are Python/API composition, not config).
+    :data:`~diffBloch.engine.forward.LossFn` ``build_engine`` consumes; only implemented terms are
+    admissible. Only knobs the default path actually consumes live here -- outlier rejection,
+    penalty/nuisance weighting, and gradient-norm reporting are not accepted config keys until a
+    consumer reads them, rather than accepted-but-ignored (cf. penalties, which are Python/API
+    composition, not config).
     """
 
     data_term: Literal["scaled_weighted_r", "least_squares"] = "scaled_weighted_r"
@@ -280,7 +279,7 @@ class CouplingConfig(_StrictConfig):
     delegates all validation there (one rule home, no drift).
 
     Unlike the numerical preprocess blocks, coupling carries **no defaults**: it determines the
-    physics (the per-trial SOLVE union) and is experiment-specific, so a silent faithful-default
+    physics (the per-trial SOLVE union) and is experiment-specific, so a silent default
     would let a forgotten policy pass as a deliberate one. All three fields are required when the
     block is present, and the block itself is optional only for experiments that never run the
     coupled fit (see :class:`PreprocessConfig`); composing the fit without it raises. The value-type
@@ -290,8 +289,8 @@ class CouplingConfig(_StrictConfig):
     fixed_n_segments: int  # contiguous tilt chunks (fixed mode)
     g_max: float  # coupling radius (1/Angstrom): a beam couples when |g| < g_max
     sg_max: float  # excitation-error cutoff
-    # Adaptive segmentation is a mode toggle with a faithful-fixed default, so (unlike the four
-    # physics fields) it may be omitted -- an absent block runs the current even-split behaviour.
+    # Adaptive segmentation is a mode toggle with a fixed default, so (unlike the four
+    # physics fields) it may be omitted -- an absent value runs the even-split behaviour.
     union_adaptive: bool = False  # recursive-bisection chunk boundaries instead of even splits
     union_max_new_beams_pct: float = 0.01  # adaptive: split while a midpoint adds > this fraction
 
@@ -319,10 +318,10 @@ class PreprocessConfig(_StrictConfig):
     and its per-trial ``coupling`` policy) and ``fit_thickness``. The optional ``converge_numerics``
     driver is *not* in the default recipe, so it has no config block -- a caller that composes it
     constructs :class:`~diffBloch.specs.ConvergenceTest` /
-    :class:`~diffBloch.specs.ConvergenceTolerance` at the composition site (their defaults are the
-    faithful values). Opt-in step config lives with the step, not in an always-present block.
+    :class:`~diffBloch.specs.ConvergenceTolerance` at the composition site (which carry their own
+    defaults). Opt-in step config lives with the step, not in an always-present block.
 
-    ``coupling`` is ``None`` unless declared: it has no faithful default (see
+    ``coupling`` is ``None`` unless declared: it has no default (see
     :class:`CouplingConfig`), so an experiment that runs the coupled orientation fit must declare it
     or the recipe build raises. An experiment that never runs the fit may leave it unset.
     """

--- a/src/diffBloch/core/adp.py
+++ b/src/diffBloch/core/adp.py
@@ -11,7 +11,7 @@ from torch import Tensor
 def cholesky_adp(raw_factor: Tensor) -> Tensor:
     """Map raw 3x3 factors to symmetric positive-semidefinite ADP matrices.
 
-    The private implementation stores anisotropic ADPs as Cholesky factors and expands them as
+    Anisotropic ADPs are stored as Cholesky factors and expanded as
     ``L @ L.T``. Only the lower triangle is used, giving the six degrees of freedom of a symmetric
     PSD matrix and avoiding gauge-redundant upper-triangular parameters.
     """

--- a/src/diffBloch/core/adp.py
+++ b/src/diffBloch/core/adp.py
@@ -40,10 +40,9 @@ def cif_adp_to_star(uij_cif: Tensor, reciprocal_lengths: Tensor) -> Tensor:
     """Convert CIF-frame anisotropic ADPs ``Uij_cif`` to the reciprocal ``U*`` frame.
 
     ``U*_ij = d*_i d*_j Uij_cif`` with ``d* = (|a*|, |b*|, |c*|)`` (``reciprocal_lengths``, shape
-    ``(3,)``). This is the private CIF->Cartesian->star chain (``diffBloch_private`` ``Uij_layer``,
-    atoms.py:169-171) with the orthogonalization matrix ``A`` cancelled algebraically
-    (``A^-1 A D* U D* A^T A^-T = D* U D*``), so it depends only on ``reciprocal_cell`` and is
-    exactly faithful to the private result. Differentiable in ``uij_cif``; supports a batch axis.
+    ``(3,)``). This is the CIF->Cartesian->star transform with the orthogonalization matrix ``A``
+    cancelled algebraically (``A^-1 A D* U D* A^T A^-T = D* U D*``), so it depends only on
+    ``reciprocal_cell``. Differentiable in ``uij_cif``; supports a batch axis.
     """
     _require_trailing_matrix(uij_cif, name="uij_cif")
     if reciprocal_lengths.shape != (3,):
@@ -57,11 +56,11 @@ def cartesian_adp_to_star(uij_cart: Tensor, reciprocal_basis: Tensor) -> Tensor:
 
     ``U* = B Uij_cart B^T`` with ``B = reciprocal_cell`` (rows ``a*, b*, c*``). For an isotropic
     Cartesian displacement ``Uij_cart = Uiso I`` this reduces to the textbook ``U* = Uiso G*``
-    (``G* = B B^T`` the reciprocal metric), so ``DWF = exp(-2 pi^2 Uiso |g|^2)``. This replaces the
-    private ``Uij_layer`` ``A^-1 (Uiso I) A^-T`` path, whose ``A`` (Trueblood eq. 50) is built from
-    a ``c_star`` using ``cross(c, b) = |a*|`` rather than ``cross(a, b) = |c*|`` -- a private bug
-    that mislabels ``|a*|`` as ``c*`` and only affects anisotropic cells (see REFERENCES.md).
-    Differentiable in ``uij_cart``; supports a leading batch axis.
+    (``G* = B B^T`` the reciprocal metric), so ``DWF = exp(-2 pi^2 Uiso |g|^2)``. Building ``U*``
+    directly from ``B`` avoids the ``A^-1 (Uiso I) A^-T`` route (``A`` per Trueblood et al. 1996,
+    eq. 50), where a ``c*`` formed from ``cross(c, b) = |a*|`` rather than ``cross(a, b) = |c*|``
+    mislabels ``|a*|`` as ``|c*|`` and corrupts anisotropic cells. Differentiable in ``uij_cart``;
+    supports a leading batch axis.
     """
     _require_trailing_matrix(uij_cart, name="uij_cart")
     if reciprocal_basis.shape != (3, 3):

--- a/src/diffBloch/core/crystal.py
+++ b/src/diffBloch/core/crystal.py
@@ -48,8 +48,7 @@ def cell_matrix_from_parameters(parameters: FloatArray) -> FloatArray:
 def reciprocal_cell(cell: FloatArray) -> FloatArray:
     """Return reciprocal lattice vectors as rows in Angstrom^-1.
 
-    This matches the private helper's ASE-compatible convention:
-    ``reciprocal_cell = pinv(cell).T``.
+    Uses the ASE-compatible convention ``reciprocal_cell = pinv(cell).T``.
     """
     matrix = _cell_array(cell)
     return np.linalg.pinv(matrix).T

--- a/src/diffBloch/core/dynamical/assembly.py
+++ b/src/diffBloch/core/dynamical/assembly.py
@@ -1,14 +1,14 @@
 """Differentiable structure-matrix assembly (the Bloch ``A`` path).
 
 Combines a geometry-only plan (precomputed, NumPy) with the refined structure factors ``Fgb``
-(torch, differentiable). Stage 8 builds this bottom-up: the gather maps ``Fgb`` onto the ``(N, N)``
+(torch, differentiable). It is built bottom-up: the gather maps ``Fgb`` onto the ``(N, N)``
 off-diagonal positions ``F(g_j - g_i)``, then :func:`structure_matrix` scales it
 (``prefactor * Mii_i * Mii_j``) and fills the diagonal (``2 * k_n * Sg * Mii``). The full
 ``build_bloch_system`` (psi0, mask, propagators) follows, drawing its constants from the sibling
 ``core.dynamical.primitives`` module.
 
 This is the torch half of ``core.dynamical``; ``primitives`` is the NumPy half. The split mirrors
-the codebase's ``core.reciprocal`` (geometry) vs ``core.scattering`` (differentiable) seam.
+the codebase's ``core.reciprocal`` (geometry) vs ``core.scattering`` (differentiable) boundary.
 """
 
 from __future__ import annotations
@@ -35,8 +35,7 @@ type FloatArray = NDArray[np.float64]
 # The off-diagonal of the Bloch structure matrix is ``A[i,j] = scale * F(g_j - g_i)`` — a gather of
 # the structure factors ``Fgb`` onto every pair of beams. ``F`` is the only refined (differentiable)
 # input; the gather *indices* are pure geometry, so they are precomputed once into a frozen plan.
-# Ports the gather half of ``diffBloch_private`` ``calculate_structure_matrix`` /
-# ``raveled_hkl_to_hkl_torch``, preserving its ``gmh = hkl[None] - hkl[:, None]`` ordering
+# The gather uses the ``gmh = hkl[None] - hkl[:, None]`` ordering
 # (so ``gmh[i,j] = hkl_j - hkl_i`` and ``A[i,j] = F(g_j - g_i)``).
 
 
@@ -202,8 +201,8 @@ def _beam_index_array(hkl: IntArray, *, name: str) -> IntArray:
 # ---------------------------------------------------------------------------
 # Structure-matrix assembly: A = scale(geometry) ⊙ gather(F), diagonal replaced
 # ---------------------------------------------------------------------------
-# Adds the geometry-only scale and diagonal to the slice-1 gather, completing the Bloch structure
-# matrix A. Ports the no-absorption path of ``diffBloch_private`` ``calculate_structure_matrix``:
+# Adds the geometry-only scale and diagonal to the gather, completing the Bloch structure matrix A
+# (no-absorption path):
 #   off-diagonal  A[i,j] = prefactor * Mii_i * Mii_j * F(g_j - g_i)
 #   diagonal      A[i,i] = 2 * k_n * Sg_i * Mii_i      (replaces, not adds)
 # Every constant is a native primitive (structure_matrix_prefactor, mii_factors, excitation_errors,
@@ -215,7 +214,7 @@ class BeamPlan:
     """Geometry/numerics-only plan for a beam set (immutable across refinement).
 
     Everything fixed by geometry and beam energy, with no dependence on the refined ``Fgb``: the
-    slice-1 ``gather`` of structure factors onto beam pairs, the symmetrisation factors ``mii``
+    ``gather`` of structure factors onto beam pairs, the symmetrisation factors ``mii``
     (``(N,)``), the scalar off-diagonal ``prefactor``, the precomputed real structure-matrix
     ``diagonal`` (``(N,)`` = ``2 * k_n * Sg * Mii``), the propagation constant ``k_n``, the incident
     wavefunction ``psi0`` (``(N,)``, 1 at the 000 beam), and the active-beam ``mask`` (``(N,)``).
@@ -246,20 +245,19 @@ def build_beam_plan(
     """Precompute the geometry/numerics for a beam set.
 
     ``beam_hkl`` ``(N, 3)`` selects the beams; ``structure_factor_hkl`` ``(G, 3)`` / ``gpts`` define the ``Fgb``
-    support grid (slice-1 gather); ``reciprocal_basis`` ``(3, 3)`` gives ``g = beam_hkl @
+    support grid; ``reciprocal_basis`` ``(3, 3)`` gives ``g = beam_hkl @
     reciprocal_basis``. ``energy`` (eV) and ``u0`` (mean-inner-potential) set the wavevector.
-    Composes the native primitives into the off-diagonal scale, the structure-matrix diagonal, and
-    the propagation pieces (``k_n``, ``psi0``, ``mask``) -- mirroring ``diffBloch_private``
-    ``calculate_structure_matrix`` (no-absorption path) and the ``psi0 = (hkl == 000)``
-    convention of its dynamical-scattering propagator. ``mask`` is all-True here: the beams are the
-    pre-selected active set (per-orientation ``sg_max`` selection is deferred).
+    Composes the native primitives into the off-diagonal scale (the no-absorption structure-matrix),
+    the structure-matrix diagonal, and the propagation pieces (``k_n``, ``psi0``, ``mask``), with
+    ``psi0`` the ``(hkl == 000)`` incident-beam convention. ``mask`` is all-True here: the beams are
+    the pre-selected active set (per-orientation ``sg_max`` selection is deferred).
 
     ``gather`` may be a precomputed :class:`StructureFactorGather` for this exact ``(structure_factor_hkl,
     beam_hkl, gpts)`` -- the F-gather is basis-independent, so callers rebuilding many plans over a
     single beam set (rocking-curve tilts, orientation-search trials) build it once and pass it in,
-    skipping the per-call index-map construction and its validation (the dominant cost; ports the
-    private's precomputed HKL->index map, ``diffBloch_private`` 6bb3031). When ``None`` it is built
-    here. A cheap shape guard rejects a gather that does not match this beam set / box.
+    skipping the per-call index-map construction and its validation (the dominant cost). When
+    ``None`` it is built here. A cheap shape guard rejects a gather that does not match this beam
+    set / box.
 
     ``validate`` is forwarded to :func:`build_structure_factor_gather` when building the gather here
     (default ``True``); pass ``False`` on a hot rebuild loop whose grid coverage is guaranteed by an
@@ -293,7 +291,7 @@ def build_beam_plan(
 def structure_matrix(plan: BeamPlan, structure_factors: Tensor) -> Tensor:
     """Assemble the Bloch structure matrix ``A`` from a plan and structure factors ``Fgb``.
 
-    Off-diagonal ``A[i,j] = prefactor * Mii_i * Mii_j * F(g_j - g_i)`` (slice-1 gather, then
+    Off-diagonal ``A[i,j] = prefactor * Mii_i * Mii_j * F(g_j - g_i)`` (gathered, then
     broadcast-scaled); the diagonal is replaced by the precomputed ``2 * k_n * Sg_i * Mii_i``.
     Differentiable in ``structure_factors`` (the diagonal is a geometry constant). Returns a complex
     ``(N, N)`` tensor in the dtype of ``structure_factors``.
@@ -309,8 +307,7 @@ def _fill_diagonal(matrix: Tensor, diagonal: Tensor) -> Tensor:
 
     Gradient flows through the off-diagonal copy; the diagonal positions are overwritten. Rank-
     polymorphic: ``matrix`` is ``(..., N, N)`` with any leading batch dims and ``diagonal`` is
-    ``(..., N)`` -- for a bare ``(N, N)`` this is exactly the single-matrix fill (byte-identical).
-    Mirrors ``diffBloch_private`` ``utils.py::fill_diagonal_torch``.
+    ``(..., N)`` -- for a bare ``(N, N)`` this is exactly the single-matrix fill.
     """
     if matrix.ndim < 2 or matrix.shape[-1] != matrix.shape[-2]:
         raise ValueError("matrix must be square (..., N, N)")

--- a/src/diffBloch/core/dynamical/primitives.py
+++ b/src/diffBloch/core/dynamical/primitives.py
@@ -1,12 +1,9 @@
 """Relativistic electron-optics primitives for the dynamical-diffraction path.
 
-Stage-8 foundation. Native ports of the electron-optics helpers the private predecessor
-(``diffBloch_private/diffBloch/dynamical.py``) imported directly from abTEM
-(``abtem.core.energy.energy2wavelength`` / ``energy2sigma``; ``abtem.core.constants.kappa``) plus
-the Spence & Zuo excitation-error convention
-(``diffBloch_private/diffBloch/utils.py::excitation_errors``). See ``REFERENCES.md`` — abTEM and
-Spence & Zuo (1992) are credited; abTEM is not a runtime dependency. The ``energy2sigma``/``kappa``
-ports reproduce abTEM's values to ~1e-8 (CODATA-2018 vs ASE constants).
+Native implementations of the electron-optics helpers the dynamical path needs -- relativistic
+wavelength, interaction parameter ``sigma``, and the interaction constant ``kappa`` -- plus the
+Spence & Zuo (1992) excitation-error convention. The physical constants are CODATA-2018 (SI), kept
+local so ``core/`` carries no physical-constants dependency.
 
 These are setup constants on the geometry/numerics plan — beam energy is an experimental constant
 and ``g`` is fixed geometry, neither is refined — so they live on the NumPy planning path like
@@ -34,9 +31,8 @@ _BOHR_RADIUS = 0.529177210903e-10  # m
 
 # Conversion from the unitless (Lobato) potential parametrization to potential units, used in the
 # structure-matrix prefactor. Dimensionless in this convention (Å/eV potential units), ~0.0209.
-# Native form of abTEM's abtem.core.constants.kappa (4 pi eps0 / (2 pi a0 e) in ASE units), here the
-# equivalent CODATA-2018 closed form 2 eps0 / (a0 e) * 1e-20; reproduces abTEM's exact value
-# 0.0208865737082965 to ~1e-8 (the residual is CODATA-2018 vs ASE's constants). See REFERENCES.md.
+# The interaction constant kappa = 4 pi eps0 / (2 pi a0 e), here the equivalent CODATA-2018 closed
+# form 2 eps0 / (a0 e) * 1e-20 ≈ 0.02089.
 # Final: a fixed physical constant, not a tunable — immutability is part of the public contract.
 kappa: Final[float] = 2.0 * _VACUUM_PERMITTIVITY / (_BOHR_RADIUS * _ELEMENTARY_CHARGE) * 1e-20
 
@@ -44,9 +40,8 @@ kappa: Final[float] = 2.0 * _VACUUM_PERMITTIVITY / (_BOHR_RADIUS * _ELEMENTARY_C
 def energy2wavelength(energy: float) -> float:
     """Relativistic electron wavelength in angstrom for a beam ``energy`` in eV.
 
-    ``lambda = h c / sqrt(E e (2 m_e c^2 + E e))``, the relativistic de Broglie wavelength. This is
-    algebraically identical to abTEM's ``energy2wavelength`` (see ``REFERENCES.md``); reproduces the
-    textbook values 0.03701 / 0.02508 / 0.01969 Å at 100 / 200 / 300 keV.
+    ``lambda = h c / sqrt(E e (2 m_e c^2 + E e))``, the relativistic de Broglie wavelength. It
+    reproduces the textbook values 0.03701 / 0.02508 / 0.01969 Å at 100 / 200 / 300 keV.
     """
     if energy <= 0.0:
         raise ValueError("energy must be positive")
@@ -75,9 +70,9 @@ def wavelength2energy(wavelength: float) -> float:
 def energy2sigma(energy: float) -> float:
     """Electron interaction parameter ``sigma`` in 1/(angstrom*eV) for a beam ``energy`` in eV.
 
-    ``sigma = 2 pi m e lambda / h^2`` with the relativistic mass ``m = (1 + E e / (m_e c^2)) m_e``.
-    Native form of abTEM's ``energy2sigma`` (see ``REFERENCES.md``); reproduces its values
-    9.2440e-4 / 7.2884e-4 / 6.5262e-4 at 100 / 200 / 300 keV to ~1e-8.
+    ``sigma = 2 pi m e lambda / h^2`` with the relativistic mass ``m = (1 + E e / (m_e c^2)) m_e``
+    (Spence & Zuo 1992). It reproduces the standard values 9.2440e-4 / 7.2884e-4 / 6.5262e-4 at
+    100 / 200 / 300 keV.
     """
     if energy <= 0.0:
         raise ValueError("energy must be positive")
@@ -92,9 +87,8 @@ def energy2sigma(energy: float) -> float:
 def structure_matrix_prefactor(energy: float) -> float:
     """Off-diagonal structure-matrix prefactor ``sigma / (kappa * lambda * pi)``.
 
-    Scales structure factors into the Bloch structure matrix ``A``; ported from the repeated private
-    ``energy2sigma(energy) / (kappa * energy2wavelength(energy) * np.pi)``
-    (``diffBloch_private`` utils.py:772/878, dynamical.py:1001/1059).
+    Scales structure factors into the Bloch structure matrix ``A``. It is
+    ``energy2sigma(energy) / (kappa * energy2wavelength(energy) * pi)``.
     """
     return energy2sigma(energy) / (kappa * energy2wavelength(energy) * np.pi)
 
@@ -102,8 +96,8 @@ def structure_matrix_prefactor(energy: float) -> float:
 def wavevector_magnitude(energy: float, *, u0: float = 0.0) -> float:
     """Corrected wavevector magnitude ``K_n = sqrt(1/lambda^2 + U0)`` in Å^-1.
 
-    ``u0`` is the mean-inner-potential correction term (added to ``1/lambda^2`` in Å^-2, as the
-    private code treats it); ``u0=0`` gives the vacuum wavevector ``1/lambda``.
+    ``u0`` is the mean-inner-potential correction term (added to ``1/lambda^2`` in Å^-2);
+    ``u0=0`` gives the vacuum wavevector ``1/lambda``.
     """
     k0 = 1.0 / energy2wavelength(energy)
     radicand = k0**2 + u0
@@ -130,9 +124,9 @@ def excitation_errors(g: FloatArray, energy: float, *, u0: float = 0.0) -> Float
 def mii_factors(g: FloatArray, energy: float, *, u0: float = 0.0) -> FloatArray:
     """Diagonal ``Mii`` factors that symmetrise the Bloch structure matrix.
 
-    ``Mii = 1 / sqrt(1 - g_z / K_n)`` with ``K_n = wavevector_magnitude(energy, u0=u0)``; port of
-    ``diffBloch_private`` ``dynamical.py::calculate_M_matrix``. The structure matrix uses them on
-    both axes off-diagonal (``Mii_i Mii_j``) and once on the diagonal. ``Mii = 1`` at ``g = 0``;
+    ``Mii = 1 / sqrt(1 - g_z / K_n)`` with ``K_n = wavevector_magnitude(energy, u0=u0)``. The
+    structure matrix uses them on both axes off-diagonal (``Mii_i Mii_j``) and once on the diagonal.
+    ``Mii = 1`` at ``g = 0``;
     ``g`` is ``(N, 3)`` in Å^-1, returns ``(N,)``.
     """
     g_array = np.asarray(g, dtype=np.float64)

--- a/src/diffBloch/core/losses.py
+++ b/src/diffBloch/core/losses.py
@@ -1,17 +1,15 @@
 """Intensity-space loss/metric functions for refinement.
 
-Pure ports of the intensity comparisons in ``diffBloch_private/diffBloch/metrics.py`` (the
-``model``/``ase`` position metrics there belong to the engine/eval layer and are out of scope here).
-All functions compare a ``calculated`` intensity tensor against an ``observed`` one and reduce over
-the final (reflection) axis, so a ``(T, N)`` thickness/orientation batch yields a ``(T,)`` loss.
+The intensity comparisons used to score and refine a structure. (Position-space metrics belong to
+the engine/eval layer and are out of scope here.) All functions compare a ``calculated`` intensity
+tensor against an ``observed`` one and reduce over the final (reflection) axis, so a ``(T, N)``
+thickness/orientation batch yields a ``(T,)`` loss.
 
-- ``mse`` / ``l1`` / ``weighted_mse`` -- generic regression losses (private ``mse_loss`` /
-  ``l1_loss`` / ``weighted_mse_loss``).
-- ``rbragg`` -- the crystallographic Bragg R(obs) factor over reflections with ``I_obs > 3*sigma``
-  (private ``rbragg_abs``).
-- ``w_rbragg`` -- the weighted R2 of Klar et al. 2023 (private ``wRbragg``).
+- ``mse`` / ``l1`` / ``weighted_mse`` -- generic regression losses.
+- ``rbragg`` -- the crystallographic Bragg R(obs) factor over reflections with ``I_obs > 3*sigma``.
+- ``w_rbragg`` -- the weighted R2 of Klar et al. 2023.
 
-See ``REFERENCES.md`` for the R-factor sources. Differentiable in ``calculated``.
+Differentiable in ``calculated``.
 """
 
 from __future__ import annotations
@@ -68,8 +66,8 @@ def rbragg(calculated: Tensor, observed: Tensor, sigmas: Tensor) -> Tensor:
     0/1 mask: experimental intensities can be negative (background-subtracted), so ``sqrt`` of an
     excluded reflection is ``NaN``, and ``NaN * 0`` would poison the sum. Masked-in reflections have
     ``I_obs > 3*sigma > 0`` (and calculated ``|psi|^2 >= 0``), so their square roots are always
-    finite; the clamps guard only against numerical noise. This diverges from the private
-    ``metrics.rbragg_abs`` (multiply-mask, ``NaN``-unsafe on negatives).
+    finite; the clamps guard only against numerical noise. A 0/1 multiply-mask would be
+    ``NaN``-unsafe on the negative excluded intensities, which is why selection is used instead.
     """
     _check_pair(calculated, observed)
     _check_sigmas(sigmas, observed)
@@ -87,8 +85,8 @@ def w_rbragg(calculated: Tensor, observed: Tensor, sigmas: Tensor, *, mu: float 
 
     ``w = 1 / sqrt( sigma(sqrt(I_obs))^2 + (mu*sqrt(I_obs))^2 )`` with ``mu`` the instability
     factor;
-    weak reflections (``I_obs < 0.01*sigma``) use the ``5*sqrt(sigma)`` floor from the reference
-    SI.
+    weak reflections (``I_obs < 0.01*sigma``) use the ``5*sqrt(sigma)`` floor from the Klar et al.
+    2023 supplementary information.
     """
     _check_pair(calculated, observed)
     _check_sigmas(sigmas, observed)
@@ -114,7 +112,7 @@ def optimal_scale(
 ) -> tuple[Tensor, Tensor]:
     """Grid-search the multiplicative scale on ``calculated`` that minimises ``metric``.
 
-    Pure port of the private ``utils.initialize_scaling_factor``. The search runs ``num_points``
+    The search runs ``num_points``
     factors in ``[lo, hi]`` *relative to* the total ratio ``sum(observed)/sum(calculated)`` (so it
     is centred near scale 1), evaluates ``metric(scaled, observed, sigmas)`` at each, and returns
     the **absolute** scale applied to ``calculated`` and the minimum metric value. ``metric``

--- a/src/diffBloch/core/products.py
+++ b/src/diffBloch/core/products.py
@@ -63,11 +63,11 @@ class PlainSum:
 class MosaicSmoothed:
     """Mosaicity: a width-``window`` moving average over the tilt axis, applied before the sum.
 
-    Models crystal mosaic spread by broadening the rocking curve (the private ``moving_average``).
-    ``window`` consecutive tilts are averaged in a sliding window, then the smoothed curve is
-    summed. Equivalently the integrated intensity is the sum of the ``N - window + 1`` window means:
-    the private zero-pads the smoothed curve back to length ``N`` before summing, and those zeros do
-    not change the sum. ``window`` must not exceed the tilt count ``N`` (checked at reduction time).
+    Models crystal mosaic spread by broadening the rocking curve. ``window`` consecutive tilts are
+    averaged in a sliding window, then the smoothed curve is summed. Equivalently the integrated
+    intensity is the sum of the ``N - window + 1`` window means: padding the smoothed curve back to
+    length ``N`` with zeros before summing does not change the sum. ``window`` must not exceed the
+    tilt count ``N`` (checked at reduction time).
     """
 
     window: int
@@ -86,7 +86,7 @@ def reduce_tilts(stacked: Tensor, reduction: TiltReduction) -> Tensor:
     """Reduce stacked per-tilt intensities ``(N_tilts, ...)`` over the leading tilt axis.
 
     The rocking-curve rotation-frame integration: :class:`PlainSum` sums the tilts;
-    :class:`MosaicSmoothed` applies a width-``window`` moving average first (the private mosaicity
+    :class:`MosaicSmoothed` applies a width-``window`` moving average first (the mosaicity
     broadening). Public because the tilt axis is reduced from two places -- a single shared beam set
     (:meth:`BlochSolution.integrate` / :meth:`BlochSolution.integrate_batched`) and the segmented
     coupling path, which reassembles each reflection's curve across per-chunk beam sets onto a
@@ -261,8 +261,8 @@ def build_alignment_plan(
     is how ``couple_beams`` keeps scoring on the ``select_beams`` selection while the *solve* set
     expands to the coupling union -- ``solution_hkl`` (the union) grows, but the scored axis stays
     the pre-couple set. It is an intersection, so a ``restrict_to`` reflection absent from
-    ``solution_hkl`` is dropped (faithful: you can only score a reflection you solved, the same
-    ``scored ⊆ coupled`` invariant the private's ``filter_hkls`` has by running on the coupled set).
+    ``solution_hkl`` is dropped: you can only score a reflection you solved, which is the
+    ``scored ⊆ coupled`` invariant.
     ``None`` (the default) scores the whole ``pattern ∩ solution``, keeping the tilt-independent
     path unchanged. ``pattern_index`` indexes the full ``pattern_hkl`` regardless, so ``align`` is
     untouched.

--- a/src/diffBloch/core/scattering.py
+++ b/src/diffBloch/core/scattering.py
@@ -1,17 +1,15 @@
 """Electron structure factors (Lobato parametrization), vectorised.
 
-Pure port of the elastic path in ``diffBloch_private/diffBloch/dynamical.py``:
-``StructureFactorNet.calculate_scattering_factors`` / ``calculate_dwf_factor`` / ``forward``. The
-private per-atom Python loops are vectorised here over unique-Z groups and a single batched phase
-sum.
+The elastic structure-factor path -- form factors, Debye-Waller factors, and the phase sum --
+vectorised over unique-Z groups into a single batched phase sum.
 
-Form factors use the native Lobato–Van Dyck (2014) parametrization (coefficients vendored in
-``core/data/lobato.json``; see ``REFERENCES.md``), so abTEM is not a runtime dependency. The form
-factor is a setup constant — only ``positions``, ``uij_star`` and ``occupancies`` carry gradients.
+Form factors use the Lobato–Van Dyck (2014) parametrization (coefficients vendored in
+``core/data/lobato.json``), so no external scattering library is needed at runtime. The form factor
+is a setup constant — only ``positions``, ``uij_star`` and ``occupancies`` carry gradients.
 
-Absorption (the imaginary ``U0'`` path) is intentionally deferred; the quartz anchor runs with
-``absorption: false``. ``structure_factors`` consumes ADPs already in the U* (reciprocal) frame; the
-Cartesian→U* conversion belongs to the ADP/spec layer that wires this into the engine.
+Absorption (the imaginary ``U0'`` path) is intentionally deferred (runs set ``absorption: false``).
+``structure_factors`` consumes ADPs already in the U* (reciprocal) frame; the Cartesian→U*
+conversion belongs to the ADP/spec layer that wires this into the engine.
 """
 
 from __future__ import annotations
@@ -96,13 +94,13 @@ def debye_waller_factor(hkl: Tensor, uij_star: Tensor) -> Tensor:
 def structure_factor_cutoff(
     g: Tensor, g_max: float, *, mode: StructureFactorCutoff = "hard"
 ) -> Tensor:
-    """Reflection resolution cutoff: a hard ``|g| <= g_max`` mask or the private taper window."""
+    """Reflection resolution cutoff: a hard ``|g| <= g_max`` mask or a logistic taper window."""
     if g_max <= 0.0:
         raise ValueError("g_max must be positive")
     if mode == "hard":
         return (g <= g_max).to(g.dtype)
     if mode == "taper":
-        # Logistic taper (the private "taper" window): roll-off centred at TAPER_ALPHA * g_max with
+        # Logistic taper window: roll-off centred at TAPER_ALPHA * g_max with
         # logistic width TAPER_WIDTH. TAPER_ALPHA = 1 - 0.05 starts the roll-off ~5% below g_max.
         taper_width, taper_alpha = 0.005, 1.0 - 0.05
         return 1.0 / (1.0 + torch.exp((g / g_max - taper_alpha) / taper_width))
@@ -124,11 +122,10 @@ def structure_factors(
 ) -> Tensor:
     """Vectorised electron structure factors ``Fgb`` (elastic).
 
-    ``Fgb(h) = (1/V) sum_atoms f_e * DWF * occ * cutoff * exp(2 pi i r . h)``, ported from
-    ``StructureFactorNet.forward``. ``|g|`` is derived internally from ``hkl`` and
-    ``reciprocal_basis`` (no separate ``g`` argument to keep in sync). Differentiable in
-    ``positions``, ``uij_star``, ``occupancies``; ``f_e`` is a constant form factor. Components
-    below ``extinction_threshold`` are zeroed to match the private symmetry-extinction cleanup.
+    ``Fgb(h) = (1/V) sum_atoms f_e * DWF * occ * cutoff * exp(2 pi i r . h)``. ``|g|`` is derived
+    internally from ``hkl`` and ``reciprocal_basis`` (no separate ``g`` argument to keep in sync).
+    Differentiable in ``positions``, ``uij_star``, ``occupancies``; ``f_e`` is a constant form
+    factor. Components below ``extinction_threshold`` are zeroed as a symmetry-extinction cleanup.
     Returns a complex ``(M,)`` tensor.
     """
     n_atoms = positions.shape[0]

--- a/src/diffBloch/core/solver.py
+++ b/src/diffBloch/core/solver.py
@@ -11,8 +11,7 @@ Two first-class methods, selected by a ``SolverMethod`` *value* (strategy-as-val
 Both are first-class and swappable off the *same* ``BlochSystem`` (no geometry/energy/hkl needed --
 the system is the closed problem). They differ in *what* they return -- symmetrised vs physical
 amplitudes -- coinciding only at ``Mii == 1``; that distinction is a feature to experiment with, not
-a bug. Ports the no-absorption path of ``diffBloch_private``
-``dynamical.py::calculate_dynamical_scattering_batched`` (here single-system).
+a bug. The no-absorption path assumes ``A`` is Hermitian.
 """
 
 from __future__ import annotations
@@ -74,22 +73,22 @@ def propagate(
     single system (``a`` ``(N, N)``) returns ``(T, N)``; a batched system (``a`` ``(B, N, N)``, e.g.
     an orientation's rocking-curve tilts stacked by :func:`core.dynamical.build_bloch_systems`)
     returns ``(B, T, N)`` -- one batched ``eigh`` / ``matrix_exp`` over all tilts. The single-system
-    path is byte-identical to the un-batched computation (the batch axis is simply absent).
+    path is exactly the un-batched computation (the batch axis is simply absent).
     Differentiable in ``A`` (hence in ``Fgb``). ``method`` picks the propagator: ``matrix_exp``
     (refine default, stable autograd) or ``bloch_eigen`` (eval-only). The no-absorption path
     assumes ``A`` is Hermitian.
 
     ``precision`` selects the numeric field of the eigensolve/matrix-exponential -- orthogonal to
-    ``method``. ``"fp64"`` (the default) runs the whole propagation in complex128/float64 and is a
-    pure identity on today's path (byte-identical). ``"fp32"`` downcasts the operator to complex64
+    ``method``. ``"fp64"`` (the default) runs the whole propagation in complex128/float64.
+    ``"fp32"`` downcasts the operator to complex64
     and builds ``thicknesses`` at float32, roughly halving the O(N^3) solve's time and memory. It is
     used automatically only by the preprocess fits' coarse search path; terminal inference keeps the
     fp64 default, while refinement may opt into fp32 explicitly when speed matters more than decimal
-    places. Ports ``diffBloch_private`` ``dynamical.py``'s complex64 eigensolve (#127/#133).
+    places.
 
     ``max_batch`` (``matrix_exp`` only) caps how many ``(N, N)`` operators are exponentiated in one
     ``torch.matrix_exp`` call. ``None`` (the default) builds the whole ``(..., T, N, N)`` transfer
-    at once (byte-identical to before). A positive integer instead streams the flattened
+    at once. A positive integer instead streams the flattened
     ``(B*T, N, N)`` operator stack in row-blocks, so that transfer is never materialized -- the peak
     drops from ``~K*B*T*N**2`` to ``~K*max_batch*N**2``. ``torch.matrix_exp`` shares one
     scaling-and-squaring count across a batch (from its max norm), so regrouping shifts rounding by
@@ -168,8 +167,7 @@ def _propagate_matrix_exp(
     # `max_batch`, applying psi0 per block, so the full (..., T, N, N) transfer is never
     # materialized. Matches the unbounded solve to machine precision (torch.matrix_exp shares one
     # squaring count per batch, so regrouping shifts rounding by ~1 ulp, never accuracy); this
-    # generalizes diffBloch_private's single-thickness cover-batch chunk (dynamical.py
-    # calculate_dynamical_scattering_batched, max_chunk=8) to the multi-thickness grid.
+    # generalizes a single-thickness cover-batch chunk to the multi-thickness grid.
     n = a.shape[-1]
     a_flat = a.reshape(-1, n, n)  # (B, N, N); B == 1 for a single (N, N) system
     n_batch, n_thick = a_flat.shape[0], scalars.shape[0]

--- a/src/diffBloch/core/symmetry.py
+++ b/src/diffBloch/core/symmetry.py
@@ -62,8 +62,8 @@ def build_asu_expansion_plan(
 ) -> AsuExpansionPlan:
     """Precompute unique ASU/symop memberships for later torch expansion.
 
-    This mirrors the private atom-major, symop-minor membership order while moving duplicate
-    detection out of the differentiable path.
+    Membership is ordered atom-major, symop-minor; duplicate detection is kept out of the
+    differentiable path.
     """
     if symprec <= 0.0:
         raise ValueError("symprec must be positive")

--- a/src/diffBloch/engine/chemistry.py
+++ b/src/diffBloch/engine/chemistry.py
@@ -2,7 +2,7 @@
 
 Both the soft bond penalties and the hard hydrogen-riding constraint perceive likely connectivity
 from covalent radii, so the table and lookup live here rather than in one of them -- neither should
-import the other's private helper.
+import an internal helper of the other.
 """
 
 from __future__ import annotations
@@ -12,7 +12,7 @@ import numpy as np
 __all__ = ["COVALENT_RADII_ANGSTROM", "covalent_radius"]
 
 # Pyykko/Atsumi-style single-bond covalent radii, rounded, for common organic elements (Angstrom).
-# A perception heuristic only; explicit/Mogul connectivity can replace it later.
+# A perception heuristic only; an explicit connectivity table can replace it.
 COVALENT_RADII_ANGSTROM: dict[int, float] = {
     1: 0.31,  # H
     6: 0.76,  # C

--- a/src/diffBloch/engine/components.py
+++ b/src/diffBloch/engine/components.py
@@ -57,7 +57,7 @@ class PerOrientationThickness:
 
     This is the simplest concrete component: it seeds params tensors from the prepared Plan's fixed
     orientation thicknesses and supplies ``positive(params[rotation_index])`` during the forward
-    solve. It is an ablation/proof component before adding the apparent-thickness neural network.
+    solve. Each orientation carries its own free thickness, with no sharing across orientations.
     """
 
     key: str = "per_orientation_thickness"
@@ -103,8 +103,9 @@ class QuadraticThicknessProfile:
     """Bounded low-dimensional thickness profile over orientation angle.
 
     The component evaluates ``a0 + a1*x + a2*x^2`` where ``x`` is the rotation angle from identity
-    normalized by pi, then applies :class:`ThicknessBounds`. It is an interpretable bridge between
-    per-orientation free thicknesses and a neural apparent-thickness model.
+    normalized by pi, then applies :class:`ThicknessBounds`. It ties thickness to orientation with
+    three shared coefficients rather than one free value per orientation, an interpretable
+    middle ground between free per-orientation thicknesses and a learned apparent-thickness model.
     """
 
     bounds: ThicknessBounds
@@ -163,11 +164,11 @@ def _orientation_angle_fraction(orientation: Tensor) -> Tensor:
 
 @dataclass(frozen=True)
 class ApparentThicknessNN:
-    """Paper-style bounded apparent-thickness neural network component.
+    """Bounded apparent-thickness neural-network component.
 
-    The network maps orientation angle to two outputs ``(mu, sigma_raw)`` using the paper MLP
-    architecture. The first implementation consumes only ``mu`` and rejects stochastic thickness
-    sampling until the sigma likelihood/sampling path is wired.
+    The network maps orientation angle to two outputs ``(mu, sigma_raw)`` through a small MLP, then
+    applies :class:`ThicknessBounds` to the mean. Only ``mu`` is consumed for the forward thickness;
+    the ``sigma`` output is not used, so the thickness is deterministic (no stochastic sampling).
     """
 
     bounds: ThicknessBounds

--- a/src/diffBloch/engine/constraints.py
+++ b/src/diffBloch/engine/constraints.py
@@ -70,8 +70,8 @@ class HydrogenRiding:
 
     Limitations (the model deliberately kept simple; upgrades slot into this same transform):
     the fixed offset does not re-point H when the parent's local frame *rotates* (only translation
-    is followed); the ``uij_star`` scale is exact for an isotropic parent (abiraterone is all-Uiso)
-    and approximate for an anisotropic one.
+    is followed); the ``uij_star`` scale is exact for an isotropic parent (all-Uiso) and approximate
+    for an anisotropic one.
     """
 
     name: str

--- a/src/diffBloch/engine/forward.py
+++ b/src/diffBloch/engine/forward.py
@@ -9,9 +9,8 @@ rotation) and maps :class:`~diffBloch.params.RefinableParams` to a differentiabl
 
 ``objective_value`` / ``simulate`` are pure and differentiable;
 :func:`run_refinement_model` delegates to the quarantined imperative loop in
-:mod:`diffBloch.engine.refine`. ``from_config`` / ``from_experiment``
-construction is deferred until beam selection (stage 11) exists; engines are assembled from explicit
-per-orientation beam sets.
+:mod:`diffBloch.engine.refine`. Engines are assembled from explicit per-orientation beam sets that
+preprocessing has already selected.
 """
 
 from __future__ import annotations
@@ -101,7 +100,7 @@ class RefinementEngine:
     orientations: tuple[OrientationPlanLike, ...]
     loss: LossFn
     method: SolverMethod = "matrix_exp"
-    # Solve numeric field. "fp64" everywhere by default (byte-identical to complex128). "fp32"
+    # Solve numeric field. "fp64" (complex128) everywhere by default. "fp32"
     # (complex64) is a speed/precision knob: preprocess uses it only for transient coarse-search
     # engines, and the default refine path stays fp64 unless config opts in. See
     # core.solver.propagate.
@@ -110,7 +109,7 @@ class RefinementEngine:
     # rounding-level ~1 ulp shift, never accuracy). None (default) lets each
     # solve pick a memory-safe block from its beam count (memory_safe_max_batch), which bounds the
     # (B, T, N, N) propagator that a wide coupled segment x a thickness grid would otherwise
-    # materialize all at once (the adaptive-union fit_thickness OOM). A positive int pins the block
+    # materialize all at once. A positive int pins the block
     # for a specific device budget. Execution-only, like precision/method.
     max_batch: int | None = None
 
@@ -142,8 +141,7 @@ class RefinementEngine:
         (:meth:`fgb`), aligns calculated vs observed intensities, and grid-searches the intensity
         scale minimising wR2 (:func:`diffBloch.core.losses.optimal_scale`). With multiple
         thicknesses the best-fitting thickness's score is returned -- thickness is a nuisance when
-        scoring orientation (the private preprocess scored the first thickness). This is the
-        objective ``fit_orientation`` minimises.
+        scoring orientation. This is the objective ``fit_orientation`` minimises.
         """
         return self.score_orientation_per_thickness(orientation, fgb).min()
 
@@ -205,8 +203,9 @@ class RefinementEngine:
         (duplicate names rejected), so both the diffraction term and the ``penalties`` see the
         transformed state. The ``"diffraction"`` component is always present; ``penalties`` add
         weighted soft-penalty components (bond-length, etc.) without making the optimizer know their
-        details. Hydrogen riding will be the first concrete ``ConstraintTransform``; a soft penalty
-        and a hard constraint are distinct -- a constraint reparameterizes, it is not a cost term.
+        details. Hydrogen riding (:class:`~diffBloch.engine.constraints.HydrogenRiding`) is one such
+        ``ConstraintTransform``; a soft penalty and a hard constraint are distinct -- a constraint
+        reparameterizes, it is not a cost term.
         """
         return self._objective_value(
             params,
@@ -221,7 +220,7 @@ class RefinementEngine:
         *,
         penalties: tuple[PenaltyTerm, ...] = (),
     ) -> ObjectiveValue:
-        """Return the objective for a JAX-style refinement model.
+        """Return the objective for a :class:`RefinementModel`.
 
         Structure-only models delegate to :meth:`objective_value` for exact behavior parity. Models
         with components use the same objective order, but let components supply forward-context
@@ -331,7 +330,7 @@ class RefinementEngine:
         real_dtype, _ = precision_dtypes(self.precision)
         thicknesses = thicknesses.to(device=device, dtype=real_dtype)
         beam_hkl = orientation.beam_hkl.to(device)
-        # Untilted (length 1): the static solve, byte-identical to the pre-integration path.
+        # Untilted (length 1): the static single solve.
         if len(orientation.beam_plans) == 1:
             amplitudes = propagate(
                 build_bloch_system(orientation.beam_plans[0], fgb),
@@ -362,7 +361,7 @@ class RefinementEngine:
     ) -> BlochSolution:
         """Solve each tilt-chunk on its own beam set, reassemble the union curve, then reduce.
 
-        The tilt-dependent coupling path (Option A): each :class:`SegmentPlan` is solved over its
+        The tilt-dependent coupling path: each :class:`SegmentPlan` is solved over its
         covered tilts with the batched propagator, and its per-tilt intensities are scattered onto
         the shared ``(N_tilts, T, N_union)`` rocking curve (each tilt belongs to exactly one
         segment; a beam absent from a chunk stays 0 at that chunk's tilts). Only once the whole
@@ -393,8 +392,8 @@ class RefinementEngine:
             curve[cover] = block
         total = reduce_tilts(curve, plan.tilt_reduction)  # (T, n_union)
         # The reassembled curve is an intensity sum, so its per-tilt amplitudes were never coherent;
-        # store the magnitude sqrt(total) in the solve's complex format (complex128 under fp64 ->
-        # byte-identical to today; complex64 under fp32, matching the static/batched fp32 paths).
+        # store the magnitude sqrt(total) in the solve's complex format (complex128 under fp64,
+        # complex64 under fp32, matching the static/batched paths).
         _, complex_dtype = precision_dtypes(self.precision)
         return BlochSolution(
             total.sqrt().to(complex_dtype), total, plan.beam_hkl.to(device), thicknesses
@@ -405,8 +404,8 @@ class RefinementEngine:
 class ForwardContext:
     """Forward-model values supplied by refinement model components.
 
-    Phase 4 keeps this narrow: apparent thickness is the only value admitted because it is the only
-    upcoming concrete component. Scale/background/damage fields should be added only when consumed.
+    Deliberately narrow: apparent thickness is the only value admitted, since it is the only value a
+    component currently supplies. Scale/background/damage fields should be added only when consumed.
     """
 
     thickness: Tensor | None = None
@@ -444,10 +443,10 @@ class ModelComponent(Protocol):
 class StructureComponent:
     """The physical-structure component of a refinement model.
 
-    This is a no-behavior-change wrapper around the existing structure refinement inputs:
-    ``initial`` is today's :class:`~diffBloch.params.RefinableParams`, and ``constraints`` is
-    today's tuple of hard molecular transforms applied after crystallographic ``constrain``. The
-    long-term JAX-style endpoint is for structure-local hard parameterizations to live here.
+    A thin wrapper around the structure refinement inputs: ``initial`` is the
+    :class:`~diffBloch.params.RefinableParams`, and ``constraints`` is the tuple of hard molecular
+    transforms applied after the crystallographic ``constrain``. Structure-local hard
+    parameterizations belong here.
     """
 
     initial: RefinableParams
@@ -516,10 +515,10 @@ def build_refinement_model(
     components: tuple[ModelComponent, ...] = (),
     component_params: Mapping[str, Mapping[str, Tensor]] = MappingProxyType({}),
 ) -> RefinementModel:
-    """Construct the phase-1 JAX-style refinement model wrapper.
+    """Construct a :class:`RefinementModel`.
 
-    This is intentionally behavior-equivalent to today's structure-only refinement when no
-    components are supplied. Concrete component execution is added in later phases.
+    With no components supplied it is behavior-equivalent to structure-only refinement; supplied
+    components contribute forward-context values (e.g. apparent thickness) to that structure core.
     """
     return RefinementModel(
         structure=StructureComponent(initial=initial, constraints=constraints),
@@ -532,7 +531,7 @@ def build_refinement_model(
 class ModelRefinementResult:
     """The outcome of optimizing a refinement model.
 
-    The JAX-style result returns the optimized model value. ``params``/``best_params`` properties
+    Returns the optimized model value. ``params``/``best_params`` properties
     preserve the structure-only convenience used by the default app path and existing tests.
     """
 

--- a/src/diffBloch/engine/penalties.py
+++ b/src/diffBloch/engine/penalties.py
@@ -23,8 +23,8 @@ class BondLengthPenalty:
     The current ASU positions are fractional coordinates, so the penalty owns the invariant
     fractional-to-Cartesian cell matrix. ``pairs`` indexes ASU atom rows; ``target_angstrom`` and
     ``sigma_angstrom`` carry the penalty target and tolerance for each pair. The raw loss is the
-    mean squared normalized bond-distance residual by default. ``flat_bottom_l1`` is the
-    private/abiraterone-style robust criterion: zero inside the sigma tolerance and linear outside.
+    mean squared normalized bond-distance residual by default. ``flat_bottom_l1`` is a robust
+    criterion: zero inside the sigma tolerance and linear outside.
     """
 
     pairs: Tensor
@@ -84,9 +84,8 @@ def perceive_bond_length_penalty(
 
     This is an explicit source/builder layer, separate from the pure penalty value. It assumes
     the bonded molecule is contiguous in the ASU and deliberately does **not** do minimum-image
-    wrapping, matching the private bond loss. The perceived target for each bond is the current
-    Cartesian distance in the input structure; Mogul/CIF penalty sources can later provide
-    literature targets and sigmas.
+    wrapping. The perceived target for each bond is the current Cartesian distance in the input
+    structure; an external source of literature bond targets and sigmas could supply them instead.
     """
     if sigma_angstrom <= 0:
         raise ValueError("bond-penalty sigma must be positive")

--- a/src/diffBloch/engine/plan.py
+++ b/src/diffBloch/engine/plan.py
@@ -43,22 +43,19 @@ __all__ = [
     "mean_plan_thickness",
 ]
 
-# Half-Angstrom shell added to the derived structure-factor support radius (the private's
-# ``2 * g_max + 0.5`` prefilter). It reconciles the two metrics in play: the coupling filter cuts
-# ``|g| < g_max`` in the *orientation* metric (which folds the experimental cell correction --
-# ``u_matrix`` is deliberately non-orthonormal), while the grid is tabulated on the ideal-cell
-# ``reciprocal_cell`` metric. The two differ by the cell-correction magnitude (~1% on quartz), so a
-# coupled beam difference can be up to that fraction past a bare ``2 * g_max`` in the grid metric.
-# This is a private-compatibility shell, not a tunable scientific knob. See
-# StructureFactorGrid.from_cell_for_beam_cutoff.
+# Half-Angstrom shell added to the derived structure-factor support radius. It reconciles the two
+# metrics in play: the coupling filter cuts ``|g| < g_max`` in the *orientation* metric (which folds
+# the experimental cell correction -- ``u_matrix`` is deliberately non-orthonormal), while the grid
+# is tabulated on the ideal-cell ``reciprocal_cell`` metric. The two differ by the cell-correction
+# magnitude (~1% on quartz), so a coupled beam difference can be up to that fraction past a bare
+# ``2 * g_max`` in the grid metric. This is a numerical safety shell, not a tunable scientific knob.
+# See StructureFactorGrid.from_cell_for_beam_cutoff.
 _SUPPORT_MARGIN = 0.5
 
 
 @dataclass(frozen=True)
 class StructureFactorGrid:
     """The shared ``Fgb`` support grid, owned once and reused by structure factors and beam plans.
-
-    v1 analog: the ``g-h`` grid of ``StructureFactorNet``.
 
     Three reciprocal-space radii are easy to conflate; they are distinct concerns:
 
@@ -115,24 +112,19 @@ class StructureFactorGrid:
 
         The ``2x`` is **fundamental**, not an implementation artifact: any coupled Bloch solve that
         gathers ``F(g - h)`` from a tabulated grid needs the table out to twice the beam cutoff, so
-        the factor cannot be designed away. ``diffBloch_private`` #154 did **not** remove it -- it
-        removed the *bookkeeping* of it. The old convention made the caller declare the doubled
-        radius and then halved it internally (``self.g_max = sf_g_max / 2``), an error-prone
-        double-entry; #154 flipped it so the caller declares the beam cutoff and the ``2x`` support
-        is *derived* (private's ``StructureFactorNet`` builds its g-h grid at ``2 * self.g_max``).
-        This method is the public port of that derivation: pass the physical solve cutoff, get the
-        ``2x`` support -- the hand-doubled ``from_cell`` radius is what #154 made unnecessary, not
-        the ``2x`` itself. ``solve_g_max`` is the beam/coupling cutoff, distinct from the
+        the factor cannot be designed away. The API is arranged so the caller declares the *physical
+        solve cutoff* and the ``2x`` support is *derived* here, rather than declaring the doubled
+        radius and halving it internally (``self.g_max = sf_g_max / 2``) -- an error-prone
+        double-entry. ``solve_g_max`` is the beam/coupling cutoff, distinct from the
         scoring-resolution cutoff (``g_max_refine``), which selects reflections for the objective,
         not the solve.
 
-        The support radius is ``2 * solve_g_max + _SUPPORT_MARGIN`` -- ``diffBloch_private``'s
-        ``2 * g_max + 0.5`` prefilter shell. The half-Angstrom headroom reconciles the coupling
-        filter's *orientation* metric (which folds the experimental cell correction -- ``u_matrix``
-        is deliberately non-orthonormal, ~1% on quartz) with this ideal-cell ``reciprocal_cell``
-        metric, so a coupled beam difference near ``2 * solve_g_max`` in the former still lands
-        inside the grid in the latter. The shell only enlarges the (unused-at-the-margin) SF table;
-        it changes neither the coupled beam set nor the scored set.
+        The support radius is ``2 * solve_g_max + _SUPPORT_MARGIN``. The half-Angstrom headroom
+        reconciles the coupling filter's *orientation* metric (which folds the experimental cell
+        correction -- ``u_matrix`` is deliberately non-orthonormal, ~1% on quartz) with this
+        ideal-cell ``reciprocal_cell`` metric, so a coupled beam difference near ``2 * solve_g_max``
+        in the former still lands inside the grid in the latter. The shell only enlarges the
+        (unused-at-the-margin) SF table; it changes neither the coupled beam set nor the scored set.
         """
         if solve_g_max <= 0.0:
             raise ValueError("solve_g_max must be positive")
@@ -151,7 +143,7 @@ class OrientationPlan:
     the lab-frame basis is derived from it, never stored. ``tilts`` ``(N, 3, 3)`` is the
     rocking-curve integration tilt set (source): N goniometer sub-orientations, each built into
     the matching entry of ``beam_plans`` (``N = len(beam_plans)``). The default is a single identity
-    tilt ``(1, 3, 3)`` -- one static solve, byte-identical to the pre-integration plan; a longer set
+    tilt ``(1, 3, 3)`` -- one static solve; a longer set
     is baked by ``integrate_rocking_curve`` and summed as ``|psi|^2`` over the tilts by the engine.
     ``thickness`` ``(T,)`` is the specimen's
     thickness for this rotation (its beam path length at this tilt), held fixed during refinement.
@@ -195,7 +187,7 @@ class OrientationPlan:
         ``orientation_basis(grid.cell, orientation) = reciprocal_cell(cell @ orientation.T)`` and
         drives ``g`` -> ``Sg`` / ``Mii`` only. When ``None`` the orientation is the identity and the
         shared ``grid.reciprocal_basis`` is used directly (the untilted / single-orientation case),
-        making that path byte-identical to the unoriented build. The rotation convention (and the
+        making that path identical to the unoriented build. The rotation convention (and the
         measured-cell correction folded into ``orientation``) is derived upstream in ``preprocess``;
         the ``Fgb`` gather is keyed on ``grid.structure_factor_hkl`` and is unaffected.
 
@@ -210,8 +202,8 @@ class OrientationPlan:
         ``tilts`` ``(N, 3, 3)`` is the optional rocking-curve integration set: N goniometer
         rotations, each left-multiplying ``orientation`` (``R_tilt @ orientation``) into its own
         built ``beam_plan``, sharing this orientation's one beam set. ``None`` (the default) is a
-        single identity tilt, so ``beam_plans`` has length 1 and the untilted path is byte-identical
-        to before; ``integrate_rocking_curve`` passes the tilt matrices from
+        single identity tilt, so ``beam_plans`` has length 1 and the untilted path is the plain
+        static solve; ``integrate_rocking_curve`` passes the tilt matrices from
         :func:`~diffBloch.preprocess.orientation.rocking_curve_tilts`.
 
         ``tilt_reduction`` selects how the engine reduces the tilt sub-solutions over the rocking
@@ -224,8 +216,7 @@ class OrientationPlan:
         tilts here share one, and a caller rebuilding this plan over a fixed beam set (rocking
         integration, orientation-search trials) passes the seed plan's gather
         (``op.beam_plans[0].gather``) to skip re-deriving it on every rebuild -- the dominant
-        preprocess cost (the fix the private applied in its 6bb3031). When ``None`` it is built once
-        here and shared across the tilts.
+        preprocess cost. When ``None`` it is built once here and shared across the tilts.
 
         ``validate`` (default ``True``) is forwarded to
         :func:`~diffBloch.core.dynamical.build_structure_factor_gather` when it builds the gather
@@ -248,7 +239,7 @@ class OrientationPlan:
             nominal_basis = orientation_basis(np.asarray(grid.cell), rotation)
         if tilts is None:
             tilt_mats = np.eye(3, dtype=np.float64)[None]
-            # No tilts: reuse the nominal basis exactly, keeping the untilted build byte-identical.
+            # No tilts: reuse the nominal basis exactly for the untilted build.
             bases = [nominal_basis]
         else:
             tilt_mats = np.asarray(tilts, dtype=np.float64)
@@ -330,9 +321,7 @@ class SegmentPlan:
 
 @dataclass(frozen=True)
 class CoupledOrientationPlan:
-    """A rotation whose rocking curve couples a *different* beam set per tilt chunk (the private).
-
-    v1 analog: the ``A_batches`` / ``cell_chunks`` reassembly in ``BlochNet.forward``.
+    """A rotation whose rocking curve couples a *different* beam set per tilt chunk.
 
     The tilt-dependent generalization of :class:`OrientationPlan`: instead of one beam set shared
     across all tilts, the curve is partitioned into :class:`SegmentPlan` chunks, each solving its

--- a/src/diffBloch/engine/refine.py
+++ b/src/diffBloch/engine/refine.py
@@ -7,9 +7,6 @@ and the caller's parameters, clones the *target* fields into fresh ``requires_gr
 rest become detached constants), steps a chosen backend, and returns a new detached
 :class:`RefinementResult`.
 The caller's parameters are never touched. ``core/`` stays free of ``torch.optim`` entirely.
-
-Deliberately deferred surface: per-group learning rates, ``least_squares``, component ``activate``,
-and ``OptimizerState``/history threading.
 """
 
 from __future__ import annotations
@@ -61,8 +58,8 @@ _TRAINABLE_FIELDS: dict[str, tuple[str, ...]] = {
 class AtomSelection:
     """A coarse atom/parameter selection for one trainable group.
 
-    Phase 5 only distinguishes whole-group ``all`` vs ``none``. Later phases can extend this value
-    with element or index filters without reintroducing stringly-typed refinement targets.
+    The current modes distinguish whole-group ``all`` vs ``none``. The value can be extended with
+    element or index filters without reintroducing stringly-typed refinement targets.
     """
 
     mode: Literal["all", "none"]
@@ -135,7 +132,7 @@ class TrainableSpec:
 
     @classmethod
     def positions_and_adp(cls) -> TrainableSpec:
-        """The historical default: refine positions and ADPs when present."""
+        """The default: refine positions and ADPs when present."""
         return cls(positions=AtomSelection.all(), adp=AtomSelection.all())
 
 
@@ -403,8 +400,8 @@ class _TrainableParams:
     """Frozen parameter context plus the trainable leaves that override it.
 
     This keeps optimizer leaves explicit and reconstructs a full :class:`RefinableParams` value for
-    each objective evaluation. With today's whole-group selections the overrides are full tensors;
-    later per-atom selections can reconstruct full fields from smaller selected leaves here.
+    each objective evaluation. Under whole-group selections the overrides are full tensors;
+    per-atom selections would reconstruct full fields from smaller selected leaves here.
     """
 
     frozen: RefinableParams
@@ -435,8 +432,8 @@ def _to_trainable_params(
             row_mask = trainable_fields[param_field.name]
             leaf_value = value[row_mask.to(device=value.device)] if row_mask is not None else value
             leaf = leaf_value.detach().clone().requires_grad_(True)
-            # Keep the detached full-field baseline even when this whole field is overridden today:
-            # future per-atom leaves will reconstruct by scattering selected rows onto it.
+            # Keep the detached full-field baseline even when this whole field is overridden:
+            # per-atom leaves reconstruct by scattering selected rows onto it.
             frozen_values[param_field.name] = value.detach().clone()
             overrides[param_field.name] = _FieldOverride(leaf=leaf, row_mask=row_mask)
             leaves.append(leaf)

--- a/src/diffBloch/io/_cifio.py
+++ b/src/diffBloch/io/_cifio.py
@@ -63,7 +63,7 @@ def loop_rows(block: gemmi.cif.Block, first_tag: str) -> list[dict[str, str]]:
     tags = [str(tag) for tag in loop.tags]
     width = int(loop.width())
     # Materialise loop.values once: it is a gemmi property that rebuilds the whole flat vector on
-    # each access, so slicing per row is O(rows^2) -- ~750s on LTA's 29k reflections, ~0.01s here.
+    # each access, so slicing per row would be O(rows^2) -- pathological on large reflection loops.
     flat = list(loop.values)
     rows: list[dict[str, str]] = []
     for start in range(0, len(flat), width):

--- a/src/diffBloch/io/symmetry_setup.py
+++ b/src/diffBloch/io/symmetry_setup.py
@@ -1,10 +1,10 @@
-"""Symmetry-constraint setup seam.
+"""Symmetry-constraint setup: extract special-position constraints at the io boundary.
 
-Extracts special-position constraints from a validated :class:`StructureRecord` at the io boundary,
+Extracts special-position constraints from a validated :class:`StructureRecord`,
 as plain-value arrays the torch-only :func:`diffBloch.params.constrain` then applies. The position
 constraint is the **site-symmetry projector** built natively from the record's symmetry operators
-(no diffpy on the position path); the diffpy-backed ADP (``Uij``) constraints land with the ADP
-stage behind this same seam.
+(no diffpy on the position path); the diffpy-backed ADP (``Uij``) equality constraints are extracted
+at this same boundary.
 """
 
 from __future__ import annotations

--- a/src/diffBloch/preprocess/__init__.py
+++ b/src/diffBloch/preprocess/__init__.py
@@ -1,15 +1,15 @@
 """The preprocess pipeline: fit the experiment's nuisances + numerics, emit the invariant ``Plan``.
 
-Stage 11 builds this as a composable ``Plan -> Plan`` pipeline (a scikit-learn-style sequence of
+This is a composable ``Plan -> Plan`` pipeline (a scikit-learn-style sequence of
 transformers) producing the geometry the differentiable refinement is conditioned on:
 ``preprocess -> Plan -> refine``. ``refine`` is the terminal estimator (``Plan -> Result``) and
 never re-enters here. The dependency points ``preprocess -> engine``; the engine never imports
 preprocess.
 
-This first slice lays the spine: the :class:`~diffBloch.preprocess.plan.Plan` value object and the
+The core pieces are the :class:`~diffBloch.preprocess.plan.Plan` value object, the
 :mod:`diffBloch.preprocess.pipeline` combinators (``pipeline`` sequencing + ``iterate_until``
-fixpoint). The real steps (``converge_numerics`` / ``fit_orientation`` / ``fit_thickness``) and
-``from_experiment`` construction land in later slices.
+fixpoint), the steps (``converge_numerics`` / ``fit_orientation`` / ``fit_thickness`` and the rest),
+and ``from_experiment`` construction from typed records.
 """
 
 from diffBloch.preprocess.driver import converge_numerics

--- a/src/diffBloch/preprocess/coupling.py
+++ b/src/diffBloch/preprocess/coupling.py
@@ -1,17 +1,17 @@
-"""Tilt-segment-union beam coupling: the per-tilt-chunk beam sets of the private rocking curve.
+"""Tilt-segment-union beam coupling: per-tilt-chunk beam sets across a rocking curve.
 
 Rocking-curve integration solves the crystal at many slightly-tilted sub-orientations. A single
 beam set for the whole curve either over-couples (every beam any tilt needs, slow) or drops beams a
-tilt needs (a reflection drifts through the Ewald sphere as the crystal rocks). The
-``diffBloch_private`` policy instead partitions the tilts into contiguous chunks and couples, within
-each chunk, the **union** of the excited-beam sets at the chunk's two boundary tilts.
+tilt needs (a reflection drifts through the Ewald sphere as the crystal rocks). This coupling policy
+instead partitions the tilts into contiguous chunks and couples, within each chunk, the **union** of
+the excited-beam sets at the chunk's two boundary tilts.
 
 This module is the pure geometry of that partition: given a
 :class:`~diffBloch.specs.SegmentedUnionCoupling`
 policy and the rotation's tilt geometry, it returns the ordered :class:`Segment` list (each a beam
-set + the disjoint tilt indices it covers). It computes the same excitation mask
-(``|Sg| < sg_max`` and ``|g| < g_max``) the private's ``BlochNet.forward`` builds its
-union sets from, reusing :func:`~diffBloch.core.dynamical.excitation_errors` and
+set + the disjoint tilt indices it covers). It computes the excitation mask
+(``|Sg| < sg_max`` and ``|g| < g_max``) from which the union sets are built,
+reusing :func:`~diffBloch.core.dynamical.excitation_errors` and
 :func:`~diffBloch.core.crystal.orientation_basis`. It does not build or solve anything -- an engine
 step turns the segments into per-chunk plans and reassembles their curves before reduction.
 """
@@ -51,9 +51,9 @@ class Segment:
 
 
 def _fixed_segment_ranges(n_tilts: int, fixed_n_segments: int) -> NDArray[np.int64]:
-    """The private's contiguous split boundaries into ``fixed_n_segments`` chunks over ``n_tilts``.
+    """Contiguous split boundaries into ``fixed_n_segments`` chunks over ``n_tilts``.
 
-    Ported verbatim from ``BlochNet.forward`` (``union_adaptive = False`` path): evenly sized chunks
+    The ``union_adaptive = False`` path: evenly sized chunks
     with the remainder front-loaded, boundaries clamped so the last index is ``n_tilts - 1``, then
     de-duplicated. Returns the strictly increasing boundary indices (length ``fixed_n_segments + 1``
     before de-duplication), so ``fixed_n_segments`` segments span ``boundaries[i] .. boundaries[i +
@@ -81,9 +81,9 @@ def _adaptive_segment_ranges(
     excited_mask: Callable[[int], NDArray[np.bool_]],
     max_new_pct: float,
 ) -> list[tuple[int, int]]:
-    """Adaptive chunk boundaries by recursive bisection (the private's ``union_adaptive`` path).
+    """Adaptive chunk boundaries by recursive bisection (the ``union_adaptive`` path).
 
-    Ported from ``BlochNet.forward``: a range ``(a, b)`` is split at its midpoint only while the
+    A range ``(a, b)`` is split at its midpoint only while the
     midpoint's excited set adds more than ``max_new_pct`` *new* beams beyond the boundary union
     ``mask(a) | mask(b)`` (else the range freezes as one chunk). Returns the ordered, inclusive
     ``(a, b)`` segment ranges partitioning ``0 .. n_tilts - 1`` (disjoint, covering each tilt once);
@@ -125,8 +125,6 @@ def build_coupling_segments(
 ) -> tuple[Segment, ...]:
     """Partition the rocking curve into boundary-union coupled segments (pure geometry).
 
-    v1 analog: the union-split block in ``BlochNet.forward``.
-
     ``candidate_beam_hkl`` ``(G, 3)`` is the beam candidate pool to select from (the shared
     :class:`~diffBloch.engine.plan.StructureFactorGrid` ``structure_factor_hkl`` -- radius
     ``2 * g_max``, so the
@@ -138,8 +136,7 @@ def build_coupling_segments(
     (mean-inner-potential correction) set the Ewald geometry.
 
     Each boundary tilt's excited mask is ``|Sg| < sg_max`` and ``|g| < g_max`` with
-    ``g = candidate_beam_hkl @ orientation_basis(cell, tilt @ orientation)`` (identical to the private's
-    ``hkl @ reciprocal_cell(unit_cell @ (R_tilt @ orientation).T)``). Segment ``i`` couples the
+    ``g = candidate_beam_hkl @ orientation_basis(cell, tilt @ orientation)``. Segment ``i`` couples the
     union of the masks at boundary tilts ``i`` and ``i + 1`` and covers the half-open tilt range
     between them; the final segment includes the end, so the covers tile ``0 .. B - 1`` exactly.
     """

--- a/src/diffBloch/preprocess/driver.py
+++ b/src/diffBloch/preprocess/driver.py
@@ -1,4 +1,4 @@
-"""The preprocess convergence driver: the ``runState`` runner for the coupled beam-knob sweeps.
+"""The preprocess convergence driver: threads state through the coupled beam-knob sweeps.
 
 The individual convergence levers (``converge_beams`` / ``converge_pool`` / ``converge_sampling``)
 and the coverage levers (``cover_beams`` / ``cover_pool``) are pure ``Plan -> Plan`` steps, each
@@ -7,13 +7,12 @@ settled knobs to self-stability (the ``both`` operation) -- needs state the ``Pl
 does not carry: the live scalars ``g_max_refine`` / ``integration_semiangle`` / ``rocking_curve_sampling``.
 This module is the **driver** that owns that state.
 
-In State-monad terms: :class:`ConvergenceState`
-is the state ``s``; a *phase* (:func:`run_coverage_phase`, :func:`run_stability_phase`) is a
-``(Plan, ConvergenceState) -> (Plan, ConvergenceState)`` computation; the driver plays
-``runState``, threading ``s`` between phases and, at its outer boundary, returning just the
-converged ``Plan`` (``evalState``). "Driver" is the runner's role name, not a monad.
+:class:`ConvergenceState` holds that state; a *phase* (:func:`run_coverage_phase`,
+:func:`run_stability_phase`) is a ``(Plan, ConvergenceState) -> (Plan, ConvergenceState)``
+computation; the driver threads the state between phases and, at its outer boundary, returns just
+the converged ``Plan``.
 
-Obstruction 1 (the cross-lever fixpoint): each candidate must re-select the window from
+The cross-lever fixpoint: each candidate must re-select the window from
 the **un-pruned pool**, not from a previous lever's pruned ``Plan``. The driver re-derives that pool
 as ``seed_beam_hkl(grid, g_max_refine)`` -- so the pool is *derived* from the grid + the live
 ``g_max_refine`` scalar, never stored.
@@ -43,7 +42,7 @@ __all__ = [
 
 @dataclass(frozen=True)
 class ConvergenceState:
-    """The driver's coordinate-descent state -- the live beam scalars (the State monad's ``s``).
+    """The driver's coordinate-descent state -- the live beam scalars threaded between phases.
 
     ``g_max_refine`` is the candidate-pool radius; ``integration_semiangle`` is the Klar window;
     ``rocking_curve_sampling`` is the rocking-curve tilt count. The un-pruned pool is *not* a field: it is
@@ -69,15 +68,14 @@ def converge_numerics(
 ) -> PlanStep:
     """Return a ``Plan -> Plan`` step running the selected convergence operation (the driver entry).
 
-    The driver's outer ``evalState`` boundary: it seeds the initial :class:`ConvergenceState` (pool
+    The driver's outer boundary: it seeds the initial :class:`ConvergenceState` (pool
     from ``test.start_g_max_refine``, window from ``selection.integration.semiangle``, tilt from
     ``rocking.sampling``), runs the ``test.operation`` phase(s), and returns just the converged
     ``Plan`` -- the settled scalars are dropped, so downstream steps never see driver state and this
     nests as one *optional* ordinary step in the preprocess pipeline (convergence stays entirely
     opt-in by construction). ``both`` runs :func:`run_coverage_phase` first and seeds
-    :func:`run_stability_phase` from its settled state (the private's ``initial_*`` handoff); the
-    single-phase operations run one and discard the state. Faithful to the private
-    ``convergence_testing`` dispatch on ``convergence_test.operation``.
+    :func:`run_stability_phase` from its settled state; the single-phase operations run one and
+    discard the state. Dispatches on ``convergence_test.operation``.
     """
 
     def run(plan: Plan) -> Plan:
@@ -111,7 +109,7 @@ def converge_numerics(
                 method=method,
             )
             return converged
-        # "both": coverage's settled scalars seed self-stability (the private's initial_* handoff).
+        # "both": coverage's settled scalars seed self-stability.
         covered, settled = run_coverage_phase(
             plan,
             start,
@@ -149,16 +147,15 @@ def run_coverage_phase(
 ) -> tuple[Plan, ConvergenceState]:
     """Grow the pool then the window to the minimum that maximises coverage; thread the scalars.
 
-    The coverage phase (``State ConvergenceState Plan``): a single ordered pass -- pool
+    The coverage phase: a single ordered pass -- pool
     (``g_max_refine``) then window (``integration_semiangle``) -- each swept by
     :func:`maximize_scalar`
     to the smallest value that still strictly increases :func:`plan_coverage` (matched observed
-    reflections). Faithful to the private ``_run_initial_minimum_param_sweep``, minus the tilt knob:
-    2.0 coverage is pure geometric membership, so the tilt count cannot move it;
+    reflections). Coverage is pure geometric membership, so the tilt count cannot move it;
     tilts are tuned in the self-stability phase instead.
 
     Each candidate is built from the **un-pruned pool** re-derived at the current ``g_max_refine``
-    (obstruction 1), so widening the window can recover beams a narrower pool clipped. ``selection``
+    (the cross-lever fixpoint), so widening the window can recover beams a narrower pool clipped. ``selection``
     supplies the fixed ``rsg`` / ``dsg`` / ``geometry``; its ``integration.semiangle`` is ignored --
     the live window comes from ``state``. Returns the coverage-maximising ``Plan`` and the settled
     :class:`ConvergenceState` (for the ``both`` handoff to self-stability). ``g_max_refine_step`` /
@@ -214,8 +211,8 @@ def run_stability_phase(
     (``rocking_curve_sampling``) knobs, each driven by :func:`converge_scalar` to the first knob value whose
     *consecutive-simulation* R-factor drops below ``tolerance.r_factor_threshold`` (a numerical
     resolution study, not an accuracy fit -- so it needs ``refinement``, unlike the pure-geometry
-    coverage phase). Faithful to the private ``_run_hyperparams_optimization``: pass 1 sweeps
-    pool -> tilt -> window; pass 2+ sweeps tilt -> pool -> window (the private's per-pass
+    coverage phase). Pass 1 sweeps
+    pool -> tilt -> window; pass 2+ sweeps tilt -> pool -> window (a per-pass
     order-swap, revisiting each knob after the others moved). Each settled scalar threads into the
     next sweep
     and the next pass via the running ``(g_max_refine, integration_semiangle, rocking_curve_sampling)``.
@@ -305,10 +302,8 @@ def _stability_build(
 
     Pool + window via :func:`_windowed_pool` (which fixes the beam SET), then rocking-curve tilt
     integration at ``rocking_curve_sampling`` on that set. Order matters: the pool/window decide *which*
-    beams, the tilt count integrates the rocking curve over them. Mirrors the private
-    ``_run_simulation``
-    (a fresh build from ``g_max`` / ``sg_max`` / ``tilt_steps``), never an incrementally-mutated
-    Plan.
+    beams, the tilt count integrates the rocking curve over them. Each candidate is a fresh build
+    from ``g_max`` / ``sg_max`` / ``tilt_steps``, never an incrementally-mutated Plan.
     """
     pooled = _windowed_pool(plan, g_max_refine, integration_semiangle, selection)
     tilts = replace(rocking, sampling=int(round(rocking_curve_sampling)))

--- a/src/diffBloch/preprocess/experiment.py
+++ b/src/diffBloch/preprocess/experiment.py
@@ -4,7 +4,7 @@ This is the *initial total construction* of the preprocess pipeline (it is not `
 there is no ``Plan`` yet). It assembles two separable products from the same records/config:
 
 - a :class:`~diffBloch.preprocess.plan.Plan` pair (``train`` / ``validation``) -- the invariant
-  geometry the preprocess steps then sharpen and ``refine`` consumes (added in the next slice);
+  geometry the preprocess steps then sharpen and ``refine`` consumes;
 - a :class:`RefinementSetup` -- the structure-side static + refinable inputs the
   :class:`~diffBloch.engine.forward.RefinementEngine` needs (ASU expansion, constraint spec, initial
   parameters, atomic numbers).
@@ -52,13 +52,12 @@ class PlanSplit:
     rotation by default); both reference the *same* grid object, so the shared ``Fgb`` support
     cannot diverge.
 
-    The split is currently **dormant machinery**: nothing downstream distinguishes ``train`` from
-    ``validation`` yet (inference and the engine take a single :class:`Plan`), and whole-experiment
+    The split is currently **dormant**: nothing downstream distinguishes ``train`` from
+    ``validation`` (inference and the engine take a single :class:`Plan`), and whole-experiment
     work uses :attr:`combined` (all rotations). A whole-*rotation* holdout is a weak
     cross-validation guard for over-determined physics refinement anyway -- the principled analog
-    holds out *reflections* (R_free), not orientations. The split is kept because it becomes
-    genuinely informative for the future learned modes (a learned ``theta -> thickness`` can overfit
-    per rotation).
+    holds out *reflections* (R_free), not orientations. It is retained because it becomes
+    informative for learned modes, where a learned ``theta -> thickness`` can overfit per rotation.
     """
 
     train: Plan
@@ -168,7 +167,7 @@ def from_experiment(
 
     Each orientation is seeded with the orientation-independent, difference-safe beam set
     ``{hkl in grid : |g| <= numerics.g_max_refine}`` (so beam differences stay within the derived
-    grid and the 000 transmitted beam is present). The faithful per-orientation ``sg_max`` / rsg-dsg
+    grid and the 000 transmitted beam is present). The per-orientation ``sg_max`` / rsg-dsg
     pruning is the later ``select_beams`` step.
 
     This is intentionally a module-level function rather than ``ExperimentSetup.from_*``: it is the
@@ -231,7 +230,7 @@ def seed_beam_hkl(grid: StructureFactorGrid, *, g_max_refine: float) -> NDArray[
 def _validation_mask(n_rotations: int, split: DataSplitConfig) -> NDArray[np.bool_]:
     """Boolean per-rotation validation mask from the split policy.
 
-    Only the Stage-1 policies are implemented: ``train='all_except_validation'`` with
+    The implemented policies are ``train='all_except_validation'`` with
     ``validation='every_10th_rotation'`` (every 10th rotation by 1-based count -> 0-based indices
     where ``(i + 1) % 10 == 0``). Other selector strings are rejected rather than silently ignored.
     """

--- a/src/diffBloch/preprocess/inference.py
+++ b/src/diffBloch/preprocess/inference.py
@@ -3,12 +3,11 @@
 ``run_inference`` is the eval-only member of the preprocess pipeline's terminal family (the other is
 ``engine.refine``, which optimizes structure): it runs one forward Bloch pass per orientation under
 ``no_grad`` and reports a per-rotation :class:`RotationInference` (the Bragg R-factor ``R_obs`` and
-two diagnostics). It is the 2.0 analog of the private ``evaluate_over_rotations`` and the terminal
-the executable quartz anchor calls.
+two diagnostics).
 
 Built entirely from the public forward spine -- ``engine.simulate`` + :func:`core.products.align` +
-:func:`core.losses.rbragg`/:func:`core.losses.optimal_scale` -- so callers (and the anchor test)
-never reach into engine internals. Preprocess is composed in optionally via the ``preprocess``
+:func:`core.losses.rbragg`/:func:`core.losses.optimal_scale` -- so callers never reach into engine
+internals. Preprocess is composed in optionally via the ``preprocess``
 ``PlanStep``; the solver is swappable via ``method``.
 """
 
@@ -70,10 +69,10 @@ class InferenceResult:
 
     @property
     def mean_r_obs(self) -> float:
-        """Mean ``R_obs`` over the finite rotations (the private aggregate convention).
+        """Mean ``R_obs`` over the finite rotations.
 
-        ``nan`` when no rotation has a finite ``r_obs``. The private reference summary averages the
-        per-rotation ``R_obs`` (rotations with no reflections are skipped), so this mirrors it.
+        ``nan`` when no rotation has a finite ``r_obs``. The per-rotation ``R_obs`` values are
+        averaged, skipping rotations with no reflections.
         """
         finite = [row.r_obs for row in self.per_rotation if math.isfinite(row.r_obs)]
         if not finite:

--- a/src/diffBloch/preprocess/orientation.py
+++ b/src/diffBloch/preprocess/orientation.py
@@ -6,17 +6,16 @@ orientation file. The orientations are first-class inputs to the ``Plan``; ``fit
 refines them in-Plan -- it must not re-orthonormalise them: they fold a ~1% measured-vs-ideal cell
 correction, so a polar/SVD projection would silently drop it.
 
-Convention, pinned against ``diffBloch_private/diffBloch/rotation_dataset.py``::
+Convention::
 
     orientation = R_z(omega) . R_x(alpha) . R_y(beta) @ U,    U = UB @ B^-1
 
 where ``B`` is the Busing-Levy reciprocal matrix built from the cell parameters and the goniometer
 rotations are active, in degrees. Geometry then uses :func:`orientation_basis` =
 ``reciprocal_cell(cell @ orientation.T)`` (NOT ``reciprocal_basis @ orientation.T``), because the
-orientation matrices are generally non-orthonormal -- see ``tests/unit/test_orientation_oracle.py``.
+orientation matrices are generally non-orthonormal.
 
-References: W. R. Busing & H. A. Levy, *Acta Cryst.* **22**, 457 (1967) (the UB-matrix formalism);
-diffBloch_private's ``rotation_dataset.py`` for the specific rotation ordering and B convention.
+Reference: W. R. Busing & H. A. Levy, *Acta Cryst.* **22**, 457 (1967) (the UB-matrix formalism).
 """
 
 from __future__ import annotations
@@ -94,8 +93,8 @@ def hexagonal_tilt(azimuth: float, polar: float) -> FloatArray:
     rotation (``det = 1``) it preserves the non-orthonormal ``U`` measured-cell correction exactly,
     so the re-orthonormalisation trap is dodged by construction.
 
-    Faithful to ``diffBloch_private``'s ``generate_new_tilt``. Reference: L. Palatinus et al.,
-    *Acta Cryst.* **A69**, 171-188 (2013), the hexagonal modified-simplex search.
+    Reference: L. Palatinus et al., *Acta Cryst.* **A69**, 171-188 (2013), the hexagonal
+    modified-simplex search.
     """
     phi, theta = np.deg2rad([azimuth, polar])
     rz = np.array(
@@ -118,16 +117,12 @@ def rocking_curve_tilts(
     left-multiply the already-PETS-rotated orientation (``R_tilt @ orientation``). ``sampling = 1``
     is special-cased to a single tilt at angle 0 (the identity), so composing the integration with a
     unit sampling is a no-op -- ``np.linspace`` would otherwise return the *start* ``-semiangle``
-    for ``num = 1``; the private only ever runs the ``sampling >= 2`` symmetric-endpoint case, so
-    this
-    edge-case centering diverges from nothing it exercises.
+    for ``num = 1``, off-centre from the nominal orientation.
 
     Continuous-rotation geometry only; ``precession`` (a cone) is a later discriminated mode and
     raises ``NotImplementedError`` here. Callers unpack a validated
     :class:`~diffBloch.specs.RockingCurve` into these raw arguments (the value-type owns the
     invariants), matching :func:`hexagonal_tilt`'s raw-float style.
-
-    Faithful to ``diffBloch_private``'s ``generate_integration_rotation_matrices``.
     """
     if geometry != "continuous_rotation":
         raise NotImplementedError(f"rocking-curve geometry {geometry!r} is not implemented")

--- a/src/diffBloch/preprocess/pipeline.py
+++ b/src/diffBloch/preprocess/pipeline.py
@@ -10,7 +10,7 @@ steps is itself a step. ``refine`` is deliberately *not* expressible here: it is
 **Provenance.** A step is self-describing: it carries a :class:`StepRecord` (its name + serialized
 params). As :func:`pipeline` applies each step it *stamps* that record onto the resulting
 :class:`~diffBloch.preprocess.plan.Plan`'s ``provenance`` tuple, so the final Plan records the
-ordered recipe that produced it -- the Writer-monad pattern (each step ``tell``\\ s its record).
+ordered recipe that produced it -- each step appends its record as it runs.
 This is what lets a checkpoint bind its identity to the recipe, not just the inputs. A step with no
 record (a bare closure, a nested composite) stamps :data:`OPAQUE` -- a plan whose provenance
 contains it can never be reused (safe: a miss, never a false hit).
@@ -141,7 +141,7 @@ def _identity(plan: Plan) -> Plan:
     return plan
 
 
-# The no-op step (pipeline identity element); records "identity" so it is a faithful, comparable
+# The no-op step (pipeline identity element); records "identity" so it is a comparable
 # provenance entry rather than an opaque miss.
 identity: Step = Step(record=StepRecord(name="identity"), run=_identity)
 
@@ -189,9 +189,8 @@ def iterate_until(step: PlanStep, *, until: ConvergenceCheck, max_iterations: in
     silent non-convergence is never returned. ``max_iterations`` must be >= 1.
 
     Provenance: the fixpoint stamps a single :data:`OPAQUE` record -- the number of iterations is
-    input-dependent, so a faithful per-iteration log would not be a stable recipe identity. A plan
-    produced through ``iterate_until`` is therefore not checkpoint-reusable yet (a safe miss); a
-    stable record is deferred with the convergence-driver checkpointing work.
+    input-dependent, so a per-iteration log would not be a stable recipe identity. A plan
+    produced through ``iterate_until`` is therefore not checkpoint-reusable (a safe miss).
     """
     if max_iterations < 1:
         raise ValueError("max_iterations must be >= 1")
@@ -212,16 +211,14 @@ def iterate_until(step: PlanStep, *, until: ConvergenceCheck, max_iterations: in
 class Fork:
     """The *choice* combinator: run one of two step lists, chosen by a predicate on the grid.
 
-    The recipe's fourth composition shape (see ``design/decisions/plan-composition-shapes.md``).
     The one rule that makes it checkpointable: **the predicate reads only the
     :class:`~diffBloch.engine.plan.StructureFactorGrid`, invariant across every preprocess step**
     (steps ``replace`` orientations; nothing resizes the grid). So the branch is a deterministic
     function of the experiment's fixed inputs -- knowable *before* running -- rather than of the
-    mutating ``Plan``. That keeps the fork *Applicative* (its shape is static), so
+    mutating ``Plan``. That keeps the fork's shape *static*, so
     :func:`resolve_recipe` can splice the chosen branch inline into a flat, fork-free recipe before
-    the checkpoint lock ever looks at it. A predicate over the ``Plan`` would be Monadic (its shape
-    would depend on intermediate results) and is deliberately unrepresentable here. See
-    ``design/decisions/combinators-and-recipe-identity.md``.
+    the checkpoint lock ever looks at it. A predicate over the ``Plan`` would make the shape depend
+    on intermediate results and is deliberately unrepresentable here.
 
     Branches are step *lists*, not pre-composed ``pipeline([...])`` closures, so each branch step's
     :class:`StepRecord` survives into the resolved recipe (a composed closure would collapse to one
@@ -270,7 +267,7 @@ def resolve_recipe(steps: Sequence[PlanStep], grid: StructureFactorGrid) -> tupl
     Splices each fork's chosen branch inline (recursively, so nested forks flatten too). Because the
     grid is invariant across the pipeline, resolving against the *base* grid here yields exactly the
     recipe that will run -- which is what lets the checkpoint lock key on a flat ``step_records``
-    list with no knowledge of forks (see ``design/decisions/combinators-and-recipe-identity.md``).
+    list with no knowledge of forks.
     """
     out: list[PlanStep] = []
     for step in steps:

--- a/src/diffBloch/preprocess/plan.py
+++ b/src/diffBloch/preprocess/plan.py
@@ -141,9 +141,9 @@ def require_built_plans(plan: Plan) -> tuple[OrientationPlanLike, ...]:
     across ``read_plan``, which reconstructs a ``Plan`` from ``.npz`` bytes). This is the parse that
     re-establishes the phase at that erased boundary -- *parse, don't validate*: it returns the
     narrowed type once, and the terminals (inference, the fits, ``couple_beams``, checkpoint
-    serialize) then hold built geometry without re-checking. See
-    ``design/decisions/candidate-vs-built-plan.md`` for why the phase-indexed alternative does not
-    survive contact with Python (no phase-changing composition; ``disallow_any_generics``).
+    serialize) then hold built geometry without re-checking. The phase-indexed alternative
+    (``Plan[P]``) does not survive contact with Python -- there is no phase-changing composition over
+    a homogeneous step list, and ``disallow_any_generics`` rejects the erased reconstruction.
 
     A :class:`CandidatePlan` has no ``beam_plans`` and is unsolvable, so this raises unless
     ``build_orientation_plans`` has run (the default recipe runs it right after ``select_beams``).

--- a/src/diffBloch/preprocess/scoring.py
+++ b/src/diffBloch/preprocess/scoring.py
@@ -4,7 +4,7 @@ Bridges the two products :func:`diffBloch.preprocess.from_experiment` returns --
 :class:`~diffBloch.preprocess.plan.Plan` and the structure-side
 :class:`~diffBloch.preprocess.experiment.RefinementSetup` -- into a runnable
 :class:`~diffBloch.engine.RefinementEngine`, then exposes the per-orientation scaling-optimised wR2
-the orientation refinement (``fit_orientation``, slice 5b) minimises.
+the orientation refinement (``fit_orientation``) minimises.
 
 ``build_engine`` is the general ``Plan + RefinementSetup -> engine`` assembly (the same engine
 ``refine`` will consume); ``score_orientations`` is the thin convenience that computes the
@@ -48,7 +48,7 @@ def build_engine(
     metric would be flat/gradient-free). It is irrelevant to :meth:`RefinementEngine.fgb` /
     :meth:`RefinementEngine.score_orientation`, which apply their own scaling-optimised wR2.
 
-    ``precision`` defaults to ``"fp64"`` (complex128 -- byte-identical to today). ``"fp32"``
+    ``precision`` defaults to ``"fp64"`` (complex128). ``"fp32"``
     (complex64) is a speed/precision knob: preprocess fits use it for transient coarse-search
     engines, and the app refinement path may opt into it explicitly via config. Terminal inference
     omits it and stays fp64. See :func:`diffBloch.core.solver.propagate`.
@@ -77,7 +77,7 @@ def score_orientations(
     """Scaling-optimised wR2 for every orientation in ``plan`` at the seeded ``refinement.params``.
 
     Computes the orientation-invariant ``F_gb`` once and reuses it across orientations. This is the
-    objective surface ``fit_orientation`` (slice 5b) searches over per rotation; here it evaluates
+    objective surface ``fit_orientation`` searches over per rotation; here it evaluates
     the current (seed) orientations, returning one scalar score per rotation.
     """
     engine = build_engine(plan, refinement, method=method)

--- a/src/diffBloch/preprocess/serialize.py
+++ b/src/diffBloch/preprocess/serialize.py
@@ -1,7 +1,7 @@
 """Serialize a preprocessed ``Plan`` to a portable ``.npz`` checkpoint and read it back.
 
 The persistence primitive behind the ``run`` program's checkpoint/resume: *serialize the whole
-``Plan``*, never per-facet state (see ``design/decisions/effects-and-observability.md``). It
+``Plan``*, never per-facet state. It
 exploits the plan types' own design -- both :class:`~diffBloch.engine.plan.OrientationPlan` and
 :class:`~diffBloch.engine.plan.CoupledOrientationPlan` separate their **source / rebuild inputs**
 (orientation / tilts / thickness / beam set(s) / observed ``pattern`` / ``energy`` / ``u0`` /

--- a/src/diffBloch/preprocess/steps/__init__.py
+++ b/src/diffBloch/preprocess/steps/__init__.py
@@ -10,7 +10,7 @@ convergence operations), :mod:`~diffBloch.preprocess.steps.fit_orientation` /
 
 Steps depend only on the parent *spine* (``plan``, ``pipeline``, ``experiment``, ``scoring``,
 ``orientation``); the parent *orchestrators* (``pipeline`` composition, ``driver``) compose steps.
-The public names are re-exported flat at :mod:`diffBloch.preprocess`. See ``README.md``.
+The public names are re-exported flat at :mod:`diffBloch.preprocess`.
 """
 
 from __future__ import annotations

--- a/src/diffBloch/preprocess/steps/beams.py
+++ b/src/diffBloch/preprocess/steps/beams.py
@@ -3,7 +3,7 @@
 A ``Plan -> Plan`` step that re-picks every :class:`~diffBloch.engine.plan.OrientationPlan`'s active
 ``beam_hkl`` using the relative-/minimum-excitation-error criterion of the SI of Klar et al. (2023),
 then rebuilds its ``BeamPlan`` + ``AlignmentPlan`` against the shared grid (``pattern`` unchanged).
-This is the faithful per-orientation selection that replaces the orientation-independent
+This is the per-orientation selection that replaces the orientation-independent
 ``g_max_refine`` seed laid down by ``from_experiment``.
 
 ``sg_max`` is the excitation-error span a reflection sweeps *during the actual integration*, so its
@@ -13,8 +13,8 @@ about the goniometer axis (``x`` in the PETS frame; ``rocking_curve_tilts`` buil
 swept excitation error has amplitude ``|(g_y, g_z)|`` -- the distance from the rock axis -- and a
 reflection *on* that axis (``g_y = g_z = 0``) never sweeps and is correctly dropped. For
 ``precession`` (an isotropic cone about the ``-z`` beam) the lever arm is instead ``|(g_x, g_y)|``,
-the distance from the beam. This matches ``diffBloch_private`` ``filter_hkls`` (``norm(k[:, 1:])``
-for its continuous-rotation data), whose beam is ``-z`` and rock axis ``x`` (same frame as ours).
+the distance from the beam. The frame convention has the beam along ``-z`` and the rock axis along
+``x``.
 """
 
 from __future__ import annotations

--- a/src/diffBloch/preprocess/steps/convergence.py
+++ b/src/diffBloch/preprocess/steps/convergence.py
@@ -26,12 +26,9 @@ before and orthogonally to the accuracy fit. This module has three layers:
 :data:`~diffBloch.preprocess.pipeline.ConvergenceCheck` that
 :func:`~diffBloch.preprocess.pipeline.iterate_until` drives to a fixpoint.
 
-Faithful to ``diffBloch_private`` ``convergence_testing`` (branch
-``pattern-vis-convergence-testing``): ``_run_hyperparams_optimization``'s nested ``optimize_gmax`` /
-``optimize_sgmax`` / ``optimize_tilt_steps`` sweeps, each stopping the first time the
-per-orientation
-``rbragg_abs`` (``_compute_step_rfactor``) drops below ``r_factor_threshold``. 2.0 keeps that exact
-stopping rule (no patience, no skip-null) and consolidates the private's knobs.
+The convergence sweep grows each numeric knob (beam-pool radius, excitation window, tilt count) and
+stops the first time the per-orientation Bragg R-factor between consecutive simulations drops below
+``r_factor_threshold`` -- a deliberately simple stopping rule (no patience, no skip-null).
 """
 
 from __future__ import annotations
@@ -72,7 +69,7 @@ type SimulationRfactor = Callable[[Plan, Plan], float]
 
 # The R-factor compares two simulations, not simulation-vs-data, so there is no measurement noise to
 # weight by; a near-zero sigma makes ``rbragg`` effectively unweighted while keeping its
-# ``I > 3*sigma`` mask inclusive (the private uses sigmas = 1e-10 for the same reason).
+# ``I > 3*sigma`` mask inclusive.
 _UNWEIGHTED_SIGMA = 1e-10
 
 
@@ -147,9 +144,9 @@ def converge_scalar[T](
     ``build(value)`` rebuilds the object at a knob value; ``measure(previous, candidate)`` is the
     consecutive-output R-factor (0 when identical). Starting from ``start`` and clicking by ``step``
     each iteration, it returns the first candidate whose R-factor against the previous build is
-    below ``tolerance.r_factor_threshold``. This is the private's exact stopping rule -- the first
+    below ``tolerance.r_factor_threshold``. The stopping rule is deliberately simple -- the first
     dip stops the sweep, and an unchanged build (R = 0) counts as converged -- with no patience and
-    no null-step handling (a faithful port). Raises
+    no null-step handling. Raises
     ``RuntimeError`` if ``tolerance.max_iterations`` steps pass without a dip below threshold
     (silent non-convergence is never returned, matching
     :func:`~diffBloch.preprocess.pipeline.iterate_until`).

--- a/src/diffBloch/preprocess/steps/coupling.py
+++ b/src/diffBloch/preprocess/steps/coupling.py
@@ -5,17 +5,17 @@ discriminated union rather than a boolean toggle:
 
 - :class:`~diffBloch.specs.TiltIndependent` -- the default: one beam set (the ``select_beams``
   active set) shared across every tilt. A no-op here (the shared set is already on the plan).
-- :class:`~diffBloch.specs.SegmentedUnionCoupling` -- the ``diffBloch_private`` policy: partition
-  the tilts into contiguous chunks and give each its own boundary-union beam set
+- :class:`~diffBloch.specs.SegmentedUnionCoupling` -- a policy that partitions
+  the tilts into contiguous chunks and gives each its own boundary-union beam set
   (:func:`~diffBloch.preprocess.coupling.build_coupling_segments`), replacing each
   :class:`~diffBloch.engine.plan.OrientationPlan` with a
   :class:`~diffBloch.engine.plan.CoupledOrientationPlan` the engine reassembles + reduces.
 
-It is the tilt-dependent generalization of ``select_beams``, and it appears **twice** in the
-faithful recipe: once after ``mosaicity`` -- so ``fit_orientation`` / ``fit_thickness`` fit *under*
-the coupling (the frozen-union fit: the seed-orientation segments re-solved at each trial) -- and
-once after the fits, re-coupling at the fitted orientation for evaluation. It is only meaningful
-once ``select_beams`` has established the Klar-selected scored set (before it, an orientation's
+It is the tilt-dependent generalization of ``select_beams``. The default app recipe does not use
+this step -- it couples *per trial* inside ``fit_orientation`` (``coupling=...``); ``couple_beams``
+is the explicit composable step when a caller wants to settle a coupled ``Plan`` directly. It is
+only meaningful once ``select_beams`` has established the Klar-selected scored set (before it, an
+orientation's
 ``alignment`` is the seed-pool intersection, too wide). It accepts either a plain
 :class:`~diffBloch.engine.plan.OrientationPlan` (the first application) or an already-coupled
 :class:`~diffBloch.engine.plan.CoupledOrientationPlan` (the re-couple), re-deriving each
@@ -28,9 +28,8 @@ fewer than two tilts. The upstream ``tilt_reduction`` (e.g. a ``mosaicity`` broa
 through unchanged.
 
 Crucially it decouples the two reflection sets the plan otherwise conflates: the *solve* set
-expands to the excitation coupling union (``|g| < 2.05``), while the *scored* set stays pinned to
-the pre-couple ``select_beams`` selection (``op.alignment.hkl``), intersected with the union. See
-``design/decisions/solve-set-vs-scored-set.md``.
+expands to the excitation coupling union, while the *scored* set stays pinned to
+the pre-couple ``select_beams`` selection (``op.alignment.hkl``), intersected with the union.
 """
 
 from __future__ import annotations
@@ -59,8 +58,8 @@ def couple_beams(policy: CouplingPolicy) -> PlanStep:
     """
     match policy:
         case TiltIndependent():
-            # A no-op on the plan, but recorded as couple_beams(TiltIndependent) so provenance shows
-            # the coupling decision faithfully (distinct from a plain unrecorded identity).
+            # A no-op on the plan, but recorded as couple_beams(TiltIndependent) so provenance
+            # records the coupling decision (distinct from a plain unrecorded identity).
             return as_step("couple_beams", policy, identity.run)
         case SegmentedUnionCoupling():
 

--- a/src/diffBloch/preprocess/steps/coverage.py
+++ b/src/diffBloch/preprocess/steps/coverage.py
@@ -9,21 +9,18 @@ no new match -- the minimal beam set that still covers the data.
 
 - :func:`plan_coverage` -- the objective: ``sum over orientations |beam_hkl & observed hkl|``.
   It is a *pure function of the Plan* (no engine, no structure factors): a "match" is set
-  membership, exactly the private's ``match == "yes"`` (an experimental hkl present in the filtered
-  simulated beam set, with no intensity gate).
+  membership (an experimental hkl present in the filtered simulated beam set, with no intensity
+  gate).
 - :func:`maximize_scalar` -- the parameter-agnostic driver: click a scalar knob upward, keep the
   build while the objective strictly increases, return the last build at the first non-increase, or
-  raise at a hard cap. Mirrors :func:`~diffBloch.preprocess.steps.convergence.converge_scalar` for
-  the
-  match-count objective.
+  raise at a hard cap. The match-count analogue of
+  :func:`~diffBloch.preprocess.steps.convergence.converge_scalar`.
 - :func:`cover_beams` / :func:`cover_pool` -- the ``Plan -> Plan`` adapters for the two beam levers
   (Klar window ``integration_semiangle`` and seed pool ``g_max_refine``).
 
-Faithful to ``diffBloch_private`` ``convergence_testing._run_initial_minimum_param_sweep`` (branch
-``pattern-vis-convergence-testing``): sequential per-knob sweeps accepting a candidate only when
-``_count_unique_matches`` increases, ``for ... else`` raising at ``MAX_SWEEP_ITERATIONS``. Two
-operations are two kinds of objective: coverage maximises *observed matches*, self-stability
-(``convergence.py``) settles *simulations*.
+The two convergence operations are two kinds of objective: coverage maximises *observed matches*
+(sequential per-knob sweeps, accepting a candidate only while the match count increases, capped),
+while self-stability (``convergence.py``) settles *simulations*.
 """
 
 from __future__ import annotations
@@ -54,8 +51,8 @@ def plan_coverage(plan: Plan) -> int:
     """Count matched reflections: ``sum over orientations |beam_hkl intersect observed hkl|``.
 
     A pure, engine-free measure of how much of the observed data the current beam set covers. A
-    "match" is an observed reflection whose hkl is present in that orientation's active beam set --
-    the 2.0 analog of the private's ``match == "yes"`` (set membership, no intensity threshold).
+    "match" is an observed reflection whose hkl is present in that orientation's active beam set
+    (set membership, no intensity threshold).
     """
     total = 0
     for op in plan.orientations:
@@ -81,9 +78,9 @@ def maximize_scalar[T](
     rebuilds the object at a knob value; ``objective(obj)`` is the score to maximise (for coverage,
     :func:`plan_coverage`). Starting from ``start`` and clicking by ``step``, it keeps a candidate
     while its score is strictly greater than the best so far and returns the best at the first step
-    that does not improve it -- the private's ``if candidate > best: accept; else: break``. Raises
+    that does not improve it (accept while ``candidate > best``, else stop). Raises
     ``RuntimeError`` if ``max_iterations`` steps pass while the score is still increasing (the score
-    never plateaus), matching the private's ``for ... else`` cap. ``max_iterations`` must be >= 1.
+    never plateaus). ``max_iterations`` must be >= 1.
     """
     if max_iterations < 1:
         raise ValueError("max_iterations must be >= 1")

--- a/src/diffBloch/preprocess/steps/fit_orientation.py
+++ b/src/diffBloch/preprocess/steps/fit_orientation.py
@@ -14,25 +14,24 @@ the step never mutates; the simulation inside is
 deterministic and depends only on its inputs, so it is ordinary computation, not a side effect.
 
 The active beam set is held fixed at each orientation's seed selection across the search -- it is
-*not* re-filtered per trial (a divergence from ``diffBloch_private``) *unless* the fit is opted into
+*not* re-filtered per trial *unless* the fit is opted into
 coupling via ``coupling=`` (see below). The rocking-curve tilt set carried by the ``Plan`` is
 threaded through every trial unchanged, so each candidate is scored under the *same* integration as
-the seed -- the fit/eval consistency invariant (the private fits under integration too, passing
-``tilts`` into every simplex trial). Ordering ``integrate_rocking_curve`` before this step therefore
-couples the fit to the integrated model; with rocking off the tilt set is a single identity,
-byte-identical to a static fit.
+the seed -- the fit/eval consistency invariant. Ordering ``integrate_rocking_curve`` before this
+step therefore couples the fit to the integrated model; with rocking off the tilt set is a single
+identity, identical to a static fit.
 
-**Coupling (opt-in, ``coupling=TrialCoupling(...)``)** reproduces the private's objective exactly:
-at *every* trial orientation both the SOLVE union (the per-tilt-segment excitation coupling) and the
-SCORED set (the Klar window intersected with a resolution cap) are re-derived from scratch, so both
-track the trial rather than staying pinned to the seed. The seed is rebuilt through the same builder
-so the greedy comparison is always coupled-vs-coupled, and the last accepted trial is already the
-coupled-at-fitted-orientation plan -- no separate ``couple_beams`` step is needed. Per-trial
-re-selection makes the objective **deliberately non-stationary**: consecutive trials score different
-reflection sets (different wR2 denominators). This is faithful -- the private's objective returns
-wR2 over each trial's own filtered set -- not a bug. It is affordable because the atomic ``F_gb`` is
-computed once and every segment's structure-factor matrix is a cheap gather-index into it (~55 ms of
-re-coupling per trial, measured), not a re-derivation.
+**Coupling (opt-in, ``coupling=TrialCoupling(...)``)** re-derives both reflection sets at every
+trial: at *every* trial orientation both the SOLVE union (the per-tilt-segment excitation coupling)
+and the SCORED set (the Klar window intersected with a resolution cap) are re-derived from scratch,
+so both track the trial rather than staying pinned to the seed. The seed is rebuilt through the same
+builder so the greedy comparison is always coupled-vs-coupled, and the last accepted trial is
+already the coupled-at-fitted-orientation plan -- no separate ``couple_beams`` step is needed.
+Per-trial re-selection makes the objective **deliberately non-stationary**: consecutive trials score
+different reflection sets (different wR2 denominators). This is intended, not a bug -- each trial's
+wR2 is over that trial's own filtered set. It is affordable because the atomic ``F_gb`` is
+computed once and every segment's structure-factor matrix is a cheap gather-index into it, not a
+re-derivation.
 
 With ``coupling=None`` (the default) each trial is ``current.with_orientation(...)``, defined on
 both the tilt-independent :class:`OrientationPlan` and the
@@ -94,10 +93,10 @@ def fit_orientation(
     ``search`` is a pre-validated :class:`~diffBloch.specs.HexagonalSearch` (invalid bounds are
     unrepresentable, so this function never re-validates): ``max_search_angle`` /
     ``min_search_angle`` (degrees) bound the shrinking tilt radius, and ``n_steps`` is the number of
-    hexagonal azimuths (6 -> 0, 60, ..., 300 deg, matching the private). ``method`` configures the
+    hexagonal azimuths (6 -> 0, 60, ..., 300 deg). ``method`` configures the
     engine's solver (``score_orientation`` uses a scaling-optimised wR2 internally).
 
-    ``coupling`` (default ``None``) opts the fit into the private's per-trial re-coupling: a
+    ``coupling`` (default ``None``) opts the fit into per-trial re-coupling: a
     :class:`~diffBloch.specs.TrialCoupling` re-derives the solve union and re-selects the scored set
     at every trial orientation (see the module docstring for the non-stationary-objective nuance).
     ``None`` keeps the tilt-independent fit (one fixed beam set across the search).
@@ -114,14 +113,14 @@ def fit_orientation(
     spans the beam-difference support; without that guarantee a skipped check would let a gather
     silently read zeros. Inert unless ``coupling`` is set (the tilt-independent path rebuilds no
     gather in the search), and, like the coverage guard, it does not enter the recipe identity: the
-    checks are pure, so ``False`` yields byte-identical gather indices when coverage holds.
+    checks are pure, so ``False`` yields identical gather indices when coverage holds.
 
     ``device`` (default ``None`` = CPU) places the search's forward solve on the given accelerator:
     the seed params are moved there and ``engine.fgb`` is computed on-device, so every per-trial
     ``score_orientation`` co-locates onto the param-derived ``fgb.device`` at the use site (the CPU
     trial rebuilds are cheap numpy; only their tensors reach the device). This is the fp32 search's
     device wiring (pair it with ``precision="fp32"`` for the large-cell fork). Kept out of the
-    recipe identity like ``workers``/``logger`` -- but unlike those it is not byte-identical: the
+    recipe identity like ``workers``/``logger`` -- but unlike those it is not bit-exact: the
     solve shifts ~1e-11 cross-device, and because the greedy search accepts on a threshold, that
     shift can flip a near-tie into a full-radius orientation difference (a well-conditioned fit
     stays; a knife-edge one legitimately diverges). Safe regardless: reproducibility is anchored at
@@ -148,12 +147,12 @@ def fit_orientation(
     ``search.max_iterations`` caps the total passes *per orientation* and a ``RuntimeError`` is
     raised if it is reached -- silent non-convergence is never returned.
 
-    The cap is a 2.0 addition: ``diffBloch_private``'s search has none (it relies on monotone wR2
-    descent + the radius floor). The search does terminate by construction for a
-    non-degenerate objective -- the cap only guards pathological ridge-walking on (near-)degenerate
-    landscapes. Its default of ``2000`` is **calibrated on the quartz anchor under the integrated
-    recipe** (slowest legitimate search: 1288 passes across 99 rotations, so 2000 has headroom);
-    raise it via config if a dataset with shallower minima trips it.
+    The cap is a runaway guard: the search terminates by construction for a
+    non-degenerate objective (monotone wR2 descent + the radius floor), so the cap only guards
+    pathological ridge-walking on (near-)degenerate landscapes. Its default of ``2000`` is
+    **calibrated on the quartz anchor under the integrated recipe** (slowest legitimate search: 1288
+    passes across 99 rotations, so 2000 has headroom); raise it via config if a dataset with
+    shallower minima trips it.
     """
 
     if workers < 1:
@@ -244,17 +243,16 @@ def _refine_one(
 
     With ``coupling=None`` each trial is ``current.with_orientation(grid, o)`` -- it rebuilds only
     the orientation-dependent bases and reuses the F-gather, so the beam set, rocking-curve tilts,
-    and reduction are held fixed across the search (byte-identical to the pre-coupling behaviour).
-    With a :class:`~diffBloch.specs.TrialCoupling`, the seed *and* every trial are rebuilt through
+    and reduction are held fixed across the search. With a
+    :class:`~diffBloch.specs.TrialCoupling`, the seed *and* every trial are rebuilt through
     :func:`_coupled_trial`, which re-couples the solve union and re-selects the scored set at that
-    orientation -- the deliberately non-stationary faithful objective (see the module docstring).
+    orientation -- the deliberately non-stationary objective (see the module docstring).
     """
     grid = plan.structure_factor_grid
     n_trials = 0
     # One rotation's search revisits the same excitation unions across many nearby trials, so the
-    # orientation-free per-segment F-gathers are memoized by beam set for the search's duration
-    # (the private caches its per-union A-matrices the same way). Scoped per rotation: bounded, and
-    # trivially thread-safe if rotations ever fit in parallel.
+    # orientation-free per-segment F-gathers are memoized by beam set for the search's duration.
+    # Scoped per rotation: bounded, and trivially thread-safe if rotations ever fit in parallel.
     gather_cache: dict[bytes, StructureFactorGather] = {}
     if coupling is None:
         current = op
@@ -308,18 +306,18 @@ def _coupled_trial(
     *,
     validate: bool = True,
 ) -> CoupledOrientationPlan:
-    """Re-couple the solve union and re-select the scored set at ``orientation`` (faithful trial).
+    """Re-couple the solve union and re-select the scored set at ``orientation`` (one coupled trial).
 
-    Ports one ``diffBloch_private`` objective evaluation: (1) ``build_coupling_segments`` re-derives
+    One objective evaluation: (1) ``build_coupling_segments`` re-derives
     the per-tilt-segment excitation union at ``orientation`` (the SOLVE set); (2) the Klar window
     (:func:`klar_beam_mask`) intersected with the scoring-resolution cap
-    (:func:`~diffBloch.core.reciprocal.gmax_mask`, an ideal-cell ``|g|`` metric mirroring the
-    private's ``resolution_filter``) selects the SCORED set from that union, with ``000`` retained
+    (:func:`~diffBloch.core.reciprocal.gmax_mask`, an ideal-cell ``|g|`` metric) selects the SCORED
+    set from that union, with ``000`` retained
     (it anchors ``psi0`` and is dropped later on pattern intersection). The observed ``pattern``,
     ``thickness``, and ``tilt_reduction`` are carried from ``op`` unchanged. The atomic ``F_gb`` is
     untouched either way; ``gather_cache`` (keyed by a segment's beam-set bytes) reuses the
     orientation-free per-segment F-gathers across a search's trials -- identical beam set, identical
-    gather -- collapsing the per-trial rebuild cost the way the private's per-union cache does.
+    gather -- collapsing the per-trial rebuild cost.
 
     ``validate`` (default ``True``) is forwarded to each cache-miss
     :func:`~diffBloch.core.dynamical.build_structure_factor_gather`; ``False`` skips its O(N^2)

--- a/src/diffBloch/preprocess/steps/fit_thickness.py
+++ b/src/diffBloch/preprocess/steps/fit_thickness.py
@@ -14,7 +14,7 @@ only the cheap propagation tail, so scoring 100 thicknesses costs barely more th
 The captured ``refinement`` is read-only context the step never mutates; the simulation inside is
 deterministic and depends only on its inputs, so it is ordinary computation, not a side effect.
 
-Faithful to ``diffBloch_private``'s ``thickness_optim``: an evenly-spaced (``np.linspace``) grid of
+The search is an evenly-spaced (``np.linspace``) grid of
 candidate thicknesses, per-candidate wR2 via the scaling factor, then the per-rotation minimum.
 
 Plan-agnostic: ``replace(op, thickness=...)`` swaps the thickness on either an

--- a/src/diffBloch/preprocess/steps/frames.py
+++ b/src/diffBloch/preprocess/steps/frames.py
@@ -1,9 +1,8 @@
 """``select_frames``: drop whole rotations whose observed pattern is too sparse to inform the fit.
 
 The whole-frame sibling of :mod:`~diffBloch.preprocess.steps.beams`: ``select_beams`` prunes the
-*reflections within* each frame, whereas ``select_frames`` drops *entire frames/orientations*. It is
-the public analog to ``diffBloch_private``'s per-dataset ``ignore_orientations`` -- for the
-beam-damaged tail of a rotation scan, where late frames carry almost no measurable signal.
+*reflections within* each frame, whereas ``select_frames`` drops *entire frames/orientations* -- for
+the beam-damaged tail of a rotation scan, where late frames carry almost no measurable signal.
 
 The drop criterion is **model-independent**: it counts each frame's *observed* strong reflections
 (``intensity > 3 * sigma``) from the stored ``pattern`` and never the calculated fit, so it cannot

--- a/src/diffBloch/preprocess/steps/mosaicity.py
+++ b/src/diffBloch/preprocess/steps/mosaicity.py
@@ -3,20 +3,20 @@
 A ``Plan -> Plan`` step that switches each rotation's tilt-axis reduction from a plain incoherent
 sum (:class:`~diffBloch.core.products.PlainSum`) to a moving-average-broadened sum
 (:class:`~diffBloch.core.products.MosaicSmoothed`). Crystal mosaicity smears each reflection's
-rocking curve; the private models it as a ``window``-wide moving average of the per-tilt intensities
-before the sum-over-tilts integration (``diffBloch_private`` ``DiffractionDataset.moving_average``).
+rocking curve; it is modelled as a ``window``-wide moving average of the per-tilt intensities
+before the sum-over-tilts integration.
 
 It is a **modifier on top of** ``integrate_rocking_curve``
 (:func:`~diffBloch.preprocess.steps.rocking_curve.integrate_rocking_curve`):
 it only has meaning once the tilt set exists (a moving average over a single tilt is degenerate), so
 it is ordered *after* that step and *before* the fits (fitting under the same integrated model used
-at evaluation -- the fit/eval consistency invariant). Off by default: no ``mosaicity`` step = the
-plain-sum reduction = today's behaviour, byte-identical.
+at evaluation -- the fit/eval consistency invariant). Off by default: no ``mosaicity`` step keeps
+the plain-sum reduction.
 
 Pure and geometry-preserving: the reduction is a per-orientation attribute, so this only
 ``dataclasses.replace``\\ s the reduction descriptor -- no beam plans are rebuilt (mirrors
-``fit_thickness`` swapping only the thickness). Faithful to the private, which passes the mosaicity
-setting into both the orientation fit and the final evaluation.
+``fit_thickness`` swapping only the thickness). The mosaicity setting feeds both the orientation fit
+and the final evaluation.
 """
 
 from __future__ import annotations

--- a/src/diffBloch/preprocess/steps/rocking_curve.py
+++ b/src/diffBloch/preprocess/steps/rocking_curve.py
@@ -6,8 +6,8 @@ the tilts (an incoherent rotation-frame integration; see
 :meth:`diffBloch.core.products.BlochSolution.integrate`). The rocking curve is *the* scientific
 enabling structure of the rotation-electron-diffraction forward model, so it is a composable,
 toggleable step rather than baked into ``from_experiment``: composing it in with
-``rocking.sampling == 1`` (a single angle-0 tilt) is the identity, so appending it off leaves the
-``Plan`` byte-identical.
+``rocking.sampling == 1`` (a single angle-0 tilt) is the identity, so leaving it out leaves the
+``Plan`` unchanged.
 
 It is pure geometry -- no engine, no structure factors, no refinement: the tilts depend only on the
 fixed ``RockingCurve`` and each settled nominal orientation, so they are prebuilt into the
@@ -16,9 +16,8 @@ fixed ``RockingCurve`` and each settled nominal orientation, so they are prebuil
 the fits settle the nominal orientation and the one shared beam set, then this bakes the integration
 geometry those results are held fixed at, reusing that beam set across every tilt.
 
-Faithful to ``diffBloch_private``'s ``generate_integration_rotation_matrices`` +
-``get_integrated_intensities`` (which the private wires in unconditionally); 2.0 exposes it as a
-composed unit.
+Building the tilt matrices and integrating their intensities is exposed here as one composable unit,
+rather than being wired in unconditionally.
 """
 
 from __future__ import annotations

--- a/src/diffBloch/specs.py
+++ b/src/diffBloch/specs.py
@@ -11,10 +11,9 @@ They are plain frozen dataclasses (the codebase's one value-object vocabulary, l
 parses YAML at the edge but never rides into a step. A direct/test caller constructs them the same
 way the config does and gets the same construction-time error.
 
-Failures raise ``ValueError`` today (fail-fast; the only callers are config-load and direct
-construction). When the ``app`` layer needs to surface validation errors *as values* (to a TUI /
-batch runner), a thin boundary ``parse(...) -> Result[Spec, ValidationError]`` adapter will wrap
-these raising constructors -- Result stays at that boundary and never enters a step.
+Failures raise ``ValueError`` (fail-fast): the callers are config-load and direct construction. A
+boundary adapter that needs to surface validation errors *as values* rather than as exceptions (for
+a TUI or batch runner) can wrap these raising constructors without changing the step contract.
 """
 
 from __future__ import annotations
@@ -55,8 +54,6 @@ class IntegrationGeometry:
     from the goniometer rock axis for ``continuous_rotation``, distance from the beam for
     ``precession`` -- which fixes the ``sg_max`` lever arm and the tilt axis, so both consumers must
     agree on it too.
-
-    Faithful to ``diffBloch_private`` (``integration_semiangle`` / ``data_collection_geometry``).
     """
 
     semiangle: float = 1.0  # degrees: tilt half-width / integration cone half-angle; scales sg_max
@@ -82,7 +79,7 @@ class BeamSelection:
     ``geometry`` that fixes its lever arm; it is *shared* with the :class:`RockingCurve` integrator
     (one physical angle, so the two cannot disagree).
 
-    Defaults are the faithful ``diffBloch_private`` values (``NumericsConfig``).
+    The default cutoffs are the values used by the default preprocess path.
     """
 
     rsg: float = 0.9  # relative excitation-error cutoff: keep when |Sg| / sg_max < rsg
@@ -99,17 +96,15 @@ class FrameSelection:
     """Validated criterion for the ``select_frames`` per-rotation (whole-frame) drop.
 
     The sibling of :class:`BeamSelection`: where that prunes *reflections within* a frame,
-    ``select_frames`` drops *whole frames* whose observed pattern is too sparse to inform the fit --
-    the public analog to ``diffBloch_private``'s per-dataset ``ignore_orientations``, for the
-    beam-damaged tail of a rotation scan. ``min_observed`` is the fewest *strong* observed
+    ``select_frames`` drops *whole frames* whose observed pattern is too sparse to inform the fit,
+    for the beam-damaged tail of a rotation scan. ``min_observed`` is the fewest *strong* observed
     reflections (``intensity > 3 * sigma``, strict) a frame must carry to be kept; frames below it
     are dropped. The count is **model-independent** -- it reads the observed pattern only, never the
     calculated fit -- so it cannot circularly keep the frames the current model already explains.
 
     ``min_observed == 0`` keeps every frame (the disabled / no-op default -- opting in requires a
-    positive threshold); a negative count is meaningless and rejected. This carries no
-    ``diffBloch_private`` value analog: the private hard-codes an explicit index list, whereas this
-    derives the drop from a data-quality floor.
+    positive threshold); a negative count is meaningless and rejected. The drop is derived from a
+    data-quality floor rather than a hard-coded list of frame indices.
     """
 
     min_observed: int = 0  # keep a frame iff its strong-reflection count (I > 3 sigma) >= this
@@ -125,14 +120,11 @@ class ConvergenceTolerance:
 
     A convergence sweep grows a simulation-accuracy knob and stops the first time *consecutive*
     simulations stop changing: ``r_factor_threshold`` is the largest consecutive-simulation R-factor
-    still counted as "converged" (the private's ``r_factor_threshold = 0.005``). ``max_iterations``
-    is the hard cap on sweep steps before non-convergence is raised (the private's
-    ``MAX_SWEEP_ITERATIONS = 100``); it also gives ``iterate_until``'s previously-bare cap a home.
+    still counted as "converged". ``max_iterations`` is the hard cap on sweep steps before
+    non-convergence is raised; it also gives ``iterate_until``'s otherwise-bare cap a home.
 
-    Defaults are the faithful ``diffBloch_private`` values
-    (``configs/convergence_test/base.yaml`` + ``convergence_testing.MAX_SWEEP_ITERATIONS``). The
-    stopping rule is the private's exactly -- the first below-threshold step stops the sweep, with
-    no patience and no null-step handling.
+    The stopping rule is deliberately simple: the first below-threshold step stops the sweep -- no
+    patience window and no null-step handling.
     """
 
     r_factor_threshold: float = 0.005  # converged once consecutive-sim R-factor < this
@@ -153,7 +145,7 @@ class ConvergenceTest:
     minimum that maximises matched-reflection coverage (pure geometry, tilt untouched);
     ``self_stability`` grows the pool, window and rocking-curve tilt count until consecutive
     simulations stop changing; ``both`` runs coverage first and seeds self-stability from its
-    settled scalars (the private's ``initial_*`` handoff). ``start_g_max_refine`` is the pool
+    settled scalars. ``start_g_max_refine`` is the pool
     sweep's start
     radius -- the window and tilt starts come from :class:`IntegrationGeometry.semiangle` and
     :class:`RockingCurve.sampling`, so they are not duplicated here. ``g_max_refine_step`` / ``integration_semiangle_step``
@@ -162,11 +154,8 @@ class ConvergenceTest:
     stopping rule + runaway cap live on :class:`ConvergenceTolerance`, not here (single
     responsibility: this type is *what to sweep*, that one is *when to stop*).
 
-    ``operation`` and ``num_passes`` are faithful to ``diffBloch_private`` ``convergence_test``
-    (branch ``pattern-vis-convergence-testing``: ``operation in {initial_minimum_param_sweep,
-    hyperparams_optimization, both}`` renamed to the 2.0 phase names; ``num_passes`` the e2e's 2).
-    The step magnitudes are 2.0 defaults -- the private branch's config yaml was not captured, so
-    they are calibrated for the convergence tutorial rather than ported verbatim (tune per dataset).
+    The step magnitudes are defaults calibrated for the convergence tutorial rather than for any one
+    dataset -- tune them per dataset.
     """
 
     operation: Literal["coverage", "self_stability", "both"] = "both"
@@ -199,12 +188,12 @@ class ConvergenceTest:
 
 @dataclass(frozen=True)
 class HexagonalSearch:
-    """Validated bounds for the ``fit_orientation`` Palatinus hexagonal search (degrees).
+    """Validated bounds for the ``fit_orientation`` hexagonal search (degrees, Palatinus et al. 2013).
 
-    Defaults are the faithful ``diffBloch_private`` values (``configs/preprocess/base.yaml``).
-    ``max_iterations`` has no private precedent (the private search has no cap -- it relies on
-    monotone wR2 descent plus the radius floor). Its default of ``2000`` is **calibrated on the
-    quartz anchor under the integrated recipe**: every one of its 99 rotations still terminates by
+    ``max_iterations`` is a runaway guard on an otherwise uncapped search: the search terminates on
+    its own by monotone wR2 descent plus the radius floor, and the cap only catches a genuine
+    non-terminating case. Its default of ``2000`` is **calibrated on the quartz anchor under the
+    integrated recipe**: every one of its 99 rotations still terminates by
     the radius floor, but the bumpier rocking-curve-integrated landscape needs many more passes than
     the static fit -- the slowest legitimate search took 1288 passes (526 without integration), so
     2000 leaves cross-platform headroom while still catching a genuine runaway. A dataset with
@@ -227,9 +216,9 @@ class HexagonalSearch:
     4. Set ``max_iterations = ceil(headroom * max(n_passes))`` with ``headroom`` ~1.5 (quartz:
        ``1288 -> 2000``). Record the calibrating dataset + recipe alongside the value.
 
-    The ``../notebooks/iain`` calibration notebook automates steps 1-4 (runs the search, plots the
-    per-rotation ``n_passes`` distribution against ``pass_cap``, flags any cap-hitters, and prints
-    the recommended cap).
+    Steps 1-4 are mechanical and can be automated: run the search, plot the per-rotation
+    ``n_passes`` distribution against ``pass_cap``, flag any cap-hitters, and read off the
+    recommended cap.
     """
 
     max_search_angle: float = 0.4  # largest tilt radius the search starts from
@@ -261,9 +250,6 @@ class RockingCurve:
     angular range as the Klar beam-selection window, shared with :class:`BeamSelection` so the two
     cannot disagree -- and the ``geometry`` that selects the sweep (``continuous_rotation``,
     goniometer x-axis tilts, implemented; or ``precession``, a deferred cone mode).
-
-    Faithful to ``diffBloch_private`` (``integration_semiangle`` / ``rocking_curve_sampling`` /
-    ``data_collection_geometry``; ``rotation_dataset.generate_integration_rotation_matrices``).
     """
 
     sampling: int = 42  # number of tilts across +/- semiangle; 1 = single static solve (identity)
@@ -278,7 +264,7 @@ class RockingCurve:
 class Mosaicity:
     """Mosaicity broadening of the rocking curve: a moving-average window over the tilt axis.
 
-    Crystal mosaic spread smears each reflection's rocking curve; the private models it as a
+    Crystal mosaic spread smears each reflection's rocking curve; diffBloch models it as a
     ``window``-wide moving average of the per-tilt intensities before the sum-over-tilts
     integration. ``window`` is the number of consecutive tilts averaged; it must be ``>= 1`` and, at
     reduction time, ``<= sampling`` (the tilt count). ``window = 1`` is the identity (no
@@ -286,14 +272,10 @@ class Mosaicity:
     of the rocking-curve integration (:class:`RockingCurve`) -- it only has meaning once the tilt
     set exists, so the ``mosaicity`` step is ordered after ``integrate_rocking_curve``.
 
-    **Divergence from ``diffBloch_private``:** the private hardcodes the moving-average
-    ``window_size = 5`` and uses its ``mosaicity_num_frames`` config only as an on/off flag (the
-    frame count never reaches the window). 2.0 keeps the faithful **default of 5** but exposes
-    ``window`` as a real, tunable config parameter -- a principled fix of the private quirk (the
-    config field name implied a tunable window the code ignored).
+    ``window`` is a tunable config parameter; its default of 5 is the standard moving-average width.
     """
 
-    window: int = 5  # tilts averaged per sliding window; faithful private default (hardcoded there)
+    window: int = 5  # tilts averaged per sliding window (standard moving-average width)
 
     def __post_init__(self) -> None:
         if self.window < 1:
@@ -304,9 +286,7 @@ class Mosaicity:
 class SegmentedUnionCoupling:
     """Tilt-segment-union beam coupling: per-tilt-chunk beam sets, not one set for the whole curve.
 
-    v1 analog: the ``union_splits`` / ``union_adaptive`` policy.
-
-    The ``diffBloch_private`` coupling policy for rocking-curve integration. It partitions the
+    The coupling policy for rocking-curve integration: it partitions the
     ``B`` tilts into ``fixed_n_segments`` contiguous, disjoint chunks and gives each chunk its own
     coupled beam set: the **union** of the excited-beam masks at the chunk's two boundary tilts.
     A beam is excited at a tilt when ``|Sg| < sg_max`` *and* ``|g| < g_max`` (a hard
@@ -314,12 +294,12 @@ class SegmentedUnionCoupling:
     :class:`BeamSelection`).
     Because a sharp reflection drifts through the Ewald sphere as the crystal rocks, the excited set
     genuinely differs across the curve; one tilt-independent set either over-couples (slow) or drops
-    beams a later tilt needs. The per-chunk union is the private's compromise. Each reflection's
-    full rocking curve is later reassembled across chunks before the mosaicity reduction (the window
-    spans more tilts than one chunk holds).
+    beams a later tilt needs. The per-chunk union is the compromise this policy strikes. Each
+    reflection's full rocking curve is later reassembled across chunks before the mosaicity
+    reduction (the window spans more tilts than one chunk holds).
 
-    ``g_max`` is the coupling radius: a beam couples when ``|g| < g_max`` (the private's post-#154
-    mask, which dropped the earlier ``- 0.2`` margin so the cutoff is the physical solve radius).
+    ``g_max`` is the coupling radius: a beam couples when ``|g| < g_max``. The cutoff is the
+    physical solve radius, with no additional margin.
     ``sg_max`` is the excitation-error cutoff. The mean-inner-potential ``u0`` and beam energy are
     experiment quantities threaded in at build time, not policy knobs.
 
@@ -330,9 +310,7 @@ class SegmentedUnionCoupling:
     where the excited set drifts and sparse where it is stable. In the adaptive mode
     ``fixed_n_segments`` is ignored.
 
-    Defaults are the faithful ``diffBloch_private`` values (``config.union_splits = 12``,
-    ``self.g_max = 2.25``, ``self.sg_max = 0.01``, ``union_adaptive = False``,
-    ``union_max_new_beams_pct = 0.01``).
+    The defaults suit the standard rocking-curve recipe (12 fixed even-sized chunks, fixed mode).
     """
 
     fixed_n_segments: int = (
@@ -380,21 +358,18 @@ def assert_grid_covers_coupling(policy: SegmentedUnionCoupling, grid_g_max: floa
 class TiltIndependent:
     """The default coupling: one beam set shared across every rocking-curve tilt.
 
-    The 2.0 baseline (and the ``diffBloch_private`` ``union_splits <= 1`` degenerate case): the
-    active beam set ``select_beams`` picks for the nominal orientation is reused, unchanged, at
-    every
-    tilt of the rocking curve. Fieldless because it carries no policy of its own -- the shared set
-    is
-    already fixed on the plan; it is the identity member of the coupling discriminated union, chosen
-    by construction when a run does *not* want the tilt-dependent per-chunk re-selection.
+    The baseline: the active beam set ``select_beams`` picks for the nominal orientation is reused,
+    unchanged, at every tilt of the rocking curve. Fieldless because it carries no policy of its own
+    -- the shared set is already fixed on the plan; it is the identity member of the coupling
+    discriminated union, chosen by construction when a run does *not* want the tilt-dependent
+    per-chunk re-selection.
     """
 
 
 # How a rocking curve couples beams across its tilts: one shared set (:class:`TiltIndependent`) or
-# the private's per-tilt-chunk boundary unions (:class:`SegmentedUnionCoupling`). A discriminated
-# union the
-# ``couple_beams`` step matches on, not a boolean toggle -- the faithful policy carries its own
-# parameters, the default carries none.
+# per-tilt-chunk boundary unions (:class:`SegmentedUnionCoupling`). A discriminated union the
+# ``couple_beams`` step matches on, not a boolean toggle -- the tilt-dependent policy carries its
+# own parameters, the default carries none.
 CouplingPolicy = TiltIndependent | SegmentedUnionCoupling
 
 
@@ -404,21 +379,18 @@ class ScoredHklSelection:
 
     When a fit re-derives its reflection sets per trial under a coupling policy, the *scored* set is
     not the solve union -- it is the union filtered back down to the reflections actually compared
-    against the observed pattern. That is two filters, mirroring ``diffBloch_private``'s
-    ``filter_hkls`` (the Klar relative-excitation window) followed by ``resolution_filter`` (a
-    radial ``|g|`` cap): ``klar`` supplies the former (:class:`BeamSelection` -- ``rsg`` / ``dsg`` +
-    the shared :class:`IntegrationGeometry`), and ``g_max`` the latter. The private's
-    ``g_min_refine`` is ``0.0`` for every dataset (verified), so no lower-shell bound is modelled;
-    add one when a dataset needs it.
+    against the observed pattern. That is two filters: the Klar relative-excitation window followed
+    by a radial ``|g|`` cap. ``klar`` supplies the former (:class:`BeamSelection` -- ``rsg`` /
+    ``dsg`` + the shared :class:`IntegrationGeometry`), and ``g_max`` the latter. No lower-shell
+    bound is modelled; add one when a dataset needs it.
 
-    ``g_max`` is the *scoring*-resolution cap (the private's ``g_max_refine`` in its scored-set
-    role), given its own named home here so it is distinct from the seed beam-pool radius -- the two
-    are numerically equal today (both ``1.6`` on quartz) but are separate quantities. It must be
-    positive.
+    ``g_max`` is the *scoring*-resolution cap, given its own named home here so it is distinct from
+    the seed beam-pool radius -- the two may be numerically equal but are separate quantities. It
+    must be positive.
     """
 
     klar: BeamSelection = field(default_factory=BeamSelection)
-    g_max: float = 1.6  # scoring-resolution cap on |g| (the private's g_max_refine scored role)
+    g_max: float = 1.6  # scoring-resolution cap on |g|
 
     def __post_init__(self) -> None:
         if self.g_max <= 0.0:
@@ -429,7 +401,7 @@ class ScoredHklSelection:
 class TrialCoupling:
     """Per-trial re-derivation of both reflection sets during an orientation fit.
 
-    The faithful ``diffBloch_private`` orientation objective re-runs the whole forward at every
+    The orientation objective under this coupling re-runs the whole forward at every
     trial orientation: it re-couples the SOLVE union (the excitation coupling of ``policy``) *and*
     re-selects the SCORED set (``scored``) from that fresh union, so both sets track the trial
     orientation rather than staying pinned to the seed. Passed to
@@ -450,8 +422,8 @@ class ThicknessGrid:
     """Validated grid of candidate thicknesses for ``fit_thickness`` (Angstroms).
 
     ``fit_thickness`` evaluates ``n_steps`` candidates spaced evenly from ``min_thickness`` to
-    ``max_thickness`` (inclusive) and keeps the lowest-wR2 one. Defaults are the faithful
-    ``diffBloch_private`` values (``configs/preprocess/base.yaml``: 5 A to 2000 A in 100 steps).
+    ``max_thickness`` (inclusive) and keeps the lowest-wR2 one. The defaults span 5 A to 2000 A in
+    100 steps.
     """
 
     min_thickness: float = 5.0  # smallest candidate thickness


### PR DESCRIPTION
## Editorial docstring pass over `/src` (now targeting `main`)

The vocab rename (#9) is on `main`; this lands the **docstring editorial pass** that was reviewed in #11. (#11 was stacked on `vocab-refactor`, so merging it never reached `main` — this PR replays the same 9 prose commits onto current `main`.)

**Prose only** — no behaviour, signatures, names, or tests change. Verified on this branch: tree byte-identical to the reviewed #11 result, `mypy` clean, 578 passed / 3 skipped, sweep clean.

Each docstring in `/src` now stands on its own — what the thing does and what it's for — aligned to the doc-site framing:
- Removed private-repo references, "faithful"/"ported" wording, private symbol names, PR/commit provenance, `design/decisions/*` / `REFERENCES.md` / "synthesis §" pointers.
- Removed build-chronology markers (stage/slice/phase numbering, "2.0", "byte-identical", "today") and the banned boundary word; grounded or dropped undefined analogies (monad asides, "JAX-style", Ecto/NimbleOptions).
- Citations inline to papers only: Lobato–Van Dyck (2014), Spence & Zuo (1992), Klar et al. (2023), Palatinus et al. (2013), Trueblood et al. (1996), Busing & Levy (1967).
- Coherence fixes verified against code: `HydrogenRiding` present-tense (not "will be"); `couple_beams` corrected (the default recipe couples per-trial in `fit_orientation`, not via `couple_beams`). Doc-site pages swept for the same terms.

One commit per layer: core, engine, preprocess, preprocess/steps, io, config, app, plus the adp straggler and the doc-site pages.
