### PR TITLE
Refresh README overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # diffBloch
 
-Differentiable Bloch-wave electron-diffraction structure refinement: a small differentiable map from
-structural parameters to a scalar R-loss, minimised by gradient descent so that simulated and observed
-diffraction intensities agree.
+Differentiable Bloch-wave structure refinement for rotating-stage 3D electron diffraction.
+
+diffBloch refines crystal structures against continuous-rotation 3DED observations: diffraction
+frames collected as the crystal is tilted/rocked through reciprocal space and reduced upstream by
+PETS2 into `.cif_pets`. Because the diffraction is dynamical — a multiple-scattering problem —
+diffBloch uses a Bloch-wave simulation rather than a kinematical approximation.
+
+The central model is a raw crystal structure plus a settled `Plan`: the structure supplies the
+differentiable crystallographic parameters, while the `Plan` supplies the reusable geometry/data
+scaffold around them. The refinement engine iteratively minimizes a scalar R-loss so simulated and
+observed diffraction intensities agree.
 
 📖 **Documentation:** <https://differentiable-electron-crystallography.github.io/diffBloch/> — API reference (Sphinx + furo), rendered from the source on every green `main`.
 
@@ -32,27 +40,38 @@ uv run diffbloch run refine examples/experiments/quartz
 uv run diffbloch run refine examples/experiments/quartz-checkpoint
 ```
 
+Use `infer` to score a settled `Plan` without changing parameters; use `refine` to optimize
+trainable structural parameters. Checkpointed examples include `plan.npz` + `plan.lock`, so they can
+reuse expensive preprocessing instead of rebuilding the `Plan` from scratch.
+
 See `examples/experiments/quartz/README.md` for the worked example and its expected residual.
+
+## Examples
+
+- `examples/experiments` contains runnable example experiments for small and large compounds,
+  including checkpointed runs that start from a committed `Plan`.
+- `examples/papers` contains paper implementations that demonstrate doing science with diffBloch via
+  richer Python API composition.
 
 ## Layout
 
 ```
-src/diffBloch/    the library (config/, io/, core/, engine, app/ — added stage by stage)
-examples/         runnable experiment directories (`examples/experiments/quartz{,-checkpoint}`)
+src/diffBloch/    the library (config/, io/, core/, engine, preprocess/, app/)
+examples/         runnable experiments and paper-style composition examples
 tests/unit/       fast per-kernel tests
-tests/e2e/        characterization anchors (opt-in: `just test-e2e`)
-docs/             Docs (Sphinx + furo, MyST); `just docs`
+tests/e2e/        characterization anchors
+docs/             docs site (Sphinx + furo, MyST)
 ```
 
 ## Layers
 
-| Layer | Role |
-|---|---|
-| IO | Parse CIF/PETS files into validated typed records. |
-| Config | Validate experiment settings and lock input/checkpoint identity. |
-| Preprocess | Build and improve the immutable `Plan` the simulator consumes. |
-| Core | Deterministic crystallographic and Bloch-wave numerical kernels. |
-| Params | Differentiable structural parameters and physical constraints. |
-| Engine | Combine `Plan` + parameters, simulate, score, and refine. |
-| Observability | Emit typed events without coupling the core to logger backends. |
-| App | CLI and default orchestration around the reusable API. |
+| Layer | Role | Guide |
+|---|---|---|
+| IO | Parse CIF/PETS files into validated typed records. | [Inputs](https://differentiable-electron-crystallography.github.io/diffBloch/inputs.html) |
+| Config | Validate experiment settings and lock input/checkpoint identity. | [Inputs](https://differentiable-electron-crystallography.github.io/diffBloch/inputs.html), [Reproducibility](https://differentiable-electron-crystallography.github.io/diffBloch/reproducibility.html) |
+| Preprocess | Build and improve the immutable `Plan` the simulator consumes. | [Preprocessing](https://differentiable-electron-crystallography.github.io/diffBloch/preprocessing.html) |
+| Core | Deterministic crystallographic and Bloch-wave numerical kernels. | [Architecture](https://differentiable-electron-crystallography.github.io/diffBloch/architecture.html) |
+| Params | Differentiable structural parameters and physical constraints. | [Refinement](https://differentiable-electron-crystallography.github.io/diffBloch/refinement.html) |
+| Engine | Combine `Plan` + parameters, simulate, score, and refine. | [Refinement](https://differentiable-electron-crystallography.github.io/diffBloch/refinement.html) |
+| Observability | Track progress and debug refinements with typed events/loggers. | [Observability](https://differentiable-electron-crystallography.github.io/diffBloch/observability-guide.html) |
+| App | CLI and default orchestration around the reusable API. | [Examples](https://differentiable-electron-crystallography.github.io/diffBloch/examples.html) |


### PR DESCRIPTION
## Summary

Refresh the README so it matches the current docs framing and architecture.

## Changes

- Describe diffBloch as Bloch-wave refinement for rotating-stage / continuous-rotation 3DED.
- Clarify dynamical diffraction as a multiple-scattering problem and contrast with kinematical approximation.
- Add the raw structure + settled `Plan` framing.
- Clarify `infer` vs `refine` and explain checkpointed examples (`plan.npz` + `plan.lock`).
- Add a short Examples section distinguishing runnable experiments from paper implementations.
- Clean up the repository layout section.
- Expand the Layers table with guide links and observability/debugging wording.

## Testing

```bash
uv run sphinx-build -W -b html docs site
```

Passed. Removed generated `site/` afterward.

## Compatibility

Documentation-only change.
