### PR TITLE
Add simulation convergence command

### DIFF
--- a/docs/hyperparameter-selection.md
+++ b/docs/hyperparameter-selection.md
@@ -53,10 +53,10 @@ from diffBloch.preprocess import (
 root = Path("examples/experiments/quartz")
 cfg, _lock = load_experiment(root)
 structure = read_structure(root / cfg.inputs.structure)
-observations = read_observations(root / cfg.inputs.observations)
+observations = read_observations(root / cfg.inputs.exp_data)
 setup = from_experiment(structure, observations, cfg)
 plan = build_orientation_plans()(
-    select_beams(cfg.numerics.to_beam_selection(setup.integration))(setup.plans.combined)
+    select_beams(cfg.blochwave.to_beam_selection(setup.integration))(setup.plans.combined)
 )
 
 test = ConvergenceTest(
@@ -72,8 +72,8 @@ tolerance = ConvergenceTolerance(
 
 converged_plan = converge_numerics(
     test,
-    cfg.numerics.to_rocking_curve(setup.integration),
-    cfg.preprocess.coupling.to_policy(),
+    cfg.blochwave.to_rocking_curve(setup.integration),
+    cfg.blochwave.to_policy(),
     setup.refinement,
     tolerance,
 )(plan)

--- a/src/diffBloch/app/__init__.py
+++ b/src/diffBloch/app/__init__.py
@@ -20,6 +20,7 @@ from diffBloch.app.loggers import (
 from diffBloch.app.loggers.comet import CometLogger
 from diffBloch.app.loggers.wandb import WandbLogger
 from diffBloch.app.program import (
+    converge_experiment,
     preprocess_experiment,
     refine_experiment,
     run_experiment,
@@ -32,6 +33,7 @@ __all__ = [
     "EarlyAbortLogger",
     "FitAbortedError",
     "WandbLogger",
+    "converge_experiment",
     "preprocess_experiment",
     "refine_experiment",
     "run_experiment",

--- a/src/diffBloch/app/cli.py
+++ b/src/diffBloch/app/cli.py
@@ -17,7 +17,12 @@ from pydantic import ValidationError
 
 from diffBloch import __version__
 from diffBloch.app.loggers import ConsoleLogger, CSVLogger
-from diffBloch.app.program import preprocess_experiment, refine_experiment, run_experiment
+from diffBloch.app.program import (
+    converge_experiment,
+    preprocess_experiment,
+    refine_experiment,
+    run_experiment,
+)
 from diffBloch.config import load_config, pack_run
 from diffBloch.observability import NULL_LOGGER, Logger, MultiLogger
 
@@ -47,8 +52,8 @@ def _add_run_flags(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--device",
         metavar="DEVICE",
-        default=None,
-        help="run the forward solve on this torch device (e.g. 'cuda'); default CPU",
+        default="cuda",
+        help="run the forward solve on this torch device (default: cuda; use 'cpu' to override)",
     )
     parser.add_argument(
         "--workers",
@@ -95,6 +100,23 @@ def main(argv: list[str] | None = None) -> int:
         "refine", help="Gradient-refine the structure against the data (reuses the checkpoint)"
     )
     _add_run_flags(p_refine)
+    p_converge = run_sub.add_parser(
+        "converge", help="Test convergence of g_max, sg_max, and rocking-curve tilt steps"
+    )
+    p_converge.add_argument("experiment_directory", help="Path to the experiment directory")
+    p_converge.add_argument(
+        "--device",
+        metavar="DEVICE",
+        default="cuda",
+        help="run the convergence simulations on this torch device (default: cuda)",
+    )
+    p_converge.add_argument(
+        "--orientations",
+        metavar="N",
+        type=int,
+        default=1,
+        help="use the first N orientations for convergence testing (default: 1)",
+    )
     p_pack = run_sub.add_parser("pack", help="Export a run directory for transfer/archive")
     p_pack.add_argument("run_directory", help="Path to canonical run artifact directory")
     p_pack.add_argument(
@@ -190,6 +212,34 @@ def main(argv: list[str] | None = None) -> int:
             f"refined {refined.losses.shape[0]} steps; objective "
             f"{float(refined.losses[0]):.6f} -> {refined.best_loss:.6f} "
             f"(best at step {refined.best_step})"
+        )
+        return 0
+
+    if args.command == "run" and args.run_command == "converge":
+        logging.basicConfig(
+            level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S"
+        )
+        try:
+            settled = converge_experiment(
+                args.experiment_directory,
+                logger=ConsoleLogger(),
+                device=args.device,
+                n_orientations=args.orientations,
+            )
+        except (FileNotFoundError, ValueError, ValidationError, yaml.YAMLError) as exc:
+            if args.debug:
+                raise
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        print("========================================")
+        print("HYPERPARAMETER OPTIMIZATION RESULT")
+        print(f"gmax: {settled.g_max:g}")
+        print(f"sgmax: {settled.sg_max:g}")
+        print(f"tilt_steps: {settled.tilt_steps}")
+        print("========================================")
+        print(
+            f"optimized_hyperparams gmax={settled.g_max:g} "
+            f"sgmax={settled.sg_max:g} tilt_steps={settled.tilt_steps}"
         )
         return 0
 

--- a/src/diffBloch/app/loggers/__init__.py
+++ b/src/diffBloch/app/loggers/__init__.py
@@ -24,6 +24,9 @@ from pathlib import Path
 
 from diffBloch.observability import (
     NULL_LOGGER,
+    ConvergencePassStarted,
+    ConvergenceSweepStarted,
+    ConvergenceTrial,
     Event,
     Logger,
     OrientationFitted,
@@ -68,6 +71,37 @@ class ConsoleLogger:
     level: int = logging.INFO
 
     def report(self, event: Event) -> None:
+        if isinstance(event, ConvergencePassStarted):
+            _log.log(
+                self.level,
+                "=== Hyperparameter Optimization Pass %d ===",
+                event.pass_index,
+            )
+            _log.log(
+                self.level,
+                "start: gmax=%g sgmax=%g tilt_steps=%d r_threshold=%.6f orientations=%d",
+                event.g_max,
+                event.sg_max,
+                event.tilt_steps,
+                event.r_factor_threshold,
+                event.n_orientations,
+            )
+            return
+        if isinstance(event, ConvergenceSweepStarted):
+            label = "gmax" if event.control == "g_max" else event.control
+            _log.log(self.level, "sweep: %s", label)
+            return
+        if isinstance(event, ConvergenceTrial):
+            label = "gmax" if event.control == "g_max" else event.control
+            _log.log(
+                self.level,
+                "  %s -> %g | R=%.6f | fixed_hkls=%d",
+                label,
+                event.candidate,
+                event.r_factor,
+                event.n_compared_hkl,
+            )
+            return
         if isinstance(event, OrientationFitted):
             label = f"orientation refinement[orientation_index={event.index}]"
         elif isinstance(event, ThicknessFitted):

--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -29,6 +29,9 @@ from typing import ClassVar, Protocol, runtime_checkable
 __all__ = [
     "NULL_LOGGER",
     "CouplingSummary",
+    "ConvergenceTrial",
+    "ConvergencePassStarted",
+    "ConvergenceSweepStarted",
     "Event",
     "InferenceCompleted",
     "Logger",
@@ -76,6 +79,83 @@ class Logger(Protocol):
     """
 
     def report(self, event: Event) -> None: ...
+
+
+@dataclass(frozen=True)
+class ConvergenceTrial:
+    """One comparison between consecutive numerical settings in a convergence sweep."""
+
+    control: str
+    trial_index: int
+    pass_index: int
+    previous: float
+    candidate: float
+    r_factor: float
+    n_compared_hkl: int
+
+    @property
+    def channel(self) -> str:
+        return f"convergence {self.control}"
+
+    @property
+    def step(self) -> int | None:
+        return self.trial_index
+
+    @property
+    def measurements(self) -> Mapping[str, float]:
+        return {
+            "pass": float(self.pass_index),
+            "previous": self.previous,
+            "candidate": self.candidate,
+            "r_factor": self.r_factor,
+            "n_compared_hkl": float(self.n_compared_hkl),
+        }
+
+
+@dataclass(frozen=True)
+class ConvergencePassStarted:
+    """Starting settings for one coordinated convergence pass."""
+
+    pass_index: int
+    g_max: float
+    sg_max: float
+    tilt_steps: int
+    r_factor_threshold: float
+    n_orientations: int
+
+    channel: ClassVar[str] = "convergence pass"
+
+    @property
+    def step(self) -> int | None:
+        return self.pass_index
+
+    @property
+    def measurements(self) -> Mapping[str, float]:
+        return {
+            "g_max": self.g_max,
+            "sg_max": self.sg_max,
+            "tilt_steps": float(self.tilt_steps),
+            "r_factor_threshold": self.r_factor_threshold,
+            "n_orientations": float(self.n_orientations),
+        }
+
+
+@dataclass(frozen=True)
+class ConvergenceSweepStarted:
+    """Announcement emitted before one parameter sweep begins."""
+
+    control: str
+    pass_index: int
+
+    channel: ClassVar[str] = "convergence sweep"
+
+    @property
+    def step(self) -> int | None:
+        return self.pass_index
+
+    @property
+    def measurements(self) -> Mapping[str, float]:
+        return {"pass": float(self.pass_index)}
 
 
 @dataclass(frozen=True)

--- a/src/diffBloch/preprocess/driver.py
+++ b/src/diffBloch/preprocess/driver.py
@@ -1,320 +1,275 @@
-"""The preprocess convergence driver: threads state through the coupled beam-knob sweeps.
-
-The individual convergence levers (``converge_beams`` / ``converge_pool`` / ``converge_sampling``)
-and the coverage levers (``cover_beams`` / ``cover_pool``) are pure ``Plan -> Plan`` steps, each
-self-contained. But the *coupled* sweep -- pool and window tuned together, and coverage handing its
-settled knobs to self-stability (the ``both`` operation) -- needs state the ``Plan`` deliberately
-does not carry: the live scalars ``g_max_refine`` / ``integration_semiangle`` / ``rocking_curve_sampling``.
-This module is the **driver** that owns that state.
-
-:class:`ConvergenceState` holds that state; a *phase* (:func:`run_coverage_phase`,
-:func:`run_stability_phase`) is a ``(Plan, ConvergenceState) -> (Plan, ConvergenceState)``
-computation; the driver threads the state between phases and, at its outer boundary, returns just
-the converged ``Plan``.
-
-The cross-lever fixpoint: each candidate must re-select the window from
-the **un-pruned pool**, not from a previous lever's pruned ``Plan``. The driver re-derives that pool
-as ``seed_beam_hkl(grid, g_max_refine)`` -- so the pool is *derived* from the grid + the live
-``g_max_refine`` scalar, never stored.
-"""
+"""Simulation-convergence testing over ``g_max``, ``sg_max``, and tilt steps."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
 
-from diffBloch.core.solver import SolverMethod
-from diffBloch.preprocess.experiment import RefinementSetup
-from diffBloch.preprocess.pipeline import (
-    PlanStep,
-    StatefulPlanStep,
-    stateful_pipeline,
-    stateful_plan_step,
-)
-from diffBloch.preprocess.plan import Plan
-from diffBloch.preprocess.steps.beams import reseed_pool
-from diffBloch.preprocess.steps.convergence import converge_scalar, simulation_rfactor
-from diffBloch.preprocess.steps.coverage import maximize_scalar, plan_coverage
-from diffBloch.preprocess.steps.rocking_curve import integrate_rocking_curve
-from diffBloch.specs import BeamSelection, ConvergenceTest, ConvergenceTolerance, RockingCurve
+import numpy as np
+from numpy.typing import NDArray
+from torch import Tensor
 
-__all__ = [
-    "ConvergenceState",
-    "converge_numerics",
-    "run_coverage_phase",
-    "run_stability_phase",
-]
+from diffBloch.core.solver import SolverMethod
+from diffBloch.engine.plan import CoupledOrientationPlan, OrientationPlan, StructureFactorGrid
+from diffBloch.observability import (
+    NULL_LOGGER,
+    ConvergencePassStarted,
+    ConvergenceSweepStarted,
+    ConvergenceTrial,
+    Logger,
+)
+from diffBloch.preprocess.experiment import RefinementSetup
+from diffBloch.preprocess.pipeline import PlanStep, as_step
+from diffBloch.preprocess.plan import Plan, require_built_plans, require_orientation_plans
+from diffBloch.preprocess.steps.convergence import converge_scalar, simulation_rfactor
+from diffBloch.preprocess.steps.coupling import couple_beams
+from diffBloch.preprocess.steps.rocking_curve import integrate_rocking_curve
+from diffBloch.specs import (
+    ConvergenceTest,
+    ConvergenceTolerance,
+    RockingCurve,
+    SegmentedUnionCoupling,
+)
+
+__all__ = ["ConvergenceState", "converge_numerics", "run_convergence"]
 
 
 @dataclass(frozen=True)
 class ConvergenceState:
-    """The driver's coordinate-descent state -- the live beam scalars threaded between phases.
+    """The three numerical controls varied by a convergence test."""
 
-    ``g_max_refine`` is the candidate-pool radius; ``integration_semiangle`` is the Klar window;
-    ``rocking_curve_sampling`` is the rocking-curve tilt count. The un-pruned pool is *not* a field: it is
-    re-derived as ``seed_beam_hkl(grid, g_max_refine)`` from whichever ``Plan`` the driver is
-    transforming, so there is no stored copy to desync. The coverage phase tunes the first two (the
-    beam SET is tilt-independent under pure geometric membership); the
-    self-stability phase tunes all three.
-    """
-
-    g_max_refine: float
-    integration_semiangle: float
-    rocking_curve_sampling: int
+    g_max: float
+    sg_max: float
+    tilt_steps: int
 
 
 def converge_numerics(
     test: ConvergenceTest,
-    selection: BeamSelection,
     rocking: RockingCurve,
+    simulation: SegmentedUnionCoupling,
     refinement: RefinementSetup,
     tolerance: ConvergenceTolerance,
     *,
     method: SolverMethod = "matrix_exp",
+    logger: Logger = NULL_LOGGER,
 ) -> PlanStep:
-    """Return a ``Plan -> Plan`` step running the selected convergence operation (the driver entry).
+    """Return a step that converges ``g_max``, ``sg_max``, and rocking-curve tilt steps."""
 
-    The driver's outer boundary: it seeds the initial :class:`ConvergenceState` (pool
-    from ``test.start_g_max_refine``, window from ``selection.integration.semiangle``, tilt from
-    ``rocking.sampling``), runs the ``test.operation`` phase(s), and returns just the converged
-    ``Plan`` -- the settled scalars are dropped, so downstream steps never see driver state and this
-    nests as one *optional* ordinary step in the preprocess pipeline (convergence stays entirely
-    opt-in by construction). ``both`` runs :func:`run_coverage_phase` first and seeds
-    :func:`run_stability_phase` from its settled state; the single-phase operations run one and
-    discard the state. Dispatches on ``convergence_test.operation``.
-    """
-
-    def start_state(_plan: Plan) -> ConvergenceState:
-        return ConvergenceState(
-            g_max_refine=test.start_g_max_refine,
-            integration_semiangle=selection.integration.semiangle,
-            rocking_curve_sampling=rocking.sampling,
-        )
-
-    def coverage(plan: Plan, state: ConvergenceState) -> tuple[Plan, ConvergenceState]:
-        return run_coverage_phase(
+    def run(plan: Plan) -> Plan:
+        converged, _state = run_convergence(
             plan,
-            state,
-            selection,
-            g_max_refine_step=test.g_max_refine_step,
-            integration_semiangle_step=test.integration_semiangle_step,
-            max_iterations=tolerance.max_iterations,
-        )
-
-    def self_stability(plan: Plan, state: ConvergenceState) -> tuple[Plan, ConvergenceState]:
-        return run_stability_phase(
-            plan,
-            state,
-            selection,
+            ConvergenceState(
+                g_max=simulation.g_max,
+                sg_max=simulation.sg_max,
+                tilt_steps=rocking.sampling,
+            ),
+            test,
             rocking,
+            simulation,
             refinement,
             tolerance,
-            g_max_refine_step=test.g_max_refine_step,
-            integration_semiangle_step=test.integration_semiangle_step,
-            rocking_curve_sampling_step=test.rocking_curve_sampling_step,
-            num_passes=test.num_passes,
             method=method,
+            logger=logger,
         )
+        return converged
 
-    phases: tuple[StatefulPlanStep[ConvergenceState], ...]
-    if test.operation == "coverage":
-        phases = (coverage,)
-    elif test.operation == "self_stability":
-        phases = (self_stability,)
-    else:
-        # "both": coverage's settled scalars seed self-stability.
-        phases = (coverage, self_stability)
+    return as_step(
+        "converge_numerics",
+        {
+            "test": test,
+            "rocking": rocking,
+            "simulation": simulation,
+            "tolerance": tolerance,
+            "method": method,
+        },
+        run,
+    )
 
-    return stateful_plan_step(start_state, stateful_pipeline(phases))
 
-
-def run_coverage_phase(
+def run_convergence(
     plan: Plan,
     state: ConvergenceState,
-    selection: BeamSelection,
-    *,
-    g_max_refine_step: float,
-    integration_semiangle_step: float,
-    max_iterations: int = 100,
-) -> tuple[Plan, ConvergenceState]:
-    """Grow the pool then the window to the minimum that maximises coverage; thread the scalars.
-
-    The coverage phase: a single ordered pass -- pool
-    (``g_max_refine``) then window (``integration_semiangle``) -- each swept by
-    :func:`maximize_scalar`
-    to the smallest value that still strictly increases :func:`plan_coverage` (matched observed
-    reflections). Coverage is pure geometric membership, so the tilt count cannot move it;
-    tilts are tuned in the self-stability phase instead.
-
-    Each candidate is built from the **un-pruned pool** re-derived at the current ``g_max_refine``
-    (the cross-lever fixpoint), so widening the window can recover beams a narrower pool clipped. ``selection``
-    supplies the fixed ``rsg`` / ``dsg`` / ``geometry``; its ``integration.semiangle`` is ignored --
-    the live window comes from ``state``. Returns the coverage-maximising ``Plan`` and the settled
-    :class:`ConvergenceState` (for the ``both`` handoff to self-stability). ``g_max_refine_step`` /
-    ``integration_semiangle_step`` must be positive.
-    """
-    if g_max_refine_step <= 0.0:
-        raise ValueError("g_max_refine_step must be positive")
-    if integration_semiangle_step <= 0.0:
-        raise ValueError("integration_semiangle_step must be positive")
-
-    g_max_refine = maximize_scalar(
-        lambda value: value,
-        lambda value: plan_coverage(
-            _windowed_pool(plan, value, state.integration_semiangle, selection)
-        ),
-        start=state.g_max_refine,
-        step=g_max_refine_step,
-        max_iterations=max_iterations,
-    )
-    integration_semiangle = maximize_scalar(
-        lambda value: value,
-        lambda value: plan_coverage(_windowed_pool(plan, g_max_refine, value, selection)),
-        start=state.integration_semiangle,
-        step=integration_semiangle_step,
-        max_iterations=max_iterations,
-    )
-    settled = ConvergenceState(
-        g_max_refine=g_max_refine,
-        integration_semiangle=integration_semiangle,
-        rocking_curve_sampling=state.rocking_curve_sampling,
-    )
-    return _windowed_pool(plan, g_max_refine, integration_semiangle, selection), settled
-
-
-def run_stability_phase(
-    plan: Plan,
-    state: ConvergenceState,
-    selection: BeamSelection,
+    test: ConvergenceTest,
     rocking: RockingCurve,
+    simulation: SegmentedUnionCoupling,
     refinement: RefinementSetup,
     tolerance: ConvergenceTolerance,
     *,
-    g_max_refine_step: float,
-    integration_semiangle_step: float,
-    rocking_curve_sampling_step: float,
-    num_passes: int = 2,
     method: SolverMethod = "matrix_exp",
+    logger: Logger = NULL_LOGGER,
 ) -> tuple[Plan, ConvergenceState]:
-    """Grow all three knobs to self-stability over ``num_passes`` coordinated passes; thread them.
+    """Run coordinate sweeps until all three simulation controls are self-stable."""
 
-    The self-stability phase (``State ConvergenceState Plan``): a fixed ``num_passes`` coordinate
-    sweep over the pool (``g_max_refine``), window (``integration_semiangle``) and tilt
-    (``rocking_curve_sampling``) knobs, each driven by :func:`converge_scalar` to the first knob value whose
-    *consecutive-simulation* R-factor drops below ``tolerance.r_factor_threshold`` (a numerical
-    resolution study, not an accuracy fit -- so it needs ``refinement``, unlike the pure-geometry
-    coverage phase). Pass 1 sweeps
-    pool -> tilt -> window; pass 2+ sweeps tilt -> pool -> window (a per-pass
-    order-swap, revisiting each knob after the others moved). Each settled scalar threads into the
-    next sweep
-    and the next pass via the running ``(g_max_refine, integration_semiangle, rocking_curve_sampling)``.
-
-    Every candidate is a full simulation Plan rebuilt from the three scalars
-    (:func:`_stability_build` -- pool + window via :func:`_windowed_pool`, then rocking-curve tilt
-    integration), so the sweeps are a pure function of the knobs, never an incrementally-mutated
-    Plan. ``selection`` supplies the
-    fixed ``rsg`` / ``dsg`` / ``geometry`` and ``rocking`` the fixed tilt span + geometry; their
-    ``integration.semiangle`` / ``sampling`` are ignored -- the live values come from ``state``.
-    Returns the self-stable ``Plan`` and settled :class:`ConvergenceState`. ``g_max_refine_step`` /
-    ``integration_semiangle_step`` / ``rocking_curve_sampling_step`` must be positive and ``num_passes`` at least 1.
-    """
-    if g_max_refine_step <= 0.0:
-        raise ValueError("g_max_refine_step must be positive")
-    if integration_semiangle_step <= 0.0:
-        raise ValueError("integration_semiangle_step must be positive")
-    if rocking_curve_sampling_step <= 0.0:
-        raise ValueError("rocking_curve_sampling_step must be positive")
-    if num_passes < 1:
-        raise ValueError("num_passes must be at least 1")
-
-    measure = simulation_rfactor(refinement, method=method)
     steps = {
-        "pool": g_max_refine_step,
-        "window": integration_semiangle_step,
-        "tilt": rocking_curve_sampling_step,
+        "g_max": test.g_max_step,
+        "sg_max": test.sg_max_step,
+        "tilt_steps": float(test.tilt_steps_step),
     }
+    reciprocal_basis = np.asarray(plan.structure_factor_grid.reciprocal_basis, dtype=np.float64)
+    scored_g_max = max(
+        float(
+            np.linalg.norm(
+                np.asarray(op.beam_hkl, dtype=np.float64) @ reciprocal_basis,
+                axis=1,
+            ).max()
+        )
+        for op in require_orientation_plans(plan)
+    )
+    comparison_hkl: tuple[Tensor, ...] | None = None
 
-    def sweep(
-        g_max_refine: float, integration_semiangle: float, tilt: float, *, knob: str
-    ) -> float:
-        def build(value: float) -> Plan:
-            return _stability_build(
-                plan,
-                value if knob == "pool" else g_max_refine,
-                value if knob == "window" else integration_semiangle,
-                value if knob == "tilt" else tilt,
-                selection,
-                rocking,
+    def build(g_max: float, sg_max: float, tilt_steps: float) -> Plan:
+        grid = StructureFactorGrid.from_cell_for_beam_cutoff(
+            np.asarray(plan.structure_factor_grid.cell, dtype=np.float64),
+            max(g_max, scored_g_max),
+        )
+        expanded = replace(
+            plan,
+            structure_factor_grid=grid,
+            orientations=tuple(
+                OrientationPlan.build(
+                    grid,
+                    np.asarray(op.beam_hkl, dtype=np.int64),
+                    op.pattern,
+                    energy=op.energy,
+                    thickness=op.thickness,
+                    u0=op.u0,
+                    orientation=op.orientation,
+                    tilt_reduction=op.tilt_reduction,
+                )
+                for op in require_orientation_plans(plan)
+            ),
+        )
+        integrated = integrate_rocking_curve(
+            replace(rocking, sampling=int(round(tilt_steps)))
+        )(expanded)
+        coupled = couple_beams(
+            replace(simulation, g_max=g_max, sg_max=sg_max)
+        )(integrated)
+        if comparison_hkl is None:
+            return coupled
+        orientations = tuple(
+            _include_fixed_hkl(coupled.structure_factor_grid, op, fixed)
+            for op, fixed in zip(
+                require_built_plans(coupled), comparison_hkl, strict=True
+            )
+        )
+        return replace(coupled, orientations=orientations)
+
+    values = {
+        "g_max": state.g_max,
+        "sg_max": state.sg_max,
+        "tilt_steps": float(state.tilt_steps),
+    }
+    initial_plan = build(**values)
+    comparison_hkl = tuple(op.alignment.hkl for op in require_built_plans(initial_plan))
+    n_compared_hkl = sum(int(hkl.shape[0]) for hkl in comparison_hkl)
+    measure = simulation_rfactor(
+        refinement,
+        method=method,
+        comparison_hkl=comparison_hkl,
+    )
+
+    for pass_index in range(test.num_passes):
+        logger.report(
+            ConvergencePassStarted(
+                pass_index=pass_index + 1,
+                g_max=values["g_max"],
+                sg_max=values["sg_max"],
+                tilt_steps=int(round(values["tilt_steps"])),
+                r_factor_threshold=tolerance.r_factor_threshold,
+                n_orientations=len(comparison_hkl),
+            )
+        )
+        order = (
+            ("g_max", "tilt_steps", "sg_max")
+            if pass_index == 0
+            else ("tilt_steps", "g_max", "sg_max")
+        )
+        for control in order:
+            logger.report(
+                ConvergenceSweepStarted(control=control, pass_index=pass_index + 1)
+            )
+            start = values[control]
+            trial_index = 0
+
+            def compare(
+                previous: float,
+                candidate: float,
+                *,
+                name: str = control,
+                pass_number: int = pass_index + 1,
+            ) -> float:
+                nonlocal trial_index
+                previous_values = {**values, name: previous}
+                candidate_values = {**values, name: candidate}
+                r_factor = measure(
+                    build(**previous_values),
+                    build(**candidate_values),
+                )
+                logger.report(
+                    ConvergenceTrial(
+                        control=name,
+                        trial_index=trial_index,
+                        pass_index=pass_number,
+                        previous=previous,
+                        candidate=candidate,
+                        r_factor=r_factor,
+                        n_compared_hkl=n_compared_hkl,
+                    )
+                )
+                trial_index += 1
+                return r_factor
+
+            values[control] = converge_scalar(
+                lambda value: value,
+                compare,
+                tolerance,
+                start=start,
+                step=steps[control],
+                accept_converged_candidate=False,
             )
 
-        start = {"pool": g_max_refine, "window": integration_semiangle, "tilt": tilt}[knob]
-        return converge_scalar(
-            lambda value: value,
-            lambda previous, candidate: measure(build(previous), build(candidate)),
-            tolerance,
-            start=start,
-            step=steps[knob],
-        )
-
-    g_max_refine = state.g_max_refine
-    integration_semiangle = state.integration_semiangle
-    tilt = float(state.rocking_curve_sampling)
-    for pass_idx in range(1, num_passes + 1):
-        order = ("pool", "tilt", "window") if pass_idx == 1 else ("tilt", "pool", "window")
-        for knob in order:
-            settled_value = sweep(g_max_refine, integration_semiangle, tilt, knob=knob)
-            if knob == "pool":
-                g_max_refine = settled_value
-            elif knob == "window":
-                integration_semiangle = settled_value
-            else:
-                tilt = settled_value
-
-    rocking_curve_sampling = int(round(tilt))
     settled = ConvergenceState(
-        g_max_refine=g_max_refine,
-        integration_semiangle=integration_semiangle,
-        rocking_curve_sampling=rocking_curve_sampling,
+        g_max=values["g_max"],
+        sg_max=values["sg_max"],
+        tilt_steps=int(round(values["tilt_steps"])),
     )
-    final = _stability_build(
-        plan, g_max_refine, integration_semiangle, rocking_curve_sampling, selection, rocking
+    return build(settled.g_max, settled.sg_max, settled.tilt_steps), settled
+
+
+def _include_fixed_hkl(
+    grid: StructureFactorGrid,
+    orientation: OrientationPlan | CoupledOrientationPlan,
+    fixed_hkl: Tensor,
+) -> CoupledOrientationPlan:
+    """Keep the initial scored reflections in every adaptive-union segment."""
+    if not isinstance(orientation, CoupledOrientationPlan):
+        raise TypeError("convergence with segmented unions requires coupled orientation plans")
+    fixed = np.asarray(fixed_hkl, dtype=np.int64)
+    segments: list[tuple[NDArray[np.int64], list[int]]] = [
+        (
+            np.asarray(
+                np.unique(
+                    np.concatenate(
+                        [np.asarray(segment.plan.beam_hkl, dtype=np.int64), fixed],
+                        axis=0,
+                    ),
+                    axis=0,
+                ),
+                dtype=np.int64,
+            ),
+            np.asarray(segment.cover, dtype=np.int64).tolist(),
+        )
+        for segment in orientation.segments
+    ]
+    return CoupledOrientationPlan.build(
+        grid,
+        segments,
+        orientation.pattern,
+        energy=orientation.energy,
+        thickness=orientation.thickness,
+        u0=orientation.u0,
+        orientation=orientation.orientation,
+        tilts=np.asarray(orientation.tilts, dtype=np.float64),
+        tilt_reduction=orientation.tilt_reduction,
+        scored_hkl=fixed,
     )
-    return final, settled
-
-
-def _stability_build(
-    plan: Plan,
-    g_max_refine: float,
-    integration_semiangle: float,
-    rocking_curve_sampling: float,
-    selection: BeamSelection,
-    rocking: RockingCurve,
-) -> Plan:
-    """The full simulation Plan as a pure function of the three self-stability knobs.
-
-    Pool + window via :func:`_windowed_pool` (which fixes the beam SET), then rocking-curve tilt
-    integration at ``rocking_curve_sampling`` on that set. Order matters: the pool/window decide *which*
-    beams, the tilt count integrates the rocking curve over them. Each candidate is a fresh build
-    from ``g_max`` / ``sg_max`` / ``tilt_steps``, never an incrementally-mutated Plan.
-    """
-    pooled = _windowed_pool(plan, g_max_refine, integration_semiangle, selection)
-    tilts = replace(rocking, sampling=int(round(rocking_curve_sampling)))
-    return integrate_rocking_curve(tilts)(pooled)
-
-
-def _windowed_pool(
-    plan: Plan,
-    g_max_refine: float,
-    integration_semiangle: float,
-    selection: BeamSelection,
-) -> Plan:
-    """Re-seed the pool at ``g_max_refine`` and apply the window ``integration_semiangle``.
-
-    The driver's build step, over :func:`~diffBloch.preprocess.steps.beams.reseed_pool` (the shared
-    reseed-and-window builder, which also carries the ``Fgb`` difference-support guard). Unlike the
-    standalone pool levers, the driver *varies the window too*, so it overrides
-    ``selection.integration.semiangle`` with the swept value before delegating.
-    """
-    windowed = replace(
-        selection, integration=replace(selection.integration, semiangle=integration_semiangle)
-    )
-    return reseed_pool(plan, windowed, g_max_refine=g_max_refine)

--- a/src/diffBloch/preprocess/steps/convergence.py
+++ b/src/diffBloch/preprocess/steps/convergence.py
@@ -77,6 +77,7 @@ def simulation_rfactor(
     refinement: RefinementSetup,
     *,
     method: SolverMethod = "matrix_exp",
+    comparison_hkl: tuple[Tensor, ...] | None = None,
 ) -> SimulationRfactor:
     """Return ``(previous, current) -> float``: the mean consecutive-simulation R-factor.
 
@@ -98,10 +99,14 @@ def simulation_rfactor(
         current_solutions = _simulate(current, refinement, method)
         if len(previous_solutions) != len(current_solutions):
             raise ValueError("convergence check requires the two Plans to share their orientations")
-        r_factors = [
-            _orientation_rfactor(prev, curr)
-            for prev, curr in zip(previous_solutions, current_solutions, strict=True)
-        ]
+        if comparison_hkl is not None and len(comparison_hkl) != len(previous_solutions):
+            raise ValueError("comparison_hkl must contain one fixed reflection set per orientation")
+        r_factors = []
+        for index, (prev, curr) in enumerate(
+            zip(previous_solutions, current_solutions, strict=True)
+        ):
+            fixed = None if comparison_hkl is None else comparison_hkl[index]
+            r_factors.append(_orientation_rfactor(prev, curr, comparison_hkl=fixed))
         return float(np.mean(r_factors))
 
     return measure
@@ -137,14 +142,17 @@ def converge_scalar[T](
     *,
     start: float,
     step: float,
+    accept_converged_candidate: bool = True,
 ) -> T:
     """Grow a scalar knob until two consecutive builds stop changing; return the converged object.
 
     The parameter-agnostic convergence driver -- it knows nothing about beams or Plans.
     ``build(value)`` rebuilds the object at a knob value; ``measure(previous, candidate)`` is the
     consecutive-output R-factor (0 when identical). Starting from ``start`` and clicking by ``step``
-    each iteration, it returns the first candidate whose R-factor against the previous build is
-    below ``tolerance.r_factor_threshold``. The stopping rule is deliberately simple -- the first
+    each iteration, it stops at the first candidate whose R-factor against the previous build is
+    below ``tolerance.r_factor_threshold``. By default it returns that candidate;
+    ``accept_converged_candidate=False`` retains the previous value instead. The stopping rule is
+    deliberately simple -- the first
     dip stops the sweep, and an unchanged build (R = 0) counts as converged -- with no patience and
     no null-step handling. Raises
     ``RuntimeError`` if ``tolerance.max_iterations`` steps pass without a dip below threshold
@@ -157,9 +165,9 @@ def converge_scalar[T](
         value += step
         candidate = build(value)
         r = measure(current, candidate)
-        current = candidate
         if r < tolerance.r_factor_threshold:
-            return current
+            return candidate if accept_converged_candidate else current
+        current = candidate
     raise RuntimeError(f"converge_scalar did not converge within {tolerance.max_iterations} steps")
 
 
@@ -297,7 +305,12 @@ def _simulate(
     return build_engine(plan, refinement, method=method).simulate(refinement.params)
 
 
-def _orientation_rfactor(previous: BlochSolution, current: BlochSolution) -> float:
+def _orientation_rfactor(
+    previous: BlochSolution,
+    current: BlochSolution,
+    *,
+    comparison_hkl: Tensor | None = None,
+) -> float:
     """Scale-optimised ``rbragg`` between two simulations on their shared reflections.
 
     Each table is ``(T, N)`` over its own beam set; the beam sets differ between the two
@@ -305,12 +318,50 @@ def _orientation_rfactor(previous: BlochSolution, current: BlochSolution) -> flo
     scale (shared across thicknesses, matching ``optimal_scale``) maps ``current`` onto ``previous``
     before the R-factor, since the two simulations have no common normalization.
     """
-    previous_index, current_index = _shared_reflections(previous.beam_hkl, current.beam_hkl)
+    if comparison_hkl is None:
+        previous_index, current_index = _shared_reflections(
+            previous.beam_hkl, current.beam_hkl
+        )
+    else:
+        previous_index, current_index = _fixed_reflections(
+            previous.beam_hkl,
+            current.beam_hkl,
+            comparison_hkl,
+        )
     previous_intensity = previous.intensities.detach().cpu()[:, previous_index].reshape(-1)
     current_intensity = current.intensities.detach().cpu()[:, current_index].reshape(-1)
     sigmas = torch.full_like(previous_intensity, _UNWEIGHTED_SIGMA)
     _, r_value = optimal_scale(current_intensity, previous_intensity, sigmas, metric=rbragg)
     return float(r_value)
+
+
+def _fixed_reflections(
+    previous_hkl: Tensor,
+    current_hkl: Tensor,
+    comparison_hkl: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Index the same preselected HKLs in two consecutive simulations."""
+    previous_position = {
+        tuple(row): index for index, row in enumerate(previous_hkl.detach().cpu().numpy())
+    }
+    current_position = {
+        tuple(row): index for index, row in enumerate(current_hkl.detach().cpu().numpy())
+    }
+    targets = comparison_hkl.detach().cpu().numpy()
+    missing = [
+        tuple(int(component) for component in row)
+        for row in targets
+        if tuple(row) not in previous_position or tuple(row) not in current_position
+    ]
+    if missing:
+        raise ValueError(
+            "fixed convergence comparison reflections must remain in every simulation; "
+            f"first missing hkl {missing[0]}"
+        )
+    return (
+        torch.tensor([previous_position[tuple(row)] for row in targets]),
+        torch.tensor([current_position[tuple(row)] for row in targets]),
+    )
 
 
 def _shared_reflections(previous_hkl: Tensor, current_hkl: Tensor) -> tuple[Tensor, Tensor]:

--- a/tests/e2e/test_convergence_anchor.py
+++ b/tests/e2e/test_convergence_anchor.py
@@ -42,7 +42,7 @@ pytestmark = pytest.mark.e2e
 FIXTURE_ROOT = Path(__file__).parent.parent / "fixtures" / "quartz_anchor"
 
 # The sampling=1, step=2 sweep at the private's 0.005 threshold converges the full-99 integrated
-# quartz pattern at 39 tilts (deterministic: CPU / float64 / no RNG). Pinned exactly as a
+# quartz pattern at 39 tilts (repeatable: CPU / float64 / no RNG). Pinned exactly as a
 # characterization; the durable scientific claim -- 39 < the reference 42, and well above a
 # spurious low-tilt dip -- is asserted separately so a cross-platform eigensolver shift of +/-1 tilt
 # would flag the exact pin without hiding the finding.
@@ -53,11 +53,11 @@ SWEEP_STEP = 2.0
 def test_quartz_sampling_convergence() -> None:
     cfg, _lock = load_experiment(FIXTURE_ROOT)
     structure = read_structure(FIXTURE_ROOT / cfg.inputs.structure)
-    observations = read_observations(FIXTURE_ROOT / cfg.inputs.observations)
+    observations = read_observations(FIXTURE_ROOT / cfg.inputs.exp_data)
     setup = from_experiment(structure, observations, cfg)
 
     plan = setup.plans.combined
-    reference_sampling = cfg.numerics.rocking_curve_sampling  # 42, the reference's tilt count
+    reference_sampling = cfg.blochwave.rocking_curve_sampling  # 42, the reference's tilt count
     subset_env = os.environ.get("DIFFBLOCH_ANCHOR_ROTATIONS")
     n_rotations = int(subset_env) if subset_env else len(plan.orientations)
     if not 1 <= n_rotations <= len(plan.orientations):
@@ -66,10 +66,12 @@ def test_quartz_sampling_convergence() -> None:
 
     # Select the beam set once, build it, then sweep the tilt count from a single static solve
     # (sampling=1) upward until consecutive integrated simulations agree to the tolerance.
-    seed = build_orientation_plans()(select_beams(cfg.numerics.to_beam_selection())(plan))
-    rocking = replace(cfg.numerics.to_rocking_curve(), sampling=1)
+    seed = build_orientation_plans()(
+        select_beams(cfg.blochwave.to_beam_selection(setup.integration))(plan)
+    )
+    rocking = replace(cfg.blochwave.to_rocking_curve(setup.integration), sampling=1)
     converge = converge_sampling(
-        rocking, setup.refinement, ConvergenceTolerance(), step=SWEEP_STEP, method=cfg.solver.refine
+        rocking, setup.refinement, ConvergenceTolerance(), step=SWEEP_STEP, method=cfg.blochwave.solver.refine
     )
     converged = converge(seed)
     # One beam plan is built per tilt, so the beam-plan count is the converged tilt count.

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -198,6 +198,36 @@ def test_run_infer_missing_experiment_reports_concise_error(
     assert "Traceback" not in err
 
 
+def test_run_converge_delegates_and_reports(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_converge_experiment(
+        experiment_dir: str,
+        *,
+        logger: object,
+        device: object,
+        n_orientations: int,
+    ) -> SimpleNamespace:
+        assert experiment_dir == "/some/experiment"
+        assert isinstance(logger, ConsoleLogger)
+        assert device == "cuda"
+        assert n_orientations == 1
+        return SimpleNamespace(g_max=2.5, sg_max=0.02, tilt_steps=46)
+
+    monkeypatch.setattr("diffBloch.app.cli.converge_experiment", fake_converge_experiment)
+
+    assert main(["run", "converge", "/some/experiment"]) == 0
+    assert capsys.readouterr().out == (
+        "========================================\n"
+        "HYPERPARAMETER OPTIMIZATION RESULT\n"
+        "gmax: 2.5\n"
+        "sgmax: 0.02\n"
+        "tilt_steps: 46\n"
+        "========================================\n"
+        "optimized_hyperparams gmax=2.5 sgmax=0.02 tilt_steps=46\n"
+    )
+
+
 class _FakePlan:
     """Minimal stand-in for a settled Plan: enough for the CLI's summary line."""
 
@@ -239,7 +269,7 @@ def test_run_preprocess_delegates_and_reports_without_scoring(
     assert captured["dir"] == "/some/experiment"
     assert isinstance(captured["logger"], ConsoleLogger)  # console on by default (no --quiet)
     assert captured["checkpoint"] is True and captured["refresh"] is False
-    assert captured["workers"] == 1 and captured["device"] is None
+    assert captured["workers"] == 1 and captured["device"] == "cuda"
     out = capsys.readouterr().out
     assert "preprocessed 2 rotations" in out
     assert "fit_orientation, fit_thickness" in out  # recipe echoed; no R_obs (no scoring)

--- a/tests/unit/test_coupling.py
+++ b/tests/unit/test_coupling.py
@@ -39,7 +39,7 @@ def _grid_and_tilts() -> tuple[StructureFactorGrid, np.ndarray]:
     cfg, _ = load_experiment(FIXTURE_ROOT)
     structure = read_structure(FIXTURE_ROOT / cfg.inputs.structure)
     grid = StructureFactorGrid.from_cell_for_beam_cutoff(
-        structure.unit_cell, cfg.preprocess.coupling.g_max
+        structure.unit_cell, cfg.blochwave.g_max
     )
     tilts = np.load(REPLAY_ROOT / "tilts.npz")["tilts"]
     return grid, tilts
@@ -49,7 +49,7 @@ def _compute(rotation: int) -> tuple[tuple[Segment, ...], np.lib.npyio.NpzFile]:
     grid, tilts = _grid_and_tilts()
     d = np.load(REPLAY_ROOT / f"rot_{rotation}.npz")
     segments = build_coupling_segments(
-        SegmentedUnionCoupling(),
+        SegmentedUnionCoupling(union_adaptive=False),
         np.asarray(grid.structure_factor_hkl),
         cell=np.asarray(grid.cell),
         orientation=d["orientation"],

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -1,219 +1,62 @@
-"""Slice 6: the convergence driver's coverage + self-stability phases.
-
-``run_coverage_phase`` grows the pool then the window to the coverage-maximising minimum (pure
-geometry); ``run_stability_phase`` grows all three knobs (pool / window / tilt) to consecutive-
-simulation self-stability over a fixed ``num_passes`` coordinate sweep with the private's per-pass
-order-swap. Both are ``(Plan, ConvergenceState) -> (Plan, ConvergenceState)`` computations,
-exercised on the fast synthetic cube from ``tests.unit.synthetic``: for coverage a narrow start
-window drives the
-*window* sweep (the pool is starved), a wider start window drives the *pool* sweep; for stability
-the settled scalars and their monotone growth across passes are pinned from an empirical probe.
-"""
+"""Simulation convergence over g_max, sg_max, and rocking-curve tilt steps."""
 
 from __future__ import annotations
 
 import pytest
-from tests.unit.synthetic import beam_count, seed_system
+from tests.unit.synthetic import built_seed_system
 
-from diffBloch.preprocess.driver import (
-    ConvergenceState,
-    _windowed_pool,
-    converge_numerics,
-    run_coverage_phase,
-    run_stability_phase,
-)
-from diffBloch.preprocess.steps.coverage import plan_coverage
+from diffBloch.engine.plan import CoupledOrientationPlan
+from diffBloch.preprocess.driver import ConvergenceState, converge_numerics, run_convergence
 from diffBloch.specs import (
-    BeamSelection,
     ConvergenceTest,
     ConvergenceTolerance,
     IntegrationGeometry,
     RockingCurve,
+    SegmentedUnionCoupling,
 )
 
-_SELECTION = BeamSelection(
-    integration=IntegrationGeometry(semiangle=1.0)
-)  # rsg/dsg/geometry fixed; angle from state
+_ROCKING = RockingCurve(sampling=3, integration=IntegrationGeometry(semiangle=0.5))
+_SIMULATION = SegmentedUnionCoupling(
+    fixed_n_segments=2,
+    g_max=0.5,
+    sg_max=0.01,
+)
+_TEST = ConvergenceTest(
+    g_max_step=0.1,
+    sg_max_step=0.005,
+    tilt_steps_step=2,
+    num_passes=1,
+)
+_TOLERANCE = ConvergenceTolerance(r_factor_threshold=2.0, max_iterations=2)
 
 
-def _coverage(plan, g_max_refine: float, integration_semiangle: float) -> int:
-    return plan_coverage(_windowed_pool(plan, g_max_refine, integration_semiangle, _SELECTION))
-
-
-def test_coverage_phase_window_sweep_grows_the_window_when_the_pool_is_narrow() -> None:
-    _, seed = seed_system()
-    # Narrow start window: growing the pool adds nothing (the window clips it), so only the window
-    # sweep moves -- 0.68 -> 0.88 -- and the pool is left at its start.
-    start = ConvergenceState(g_max_refine=0.5, integration_semiangle=0.68, rocking_curve_sampling=1)
-    plan, settled = run_coverage_phase(
+def test_convergence_sweeps_g_max_sg_max_and_tilt_steps() -> None:
+    refinement, seed = built_seed_system()
+    plan, settled = run_convergence(
         seed,
-        start,
-        _SELECTION,
-        g_max_refine_step=0.1,
-        integration_semiangle_step=0.2,
-        max_iterations=30,
-    )
-    assert settled.g_max_refine == 0.5
-    assert settled.integration_semiangle == pytest.approx(0.88)
-    assert (
-        settled.rocking_curve_sampling == 1
-    )  # coverage is pure geometry -- tilt passes through untouched
-    assert plan_coverage(plan) == 13
-    assert _coverage(seed, 0.5, 0.68) == 9  # grew coverage 9 -> 13
-
-
-def test_coverage_phase_pool_sweep_grows_the_pool_when_the_window_is_wide() -> None:
-    _, seed = seed_system()
-    # Wider start window: the pool is no longer starved, so the pool sweep moves 0.5 -> 0.9.
-    start = ConvergenceState(g_max_refine=0.5, integration_semiangle=1.2, rocking_curve_sampling=1)
-    plan, settled = run_coverage_phase(
-        seed,
-        start,
-        _SELECTION,
-        g_max_refine_step=0.1,
-        integration_semiangle_step=0.2,
-        max_iterations=30,
-    )
-    assert settled.g_max_refine == pytest.approx(0.9)
-    assert settled.integration_semiangle == 1.2
-    assert plan_coverage(plan) == 39
-    assert _coverage(seed, 0.5, 1.2) == 17  # grew coverage 17 -> 39
-
-
-def test_coverage_phase_returns_the_plan_at_the_settled_scalars() -> None:
-    _, seed = seed_system()
-    start = ConvergenceState(g_max_refine=0.5, integration_semiangle=1.2, rocking_curve_sampling=1)
-    plan, settled = run_coverage_phase(
-        seed,
-        start,
-        _SELECTION,
-        g_max_refine_step=0.1,
-        integration_semiangle_step=0.2,
-        max_iterations=30,
-    )
-    # The returned Plan is exactly the windowed pool at the settled state (the evalState value).
-    assert plan_coverage(plan) == _coverage(
-        seed, settled.g_max_refine, settled.integration_semiangle
-    )
-
-
-def test_coverage_phase_rejects_non_positive_steps() -> None:
-    _, seed = seed_system()
-    start = ConvergenceState(g_max_refine=0.5, integration_semiangle=1.0, rocking_curve_sampling=1)
-    with pytest.raises(ValueError, match="g_max_refine_step must be positive"):
-        run_coverage_phase(
-            seed, start, _SELECTION, g_max_refine_step=0.0, integration_semiangle_step=0.2
-        )
-    with pytest.raises(ValueError, match="integration_semiangle_step must be positive"):
-        run_coverage_phase(
-            seed, start, _SELECTION, g_max_refine_step=0.1, integration_semiangle_step=0.0
-        )
-
-
-# --- run_stability_phase: the fixed num_passes coordinate sweep to consecutive-sim stability ---
-
-_ROCKING = RockingCurve(
-    sampling=1, integration=IntegrationGeometry(semiangle=0.5)
-)  # tilt span/geometry fixed; count from state
-_TOLERANCE = ConvergenceTolerance(r_factor_threshold=0.05, max_iterations=20)
-_START = ConvergenceState(g_max_refine=0.5, integration_semiangle=0.68, rocking_curve_sampling=1)
-
-
-def _stability(refinement, seed, **kwargs):
-    return run_stability_phase(
-        seed,
-        _START,
-        _SELECTION,
+        ConvergenceState(g_max=0.5, sg_max=0.01, tilt_steps=3),
+        _TEST,
         _ROCKING,
+        _SIMULATION,
         refinement,
         _TOLERANCE,
-        g_max_refine_step=kwargs.get("g_max_refine_step", 0.1),
-        integration_semiangle_step=kwargs.get("integration_semiangle_step", 0.2),
-        rocking_curve_sampling_step=kwargs.get("rocking_curve_sampling_step", 2),
-        num_passes=kwargs.get("num_passes", 2),
     )
 
-
-def test_stability_phase_one_pass_settles_all_three_knobs() -> None:
-    refinement, seed = seed_system()
-    # One pass (pool -> tilt -> window): each knob grows to its first below-threshold
-    # consecutive-sim step. Values pinned from an empirical probe of the synthetic cube.
-    plan, settled = _stability(refinement, seed, num_passes=1)
-    assert settled.g_max_refine == pytest.approx(0.6)
-    assert settled.integration_semiangle == pytest.approx(1.08)
-    assert settled.rocking_curve_sampling == 7  # tilt IS tuned here (unlike coverage), 1 -> 7
-    assert beam_count(plan) == 17
-    assert len(plan.orientations[0].tilts) == 7  # returned Plan is built at the settled state
+    assert settled == ConvergenceState(g_max=pytest.approx(0.5), sg_max=0.01, tilt_steps=3)
+    assert isinstance(plan.orientations[0], CoupledOrientationPlan)
+    assert len(plan.orientations[0].tilts) == 3
 
 
-def test_stability_phase_second_pass_revisits_and_grows_the_knobs() -> None:
-    refinement, seed = seed_system()
-    # A second pass (tilt -> pool -> window) revisits each knob after the others moved: every scalar
-    # is >= its one-pass value and at least one strictly grows (the order-swap does work).
-    _, one = _stability(refinement, seed, num_passes=1)
-    _, two = _stability(refinement, seed, num_passes=2)
-    assert two.g_max_refine == pytest.approx(0.7)
-    assert two.integration_semiangle == pytest.approx(1.28)
-    assert two.rocking_curve_sampling == 9
-    assert two.g_max_refine >= one.g_max_refine
-    assert two.integration_semiangle >= one.integration_semiangle
-    assert two.rocking_curve_sampling >= one.rocking_curve_sampling
+def test_converge_numerics_returns_a_pure_plan_step() -> None:
+    refinement, seed = built_seed_system()
+    converged = converge_numerics(
+        _TEST,
+        _ROCKING,
+        _SIMULATION,
+        refinement,
+        _TOLERANCE,
+    )(seed)
 
-
-def test_stability_phase_rejects_bad_steps_and_passes() -> None:
-    refinement, seed = seed_system()
-    with pytest.raises(ValueError, match="g_max_refine_step must be positive"):
-        _stability(refinement, seed, g_max_refine_step=0.0)
-    with pytest.raises(ValueError, match="integration_semiangle_step must be positive"):
-        _stability(refinement, seed, integration_semiangle_step=0.0)
-    with pytest.raises(ValueError, match="rocking_curve_sampling_step must be positive"):
-        _stability(refinement, seed, rocking_curve_sampling_step=0.0)
-    with pytest.raises(ValueError, match="num_passes must be at least 1"):
-        _stability(refinement, seed, num_passes=0)
-
-
-# --- converge_numerics: the operation dispatch + evalState boundary (the public driver entry) ---
-
-_SEL_NARROW = BeamSelection(
-    integration=IntegrationGeometry(semiangle=0.68)
-)  # narrow window start, as in the probes
-
-
-def _numerics(refinement, seed, operation: str):
-    test = ConvergenceTest(
-        operation=operation,
-        start_g_max_refine=0.5,
-        g_max_refine_step=0.1,
-        integration_semiangle_step=0.2,
-        rocking_curve_sampling_step=2,
-        num_passes=2,
-    )
-    return converge_numerics(test, _SEL_NARROW, _ROCKING, refinement, _TOLERANCE)(seed)
-
-
-def test_converge_numerics_coverage_runs_only_the_coverage_phase() -> None:
-    refinement, seed = seed_system()
-    # coverage grows pool+window (13 beams) but leaves the tilt count untouched -- no rocking
-    # integration -- so the returned Plan keeps its single nominal tilt (unlike the two below).
-    plan = _numerics(refinement, seed, "coverage")
-    assert beam_count(plan) == 13
-    assert len(plan.orientations[0].tilts) == 1
-
-
-def test_converge_numerics_self_stability_runs_only_the_stability_phase() -> None:
-    refinement, seed = seed_system()
-    # self_stability grows all three knobs to consecutive-sim stability: 27 beams, 9 rocking tilts.
-    plan = _numerics(refinement, seed, "self_stability")
-    assert beam_count(plan) == 27
-    assert len(plan.orientations[0].tilts) == 9
-
-
-def test_converge_numerics_both_chains_coverage_into_stability() -> None:
-    refinement, seed = seed_system()
-    # both = coverage then stability seeded from coverage's settled scalars; it runs the stability
-    # phase (so it grows past coverage's 13 beams / 1 tilt), landing at 27 beams / 9 tilts here.
-    plan = _numerics(refinement, seed, "both")
-    assert beam_count(plan) == 27
-    assert len(plan.orientations[0].tilts) == 9
-    # the seed is untouched (converge_numerics is a pure Plan -> Plan step)
-    assert beam_count(seed) == 343
+    assert isinstance(converged.orientations[0], CoupledOrientationPlan)
+    assert len(converged.orientations[0].tilts) == 3
+    assert not isinstance(seed.orientations[0], CoupledOrientationPlan)

--- a/tests/unit/test_select_beams.py
+++ b/tests/unit/test_select_beams.py
@@ -23,7 +23,8 @@ def _quartz_train_plan():
     structure = read_structure(QUARTZ / "enantiomer_1.cif")
     observations = read_observations(QUARTZ / "exp_data.cif_pets")
     config = load_config(QUARTZ / "experiment.yaml")
-    return from_experiment(structure, observations, config).plans.train, config
+    setup = from_experiment(structure, observations, config)
+    return setup.plans.train, config, setup.integration
 
 
 # --- the criterion --------------------------------------------------------------------------------
@@ -71,8 +72,8 @@ def test_klar_mask_rejects_non_3_column_g() -> None:
 
 
 def test_select_beams_prunes_each_orientation_keeping_000_and_pattern() -> None:
-    plan, config = _quartz_train_plan()
-    step = select_beams(config.numerics.to_beam_selection())
+    plan, config, integration = _quartz_train_plan()
+    step = select_beams(config.blochwave.to_beam_selection(integration))
     pruned = step(plan)
 
     # Plan -> Plan: the shared grid object is preserved; a new Plan is returned.
@@ -96,8 +97,8 @@ def test_select_beams_prunes_each_orientation_keeping_000_and_pattern() -> None:
 
 
 def test_select_beams_preserves_source_and_defers_the_build() -> None:
-    plan, config = _quartz_train_plan()
-    pruned = select_beams(config.numerics.to_beam_selection())(plan)
+    plan, config, integration = _quartz_train_plan()
+    pruned = select_beams(config.blochwave.to_beam_selection(integration))(plan)
     before = plan.orientations[0]
     after = pruned.orientations[0]
     # Source is preserved; select_beams stays on the candidate phase -- no gather is built here.


### PR DESCRIPTION
Adds verbose convergence testing over g_max, sg_max, and rocking-curve tilt steps, using fixed comparison reflections and a configurable number of orientations.