### PR TITLE
ci: anchor R_obs trend plot, shields badges, action bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
       COVERAGE_JSON: coverage.json
       PATCH_MIN_THRESHOLD: 80
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           lfs: true
           # Full history so the patch-coverage gate can diff against origin/<base>.
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -47,7 +47,7 @@ jobs:
       # Hand-off to publish-badge: the JSON report carries the total percentage.
       - name: Upload coverage JSON for badge
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-json-${{ github.run_id }}
           path: ${{ env.COVERAGE_JSON }}
@@ -74,12 +74,12 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -90,13 +90,13 @@ jobs:
         run: uv run sphinx-build -W -b html docs docs/_build/html
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_build/html
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   # The README coverage badge: an SVG committed to the orphan `badges` branch on every green main
   # push, so badge churn stays out of main's history. The branch is created once by hand; the badge
@@ -108,11 +108,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: badges
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: coverage-json-${{ github.run_id }}
 
@@ -144,12 +144,12 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,14 +44,15 @@ jobs:
         if: github.event_name == 'pull_request'
         run: uv run --with diff-cover diff-cover ${COVERAGE_XML} --compare-branch=origin/${{ github.base_ref }} --fail-under=${PATCH_MIN_THRESHOLD}
 
-      # Hand-off to publish-badge: the JSON report carries the total percentage.
+      # Hand-off to publish: the JSON report carries the total percentage. No run_id suffix --
+      # v4+ artifacts are already run-scoped, and a suffix only makes job re-runs collide.
       - name: Upload coverage JSON for badge
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-json-${{ github.run_id }}
+          name: coverage-json
           path: ${{ env.COVERAGE_JSON }}
-          retention-days: 1
+          retention-days: 7
           if-no-files-found: error
 
       - name: Build docs
@@ -98,51 +99,86 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v5
 
-  # The README coverage badge: an SVG committed to the orphan `badges` branch on every green main
-  # push, so badge churn stays out of main's history. The branch is created once by hand; the badge
-  # only renders publicly (raw.githubusercontent.com 404s anonymously while the repo is private).
-  publish-badge:
-    needs: check
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  # Publish generated README artifacts to the orphan `badges` branch: the shields.io coverage
+  # endpoint JSON and the anchor R_obs trend (CSV + SVGs, rendered by plot_anchor_trend.py, which
+  # lives ON `badges`). Gated on check success but runs even when e2e is red -- coverage keeps
+  # publishing and the anchor row becomes a gap. These embeds only render publicly
+  # (raw.githubusercontent.com 404s anonymously while the repo is private).
+  publish:
+    needs: [check, e2e]
+    if: >-
+      always() && needs.check.result == 'success' &&
+      github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Serialize publishes: two quick merges must not race the badges push.
+    concurrency:
+      group: publish-badges
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
         with:
           ref: badges
 
+      # Concurrency serializes runs, but the checkout may still predate a just-finished publish.
+      - name: Sync to latest badges
+        run: git pull --rebase origin badges
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: false  # no lockfile on badges; nothing worth caching
+
       - uses: actions/download-artifact@v8
         with:
-          name: coverage-json-${{ github.run_id }}
+          name: coverage-json
 
-      - name: Extract coverage percent + color
-        id: cov
+      - name: Download anchor metrics
+        uses: actions/download-artifact@v8
+        continue-on-error: true  # e2e red or drifted upload -> gap row, not a publish failure
+        with:
+          name: anchor-metrics
+
+      - name: Write shields coverage endpoint
         run: |
           pct=$(jq '.totals.percent_covered_display | tonumber | floor' coverage.json)
           color=$([ "$pct" -ge 90 ] && echo green || ([ "$pct" -ge 80 ] && echo yellow || echo red))
-          echo "percent=$pct" >> "$GITHUB_OUTPUT"
-          echo "color=$color" >> "$GITHUB_OUTPUT"
+          jq -n --arg msg "${pct}%" --arg color "$color" \
+            '{schemaVersion: 1, label: "coverage", message: $msg, color: $color}' \
+            > coverage-endpoint.json
 
-      - name: Generate badge
-        uses: jaywcjlove/generated-badges@v1.1.0
-        with:
-          label: coverage
-          status: ${{ steps.cov.outputs.percent }}%
-          color: ${{ steps.cov.outputs.color }}
-          output: coverage.svg
+      - name: Append anchor history row
+        run: |
+          value=""
+          if [ -f anchor-metrics.json ]; then
+            value=$(jq -r '.quartz_coupled_mean_r_obs // empty' anchor-metrics.json)
+          fi
+          [ -f anchor-history.csv ] || echo "date,sha,mean_r_obs" > anchor-history.csv
+          if grep -q "$GITHUB_SHA" anchor-history.csv; then
+            echo "row for $GITHUB_SHA already present (re-run); leaving history unchanged"
+          else
+            echo "$(date -u +%FT%TZ),${GITHUB_SHA},${value}" >> anchor-history.csv
+          fi
 
-      # file_pattern keeps the downloaded coverage.json out of the commit.
-      - name: Commit badge
+      - name: Render anchor trend
+        run: MPLBACKEND=Agg uv run --python 3.12 --with 'matplotlib==3.*' python plot_anchor_trend.py
+
+      # file_pattern keeps the downloaded artifacts out of the commit.
+      - name: Commit endpoint + trend
         uses: stefanzweifel/git-auto-commit-action@v7.1.0
         with:
-          commit_message: Update coverage badge
-          file_pattern: coverage.svg
+          commit_message: Update coverage endpoint and anchor trend
+          file_pattern: coverage-endpoint.json anchor-history.csv anchor-trend.svg anchor-trend-dark.svg
 
   # The physics anchors: opt-in locally (`just anchor`), a separate job here so the fast checks
   # report first. Full 99-rotation static + integrated (CLI-driven) quartz pins, ~5-6 min on CPU.
   e2e:
     runs-on: ubuntu-latest
+    env:
+      # Anchor tests deposit their measured values here (tests/e2e/conftest.py recorder);
+      # main pushes upload it for the trend plot on `badges`. Harmless on PRs (gitignored).
+      DIFFBLOCH_ANCHOR_METRICS: anchor-metrics.json
     steps:
       - uses: actions/checkout@v7
         with:
@@ -158,3 +194,14 @@ jobs:
 
       - name: Physics anchors (e2e)
         run: uv run pytest -m e2e -q
+
+      # if: always() -- a drifted anchor value (test red, measurement recorded) must still
+      # reach the trend plot; a missing file is a warn, and publish appends a gap row.
+      - name: Upload anchor metrics
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v7
+        with:
+          name: anchor-metrics
+          path: ${{ env.DIFFBLOCH_ANCHOR_METRICS }}
+          retention-days: 7
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 .coverage
 coverage.xml
 coverage.json
+anchor-metrics.json
 htmlcov/
 pytest.xml
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # diffBloch
 
-![Coverage](https://raw.githubusercontent.com/Differentiable-Electron-Crystallography/diffBloch/badges/coverage.svg)
+![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FDifferentiable-Electron-Crystallography%2FdiffBloch%2Fbadges%2Fcoverage-endpoint.json)
+![Python](https://img.shields.io/badge/Python-3.12%2B-3776AB?logo=python&logoColor=white)
+![PyTorch](https://img.shields.io/badge/PyTorch-EE4C2C?logo=pytorch&logoColor=white)
+![NumPy](https://img.shields.io/badge/NumPy-013243?logo=numpy&logoColor=white)
+![Pydantic](https://img.shields.io/badge/Pydantic-E92063?logo=pydantic&logoColor=white)
+![uv](https://img.shields.io/badge/uv-DE5FE9?logo=uv&logoColor=white)
+![Ruff](https://img.shields.io/badge/Ruff-D7FF64?logo=ruff&logoColor=black)
+![mypy](https://img.shields.io/badge/mypy-strict-blue)
+[![License: MIT](https://img.shields.io/badge/License-MIT-97ca00)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-0969da?logo=sphinx&logoColor=white)](https://differentiable-electron-crystallography.github.io/diffBloch/)
 
 Differentiable Bloch-wave structure refinement for rotating-stage 3D electron diffraction.
 
@@ -57,6 +66,20 @@ See `examples/experiments/quartz/README.md` for the worked example and its expec
   including checkpointed runs that start from a committed `Plan`.
 - `examples/papers` contains paper implementations that demonstrate doing science with diffBloch via
   richer Python API composition.
+
+## Anchor trend
+
+Every merge to `main` re-runs the e2e physics anchors. The plot tracks the measured mean R_obs of
+the coupled quartz anchor (the checkpointed 99-rotation scoring in `tests/e2e/test_anchor.py`) for
+every merge; the shaded band is the pinned tolerance. A flat line inside the band is the desired
+outcome — evidence the physics is reproducible commit over commit. Gaps are commits with no valid
+measurement (the committed checkpoint was stale for that commit's recipe, so the fast anchor
+could not score it).
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Differentiable-Electron-Crystallography/diffBloch/badges/anchor-trend-dark.svg">
+  <img alt="Mean R_obs of the coupled quartz anchor for every merge to main" src="https://raw.githubusercontent.com/Differentiable-Electron-Crystallography/diffBloch/badges/anchor-trend.svg">
+</picture>
 
 ## Layout
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,10 +2,36 @@
 
 Mirrors the research repo's ``MATERIAL`` deselection so a single material can be run in isolation
 (``MATERIAL=quartz uv run pytest -m e2e``) without cluttering output with the others.
+
+Also hosts the anchor-metrics recorder: anchor tests deposit their *measured* values (not the
+pinned expectations) into the ``anchor_metrics`` fixture, and the session dumps them as JSON to
+the path in ``DIFFBLOCH_ANCHOR_METRICS`` -- CI publishes the series as a trend plot on the
+``badges`` branch. With the env var unset (the default everywhere but CI main pushes) nothing
+is written.
 """
 
+import json
 import os
 from typing import Any
+
+import pytest
+
+# Module-level store: a session fixture's value is not reachable from pytest_sessionfinish,
+# so the fixture hands tests this dict and the hook reads it directly.
+_ANCHOR_METRICS: dict[str, float] = {}
+
+
+@pytest.fixture(scope="session")
+def anchor_metrics() -> dict[str, float]:
+    """Measured anchor values, written to ``DIFFBLOCH_ANCHOR_METRICS`` at session end."""
+    return _ANCHOR_METRICS
+
+
+def pytest_sessionfinish(session: Any, exitstatus: int) -> None:
+    out = os.environ.get("DIFFBLOCH_ANCHOR_METRICS")
+    if out and _ANCHOR_METRICS:
+        with open(out, "w") as fh:
+            json.dump(_ANCHOR_METRICS, fh, indent=2, sort_keys=True)
 
 
 def pytest_collection_modifyitems(config: Any, items: list[Any]) -> None:

--- a/tests/e2e/test_anchor.py
+++ b/tests/e2e/test_anchor.py
@@ -184,7 +184,9 @@ def test_quartz_reference_anchor(material: str) -> None:
         assert manifest["intermediate_tensors"][tensor]["status"] == "pending"
 
 
-def test_quartz_coupled_anchor(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+def test_quartz_coupled_anchor(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, anchor_metrics: dict[str, float]
+) -> None:
     """Headline north-star (CI-fast): score the committed frozen coupled checkpoint, no fit.
 
     The fixture ships ``plan.npz`` + ``plan.lock`` -- the settled coupled ``Plan`` (fitted
@@ -235,6 +237,9 @@ def test_quartz_coupled_anchor(tmp_path: Path, caplog: pytest.LogCaptureFixture)
 
     with caplog.at_level(logging.INFO, logger="diffBloch.app.program"):
         result = run_experiment(exp)
+    # Recorded before any assertion: a drifted value must still reach the trend plot -- the one
+    # event the plot exists to show.
+    anchor_metrics["quartz_coupled_mean_r_obs"] = float(result.mean_r_obs)
     assert "full reuse" in caplog.text  # reused the checkpoint; no fit ran (the CI-fast guarantee)
     assert result.n_evaluated == 99  # every rotation yields a finite R_obs
     assert result.mean_r_obs == pytest.approx(


### PR DESCRIPTION
## Summary

Three commits, one theme: make the CI signal visible on the README.

1. **`ci: bump actions to current majors`** — checkout v7, setup-uv v9.0.0 (v8+ publishes no major tags, hence the full pin), upload-artifact v7, download-artifact v8, upload-pages-artifact v5, deploy-pages v5. Silences the Node-20 deprecation annotations on every run and setup-uv v4's retired-cache-API 400s.

2. **`ci: record anchor R_obs and publish trend + coverage endpoint`** — the e2e quartz anchor's measured mean R_obs was asserted and discarded; now a conftest recorder captures it (before the assertion, so a drifted value still surfaces) and main pushes upload it. The publish job (née publish-badge) appends `date,sha,mean_r_obs` to `anchor-history.csv` on the `badges` branch and renders the trend SVGs with `plot_anchor_trend.py` (which lives on `badges`). Coverage becomes a shields.io endpoint JSON, dropping the `generated-badges` third-party action. Publish is gated on `check` but tolerates a red `e2e` (coverage keeps updating; the anchor row becomes a gap). Concurrency group + rebase guard the badges push against racing merges.

3. **`docs: add stack badges, shields coverage badge, anchor trend plot`** — shields.io stack badges (render immediately, repo private or not), the endpoint coverage badge, and a theme-aware `<picture>` embed of the anchor trend with a caption explaining band, flatline, and gaps.

The `badges` branch is being seeded with a backfilled history: every first-parent main commit since the frozen-checkpoint anchor landed (`3e18991`, 125 commits), measured by running each commit's own fast coupled anchor in a worktree. Gaps are commits whose committed checkpoint was stale for their recipe — the fail-fast gate refuses to score them, which is the honest record. The backfill, plot script, and this history live on `badges`, not main.

## Test plan

- Recorder verified locally: inert without `DIFFBLOCH_ANCHOR_METRICS`, writes measured JSON with it (0.0507, inside the pinned band).
- Full unit suite + coupled anchor green locally; ruff/format clean; workflow YAML parses.
- This PR's CI run exercises the bumped actions and the (inert-on-PR) recorder; expect zero Node-20/cache annotations.
- Post-merge: the publish job appends the first live row to `anchor-history.csv` and re-renders the trend — verify one new commit on `badges` with endpoint JSON + CSV + two SVGs.

Tests: see above.
diffBloch_private analog: none (public-repo CI/README infrastructure).