### PR TITLE
examples: malik notebook progress, fp32 precision, LFS docs

### DIFF
--- a/examples/papers/malik-2026-hybrid-physics-ml/README.md
+++ b/examples/papers/malik-2026-hybrid-physics-ml/README.md
@@ -25,6 +25,15 @@ v1 example path.
 
 ## Running the example
 
+Prerequisite: the bundled datasets (`.cif_pets` observations, `plan.npz` checkpoints) are stored
+in [Git LFS](https://git-lfs.com/) — without it a checkout contains pointer stubs and loading
+fails with a parse error, not a missing file:
+
+```bash
+git lfs install
+git lfs pull
+```
+
 As a plain script from the repository root:
 
 ```bash

--- a/examples/papers/malik-2026-hybrid-physics-ml/malik_2026_reimplementation.py
+++ b/examples/papers/malik-2026-hybrid-physics-ml/malik_2026_reimplementation.py
@@ -12,10 +12,12 @@
 # the engine → compose the model → refine → inspect.
 
 # %%
+import logging
 from pathlib import Path
 
 import torch
 
+from diffBloch.app.loggers import ConsoleLogger
 from diffBloch.config import load_experiment
 from diffBloch.engine import (
     ApparentThicknessNN,
@@ -47,9 +49,16 @@ from diffBloch.specs import ScoredHklSelection, TrialCoupling
 # repo-root-relative path would break there).
 HERE = Path(__file__).parent if "__file__" in globals() else Path.cwd()
 EXPERIMENT_DIR = HERE / "experiments/quartz-synthetic"
-# CUDA when available, else CPU. Apple's MPS backend is deliberately excluded: the default
-# solve format is fp64 (float64/complex128 -- see core/solver.py) and MPS has no float64.
+# CUDA when available, else CPU. Apple's MPS backend is deliberately unsupported for now: the
+# refinement solve honors ``cfg.refinement.precision`` (fp32 for this experiment), but the
+# orientation fit here still solves in fp64 (float64/complex128), which MPS lacks.
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+# Live progress: diffBloch reports through typed events on a Logger; ConsoleLogger bridges them
+# to stdlib logging, and attaching a handler is the app boundary's job -- basicConfig is that
+# boundary here, so the long cells (preprocessing, refinement) scroll their progress.
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+LOGGER = ConsoleLogger()
 
 # %% [markdown]
 # ## 1. Load the experiment
@@ -101,11 +110,13 @@ plan = pipeline(
             method=cfg.solver.refine,
             coupling=coupling,
             device=DEVICE,
+            logger=LOGGER,
         ),
         select_finite_loss_frames(
             refinement, loss=cfg.refinement.objective.to_loss(), method=cfg.solver.refine
         ),
-    ]
+    ],
+    logger=LOGGER,
 )(setup.plans.combined)
 print(f"orientations after preprocess: {len(plan.orientations)}")
 
@@ -120,7 +131,13 @@ print(f"orientations after preprocess: {len(plan.orientations)}")
 # learned thickness profile, not the absolute value.
 
 # %%
-engine = build_engine(plan, refinement, loss=weighted_mse_loss, method=cfg.solver.refine)
+engine = build_engine(
+    plan,
+    refinement,
+    loss=weighted_mse_loss,
+    method=cfg.solver.refine,
+    precision=cfg.refinement.precision,
+)
 
 # %% [markdown]
 # ## 4. Compose the refinement model — structure + a learned thickness
@@ -169,7 +186,7 @@ trainable = TrainableSpec(adp=AtomSelection.all())
 STEPS = 40
 LR = 1e-3
 result = run_refinement_model(
-    engine, model, problem, trainable=trainable, steps=STEPS, optimizer="adam", lr=LR
+    engine, model, problem, trainable=trainable, steps=STEPS, optimizer="adam", lr=LR, logger=LOGGER
 )
 print(f"loss: {float(result.losses[0]):.4f} -> {float(result.losses[-1]):.4f}")
 print(f"best {result.best_loss:.4f} at step {result.best_step}")


### PR DESCRIPTION
## Summary

Three usability fixes for the Malik paper example, following on from #29:

1. **Live progress** — `ConsoleLogger` threaded through `pipeline`, `fit_orientation`, and `run_refinement_model`, with `logging.basicConfig` as the notebook's app-boundary handler. The long preprocessing/refinement cells now scroll typed progress events instead of running silent.
2. **Honor the configured solve precision** — the experiment declares `refinement.precision: fp32`, but the notebook never passed it to `build_engine`, silently refining at the fp64 default. Now threaded through, matching what `run_experiment` does (`program.py:259`). The DEVICE comment is corrected accordingly: MPS remains unsupported because the *orientation fit* here still solves fp64 — not because the refinement loop does.
3. **LFS prerequisite in the paper README** — the bundled `.cif_pets`/`plan.npz` are LFS-tracked; without git-lfs a clone fails with a parse error that never mentions LFS. The prerequisite + symptom now sit next to the run commands.

## Test plan

- ruff check + format clean.
- Full end-to-end script run in flight at PR time — a comment will follow with the loss trajectory and confirmation the progress lines scroll under fp32.

Tests: see above.
diffBloch_private analog: none (public example port).