### PR TITLE
feat(api): flatten the public surface to layer-level imports

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,9 +4,9 @@ DiffBloch is organized around one stable scientific centre: a deterministic Bloc
 The surrounding layers prepare inputs, build reusable geometry, run optimization, and report
 progress without making those concerns part of the numerical core.
 
-## Core pattern
+## End-to-end flow
 
-The core flow is:
+The end-to-end flow is:
 
 1. `.cif` + `.cif_pets` + config are parsed into typed records.
 2. Preprocessing turns those records into a reusable `Plan`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ rather than a full script because real runs need an experiment directory, locks,
 configuration.
 
 ```python
-from diffBloch.app.program import refine_experiment, run_experiment
+from diffBloch.app import refine_experiment, run_experiment
 
 # Simulate/score a checkpointed experiment.
 inference = run_experiment("examples/experiments/quartz-checkpoint")

--- a/docs/beams-and-scoring.md
+++ b/docs/beams-and-scoring.md
@@ -22,8 +22,7 @@ from pathlib import Path
 
 from diffBloch.config import load_config
 from diffBloch.io import read_structure
-from diffBloch.preprocess import read_plan, score_orientations
-from diffBloch.preprocess.experiment import RefinementSetup
+from diffBloch.preprocess import RefinementSetup, read_plan, score_orientations
 
 root = Path("examples/experiments/quartz-checkpoint")
 cfg = load_config(root / "experiment.yaml")

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -57,7 +57,7 @@ highest-precision refinement path.
 ## Python API example
 
 ```python
-from diffBloch.app.program import run_experiment
+from diffBloch.app import run_experiment
 
 result = run_experiment("examples/experiments/quartz-checkpoint")
 print(result.n_evaluated, result.mean_r_obs)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ map inspectable, reproducible, and safe to evolve, and lives *around* the core, 
 
 ## Overview
 
-### Core simulation and refinement
+### Simulation and refinement
 
 The [core](api/core.md) starts with a deterministic Bloch-wave simulation, then the
 [refinement engine](api/engine.md) exposes selected simulation inputs as differentiable
@@ -26,9 +26,9 @@ compares their calculated and observed intensities. The differentiable parameter
 quantities — primarily asymmetric-unit (ASU) atom coordinates, with ADPs, occupancies, and structure
 factors available as refinable groups.
 
-### Core flow
+### End-to-end flow
 
-The core flow is:
+The end-to-end flow is:
 
 1. `.cif` + `.cif_pets` + config are parsed into typed records.
 2. Preprocessing turns those records into a reusable `Plan`.

--- a/docs/model-composition.md
+++ b/docs/model-composition.md
@@ -21,11 +21,14 @@ structure and the scientific question, so treat the middle block as an example p
 from pathlib import Path
 
 from diffBloch.config import load_config
-from diffBloch.engine import build_refinement_model, build_refinement_problem, run_refinement_model
-from diffBloch.engine.constraints import with_hydrogen_riding
+from diffBloch.engine import (
+    build_refinement_model,
+    build_refinement_problem,
+    run_refinement_model,
+    with_hydrogen_riding,
+)
 from diffBloch.io import read_structure
-from diffBloch.preprocess import build_engine, read_plan
-from diffBloch.preprocess.experiment import RefinementSetup
+from diffBloch.preprocess import RefinementSetup, build_engine, read_plan
 
 root = Path("examples/experiments/abiraterone-checkpoint")
 cfg = load_config(root / "experiment.yaml")

--- a/docs/observability-guide.md
+++ b/docs/observability-guide.md
@@ -28,8 +28,7 @@ or Comet unless you use those backends.
 ```python
 from pathlib import Path
 
-from diffBloch.app.loggers import CSVLogger, ConsoleLogger
-from diffBloch.app.program import run_experiment
+from diffBloch.app import CSVLogger, ConsoleLogger, run_experiment
 from diffBloch.observability import MultiLogger
 
 logger = MultiLogger((

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -1,8 +1,8 @@
 # Preprocessing and `Plan`
 
-Preprocessing builds the immutable `Plan` consumed by inference and refinement. A `Plan` is not the
-structure being refined; it is the settled geometry and data scaffold around the differentiable
-structural parameters.
+The first step after loading an experiment is to create a refinable `Plan`. A `Plan` is the
+geometry and data scaffold around the differentiable structural parameters; it is not the structure
+being refined.
 
 A `Plan` carries things such as:
 
@@ -14,82 +14,33 @@ A `Plan` carries things such as:
 - fitted nuisance values such as per-rotation thickness;
 - coupled beam-union geometry when coupling is enabled.
 
-## `Plan -> Plan` steps
-
-Preprocessing is a composable `Plan -> Plan` pipeline. Any function with that shape can be a step:
-it receives a `Plan`, does one focused piece of work, and returns an updated `Plan`.
-
-Real steps include:
-
-- `select_beams`
-- `build_orientation_plans`
-- `integrate_rocking_curve`
-- `mosaicity`
-- `fit_orientation`
-- `fit_thickness`
-- `couple_beams`
-- `converge_numerics`
-
-The pipeline also provides composition helpers such as `iterate_until` and `Fork` for repeated,
-conditional, or branching preprocess logic. More advanced steps use the same contract: convergence
-sweeps repeatedly improve numerical plan values, while `fit_orientation` and `fit_thickness` score
-candidate plans and return the best updated `Plan`.
-
-## API example: loading a checkpointed `Plan`
+Conceptually, a settled `Plan` looks like this:
 
 ```python
-from diffBloch.preprocess import read_plan, require_built_plans
-
-plan = read_plan("examples/experiments/quartz-checkpoint/plan.npz")
-orientations = require_built_plans(plan)
-
-print(len(orientations))
-print(plan.grid.grid_hkl.shape)
-```
-
-## API example: composing simple steps
-
-This example shows the composition shape. It is intentionally small; the full default recipe also
-captures refinement setup, coupling policy, device/precision choices, and logging.
-
-```python
-from diffBloch.preprocess import build_orientation_plans, pipeline, select_beams
-from diffBloch.specs import BeamSelection
-
-prepare = pipeline([
-    select_beams(BeamSelection()),
-    build_orientation_plans(),
-])
-
-# prepared_plan = prepare(candidate_plan)
-```
-
-## API shape: `Fork` and `iterate_until`
-
-`Fork` chooses one of two step lists from the immutable grid, so the chosen recipe can still be
-resolved before checkpointing. `iterate_until` wraps a repeated `Plan -> Plan` improvement behind the
-same step shape.
-
-```python
-from diffBloch.preprocess import fork, identity, iterate_until
-
-large_cell_branch = fork(
-    lambda grid: grid.cell_volume > 1000.0,
-    when_true=[identity()],   # e.g. coarse/faster steps for large cells
-    when_false=[identity()],  # e.g. exact/default steps for small cells
-)
-
-repeat_until_stable = iterate_until(
-    identity(),
-    until=lambda previous, current: previous is current,
-    max_iterations=1,
+Plan(
+    structure_factor_grid=StructureFactorGrid(
+        structure_factor_hkl=...,  # shared Fgb support
+        cell=...,
+        reciprocal_basis=...,
+        g_max=...,
+    ),
+    orientations=(
+        OrientationPlan(
+            orientation=...,      # one rotation/orientation
+            beam_hkl=...,         # solve beam set
+            beam_plans=...,       # precomputed Bloch geometry for those beams
+            tilts=...,            # rocking-curve sub-orientations
+            pattern=...,          # observed intensities for this rotation
+            alignment=...,        # calculated/observed hkl alignment
+            thickness=...,        # fitted nuisance value
+        ),
+        # ...more rotations...
+    ),
+    provenance=(...),             # ordered preprocessing recipe
 )
 ```
 
-For real convergence, prefer the provided convergence steps and driver rather than the trivial
-`identity` placeholders above.
-
-## API shape: from records to an initial `Plan`
+## API shape: from experiment records to an initial `Plan`
 
 ```python
 from pathlib import Path
@@ -110,3 +61,96 @@ refinement_setup = setup.refinement
 print(len(initial_plan.orientations))
 print(refinement_setup.params.asu_positions.shape)
 ```
+
+## `Plan -> Plan` steps
+
+Preprocessing is a composable `Plan -> Plan` pipeline. A `select_beams` step, for example, is a
+function that takes a `Plan` and adjusts its geometry/data scaffold by replacing each rotation's
+candidate beam set with the reflections selected by the beam-selection policy. More generally, any
+function with that shape can be a step: it receives a `Plan`, does one focused piece of work, and
+returns an updated `Plan`.
+
+Real steps include:
+
+- {func}`diffBloch.preprocess.steps.beams.select_beams` — choose each rotation's candidate solve beams.
+- {func}`diffBloch.preprocess.steps.beams.build_orientation_plans` — build solvable per-orientation beam geometry.
+- {func}`diffBloch.preprocess.steps.rocking_curve.integrate_rocking_curve` — expand orientations into virtual rocking-curve tilts.
+- {func}`diffBloch.preprocess.steps.mosaicity.mosaicity` — apply tilt-axis mosaic broadening.
+- {func}`diffBloch.preprocess.steps.fit_orientation.fit_orientation` — search nearby orientations and keep the best-scoring one.
+- {func}`diffBloch.preprocess.steps.fit_thickness.fit_thickness` — search specimen thickness and keep the best-scoring value.
+- {func}`diffBloch.preprocess.steps.coupling.couple_beams` — settle coupled per-segment beam unions.
+- {func}`diffBloch.preprocess.driver.converge_numerics` — run coverage/convergence sweeps over numerical knobs.
+
+The pipeline also provides composition helpers such as `iterate_until` and `Fork` for repeated,
+conditional, or branching preprocess logic. More advanced steps use the same contract: convergence
+sweeps repeatedly improve numerical plan values, while `fit_orientation` and `fit_thickness` score
+candidate plans and return the best updated `Plan`.
+
+## API example: composing simple steps
+
+This example shows the composition shape. It is intentionally small; the full default recipe also
+captures refinement setup, coupling policy, device/precision choices, and logging.
+
+```python
+from diffBloch.preprocess import build_orientation_plans, pipeline, select_beams
+from diffBloch.specs import BeamSelection
+
+prepare = pipeline([
+    select_beams(BeamSelection()),
+    build_orientation_plans(),
+])
+
+# prepared_plan = prepare(candidate_plan)
+```
+
+## API example: loading a checkpointed `Plan`
+
+The end-to-end preprocessing pipeline can take a long time, and it is deliberately decoupled from
+refinement. You can checkpoint a settled `Plan` — for example, a plan whose orientations and
+thicknesses have already been fitted — then run inference or refinement over that reusable scaffold
+without recomputing the preprocessing recipe.
+
+```python
+from diffBloch.preprocess import read_plan, require_built_plans
+
+plan = read_plan("examples/experiments/quartz-checkpoint/plan.npz")
+orientations = require_built_plans(plan)
+
+print(len(orientations))
+print(plan.structure_factor_grid.structure_factor_hkl.shape)
+```
+
+## API shape: `Fork` and `iterate_until`
+
+Advanced branching and looping pipelines can be composed with the `Fork` and `iterate_until`
+utilities. `Fork` chooses one of two step lists from the immutable structure-factor grid, so the
+chosen recipe can still be resolved before checkpointing; the default app recipe uses this shape to
+route large cells through a coarser fp32 orientation/thickness-fit branch. `iterate_until` wraps a
+repeated `Plan -> Plan` improvement behind the same step shape.
+
+The convergence path is the stateful version of this idea. Its public pipeline surface is still a
+single `Plan -> Plan` step, but internally `converge_numerics` runs a small coordinate-search driver:
+it threads a `ConvergenceState` containing `g_max_refine`, `integration_semiangle`, and
+`rocking_curve_sampling` through coverage and self-stability sweeps, rebuilding candidate `Plan`
+values from each scalar setting. There is not currently a general-purpose stateful pipeline utility
+for this shape; `converge_scalar`, `run_coverage_phase`, and `run_stability_phase` are the dedicated
+helpers that formalize it for convergence.
+
+```python
+from diffBloch.preprocess import fork, identity, iterate_until
+
+large_cell_branch = fork(
+    lambda grid: grid.cell_volume > 1000.0,
+    when_true=[identity()],   # e.g. coarse/faster steps for large cells
+    when_false=[identity()],  # e.g. exact/default steps for small cells
+)
+
+repeat_until_stable = iterate_until(
+    identity(),
+    until=lambda previous, current: previous is current,
+    max_iterations=1,
+)
+```
+
+For real convergence, prefer the provided convergence steps and driver rather than the trivial
+`identity` placeholders above.

--- a/docs/refinement.md
+++ b/docs/refinement.md
@@ -50,7 +50,7 @@ diffbloch run refine examples/experiments/abiraterone-checkpoint --device cuda
 ## API example: default app refinement
 
 ```python
-from diffBloch.app.program import refine_experiment
+from diffBloch.app import refine_experiment
 
 result = refine_experiment("examples/experiments/quartz-checkpoint")
 
@@ -68,8 +68,7 @@ from pathlib import Path
 
 from diffBloch.config import load_config
 from diffBloch.engine import build_refinement_model, build_refinement_problem, run_refinement_model
-from diffBloch.preprocess import build_engine, read_plan
-from diffBloch.preprocess.experiment import RefinementSetup
+from diffBloch.preprocess import RefinementSetup, build_engine, read_plan
 from diffBloch.io import read_structure
 
 root = Path("examples/experiments/quartz-checkpoint")

--- a/examples/papers/malik-2026-hybrid-physics-ml/malik_2026_reimplementation.py
+++ b/examples/papers/malik-2026-hybrid-physics-ml/malik_2026_reimplementation.py
@@ -24,12 +24,13 @@ from diffBloch.engine import (
     TrainableSpec,
     build_refinement_model,
     build_refinement_problem,
+    mean_plan_thickness,
     run_refinement_model,
     weighted_mse_loss,
 )
-from diffBloch.engine.plan import mean_plan_thickness
 from diffBloch.io import read_observations, read_structure
 from diffBloch.preprocess import (
+    build_engine,
     build_orientation_plans,
     fit_orientation,
     from_experiment,
@@ -39,7 +40,6 @@ from diffBloch.preprocess import (
     select_beams,
     select_finite_loss_frames,
 )
-from diffBloch.preprocess.scoring import build_engine
 from diffBloch.specs import ScoredHklSelection, TrialCoupling
 
 EXPERIMENT_DIR = Path("examples/papers/malik-2026-hybrid-physics-ml/experiments/quartz-synthetic")

--- a/src/diffBloch/app/__init__.py
+++ b/src/diffBloch/app/__init__.py
@@ -1,1 +1,38 @@
-"""Application entry points (the CLI and the default experiment runner)."""
+"""Application entry points: the default experiment runners and the logger backends.
+
+This is the public surface of the ``app`` layer -- the runnable entry points a caller reaches for
+(``run_experiment`` / ``refine_experiment`` / ``preprocess_experiment``) and the concrete logger
+backends (``ConsoleLogger`` / ``CSVLogger`` / ``EarlyAbortLogger``, and the optional
+``WandbLogger`` / ``CometLogger``). The CLI (:mod:`diffBloch.app.cli`) is the console-script wrapper
+around these.
+
+The optional backends are safe to re-export here: each imports its SDK lazily (only when logging),
+so ``import diffBloch.app`` never requires the ``wandb`` / ``comet`` extras -- only *using* the
+logger does.
+"""
+
+from diffBloch.app.loggers import (
+    ConsoleLogger,
+    CSVLogger,
+    EarlyAbortLogger,
+    FitAbortedError,
+)
+from diffBloch.app.loggers.comet import CometLogger
+from diffBloch.app.loggers.wandb import WandbLogger
+from diffBloch.app.program import (
+    preprocess_experiment,
+    refine_experiment,
+    run_experiment,
+)
+
+__all__ = [
+    "CSVLogger",
+    "CometLogger",
+    "ConsoleLogger",
+    "EarlyAbortLogger",
+    "FitAbortedError",
+    "WandbLogger",
+    "preprocess_experiment",
+    "refine_experiment",
+    "run_experiment",
+]

--- a/src/diffBloch/params.py
+++ b/src/diffBloch/params.py
@@ -31,6 +31,15 @@ from diffBloch.core.constraints import (
     unit_interval,
 )
 
+__all__ = [
+    "AdpKind",
+    "ConstraintSpec",
+    "Device",
+    "PhysicalState",
+    "RefinableParams",
+    "constrain",
+]
+
 type AdpKind = Literal["Uiso", "Uani", "missing"]
 type Device = torch.device | str
 


### PR DESCRIPTION
## Flatten the public API to layer-level imports

Makes each layer's package `__init__` the canonical public surface, so advanced usage reads **one grouped line per layer** instead of reaching into submodules. Pure export/import ergonomics — no behaviour change.

A clean advanced example now reads:

```python
from diffBloch.io import read_structure, read_observations
from diffBloch.preprocess import from_experiment, RefinementSetup, build_engine, pipeline, select_beams
from diffBloch.engine import build_refinement_model, build_refinement_problem, run_refinement_model, with_hydrogen_riding
from diffBloch.specs import BeamSelection, SegmentedUnionCoupling, TrialCoupling
from diffBloch.app import run_experiment, refine_experiment, ConsoleLogger
```

### What changed
- **`diffBloch.app`** — was an empty surface (entry points only in `app.program`, loggers only in `app.loggers`). Now re-exports `run_experiment` / `refine_experiment` / `preprocess_experiment` and the logger backends `ConsoleLogger` / `CSVLogger` / `EarlyAbortLogger` / `FitAbortedError`, plus the optional **`WandbLogger` / `CometLogger`**.
  - Exporting the optional backends is safe: each imports its SDK lazily inside `.report()`, so `import diffBloch.app` never requires the `wandb`/`comet` extras — only *using* the logger does (verified: `import diffBloch.app` loads neither SDK).
- **`diffBloch.params`** — added `__all__` (`RefinableParams`, `ConstraintSpec`, `PhysicalState`, `constrain`, `AdpKind`, `Device`); it previously had no declared public surface.
- **Examples & docs** — rewrote the advanced example (malik reimplementation) and the docs code blocks to import from the layer, not submodules (`engine.plan`/`engine.constraints` → `engine`, `preprocess.scoring`/`preprocess.experiment` → `preprocess`, `app.program`/`app.loggers` → `app`). Every other name already resolved at its layer.

Acceptance: `grep -rE 'from diffBloch\.[a-z_]+\.[a-z_]+ import' examples/ docs/` returns nothing (ignoring generated `docs/_build`).

### Verification
`pytest tests/unit -q` → 578 passed / 3 skipped · `mypy src` clean · `sphinx-build -W` build succeeded · the full target import block resolves and `import diffBloch.app` pulls no optional SDK.

*(Per the discussion, this deliberately does **not** add a curated top-level `diffBloch` namespace — imports stay at the layer level.)*
