### PR TITLE
observability: OrientationFitted channel fit -> fit_orientation

### DIFF
--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -112,10 +112,11 @@ class OrientationFitted:
     the search took to converge (the quantity ``HexagonalSearch.max_iterations`` caps), and
     ``pass_cap`` that cap itself -- carried per event so a plot can show each rotation's headroom
     (``n_passes`` vs ``pass_cap``) and flag any rotation that ran to the cap. With ``workers > 1``
-    events arrive in *completion* order (the plan itself stays ordered).
+    events arrive in *completion* order (the plan itself stays ordered). The channel is shared
+    with the step's ``PlanStepCompleted`` summary line, like the refinement stream's events.
     """
 
-    channel: ClassVar[str] = "fit"
+    channel: ClassVar[str] = "fit_orientation"
     index: int
     wr2: float
     n_trials: int

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -55,6 +55,16 @@ def test_events_expose_a_uniform_channel_and_measurements_surface() -> None:
         "mean_r_obs": 0.065,
     }
 
+    fitted = _fitted(index=5, wr2=0.12)
+    assert fitted.channel == "fit_orientation"  # shared with the step's PlanStepCompleted line
+    assert fitted.step == 5  # an orientation fit's step is its rotation index
+    assert fitted.measurements == {
+        "wr2": 0.12,
+        "n_trials": 10.0,
+        "n_passes": 3.0,
+        "pass_cap": 2000.0,
+    }
+
     thickness = ThicknessFitted(index=7, wr2=0.031, thickness=1460.0)
     assert thickness.channel == "fit_thickness"
     assert thickness.step == 7  # a thickness fit's step is its rotation index


### PR DESCRIPTION
## Summary

The per-rotation orientation-fit progress line logged as `fit[n] wr2=…` — vague, and inconsistent with the observability vocabulary: the sibling event channel is `fit_thickness`, the step functions are `fit_orientation`/`fit_thickness`, and the pipeline's `PlanStepCompleted` summary for the same step already logs `fit_orientation[n] …`. Per-rotation and step-summary events now share the `fit_orientation` channel, following the refinement stream's existing shared-channel pattern (`RefinementStep` + `RefinementCompleted`); the class docstring states the sharing.

Also adds the missing channel assertion for `OrientationFitted` in `test_observability.py` — every sibling event already pins its channel string.

## Test plan

- Full unit suite green locally (581 passed, 3 skipped); ruff/format clean.
- Console scroll now reads `fit_orientation[n] wr2=…` (visible in any orientation-fitting run, e.g. the malik notebook's preprocess cell).

Tests: see above.
diffBloch_private analog: none (public observability vocabulary).