### PR TITLE
docs: add CITATION.cff, funding, docsite citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+message: "If you use diffBloch in your research, please cite it as below."
+title: diffBloch
+type: software
+authors:
+  - family-names: Doherty
+    given-names: Tiarnan
+    email: td404@cam.ac.uk
+  - family-names: Malik
+    given-names: Shreshth
+    email: shreshth_malik@yahoo.co.uk
+  - family-names: Colmey
+    given-names: Benjamin
+    email: benjamincolmey@gmail.com
+  - family-names: Maitland
+    given-names: Iain
+    email: github@iainmaitland.com
+version: 0.2.0
+license: MIT
+repository-code: https://github.com/Differentiable-Electron-Crystallography/diffBloch
+abstract: >-
+  Differentiable Bloch-wave structure refinement for rotating-stage 3D electron
+  diffraction.
+# The CFF 1.2.0 schema has no funding field; see the README's Funding section.
+# Funded by Schmidt Sciences (https://www.schmidtsciences.org/), developed with the
+# Scientific Software Engineering Center at Johns Hopkins (https://ai.jhu.edu/ssec/).

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ tests/e2e/        characterization anchors
 docs/             docs site (Sphinx + furo, MyST)
 ```
 
+## Funding
+
+This work is funded by [Schmidt Sciences](https://www.schmidtsciences.org/) and developed with
+the [Scientific Software Engineering Center (SSEC)](https://ai.jhu.edu/ssec/) at Johns Hopkins
+University.
+
 ## Layers
 
 | Layer | Role | Guide |

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,24 @@ and updating the selected trainable structural parameters.
 Python users can compose preprocessing steps, constraints, penalties, and refinement problems
 directly with the public API; the CLI is the friendly default runner, not the only path.
 
+## Citation
+
+If you use diffBloch in your research, please cite it (see
+[CITATION.cff](https://github.com/Differentiable-Electron-Crystallography/diffBloch/blob/main/CITATION.cff)):
+
+```bibtex
+@misc{diffBloch,
+  author  = {Doherty, Tiarnan and Malik, Shreshth and Colmey, Benjamin and Maitland, Iain},
+  title   = {diffBloch},
+  version = {0.2.0},
+  url     = {https://github.com/Differentiable-Electron-Crystallography/diffBloch}
+}
+```
+
+This work is funded by [Schmidt Sciences](https://www.schmidtsciences.org/) and developed with
+the [Scientific Software Engineering Center (SSEC)](https://ai.jhu.edu/ssec/) at Johns Hopkins
+University.
+
 ```{toctree}
 :hidden:
 :caption: Guides


### PR DESCRIPTION
## Summary

- **`CITATION.cff`** (schema 1.2.0, validated): authors from the research lineage's contributor history — Doherty, Malik, Colmey, Maitland, with known emails; version 0.2.0; MIT. GitHub will render a "Cite this repository" button from it.
- **README `## Funding` section**: Schmidt Sciences + the JHU Scientific Software Engineering Center (SSEC). Echoed as YAML comments in the citation file, since CFF 1.2.0 has no funding field.
- **Docsite landing page** gains a Citation section (BibTeX + funding line).

## Test plan

- `cffconvert --validate` passes; APA/BibTeX previews render the agreed author order.
- Strict `sphinx-build -W` green locally.
- After merge: "Cite this repository" appears on the repo sidebar; docsite Citation section renders on the next Pages deploy.

Tests: see above.
diffBloch_private analog: none (public-repo metadata).