### PR TITLE
Restore orientation controls and improve refinement reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Use `infer` to score a settled `Plan` without changing parameters; use `refine` 
 trainable structural parameters. Checkpointed examples include `plan.npz` + `plan.lock`, so they can
 reuse expensive preprocessing instead of rebuilding the `Plan` from scratch.
 
+The default refinement runs for 40 epochs and streams `wR2`, `R_obs`, and diffraction loss. Its
+completion summary identifies the best epoch, shows matched observed / total matched HKLs, and
+writes `refined_structure.cif`, `refined_parameters.npz`, and `refinement_summary.json` beside the
+experiment.
+
 See `examples/experiments/quartz/README.md` for the worked example and its expected residual.
 
 ## Examples

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,11 +48,8 @@ from diffBloch.preprocess import (
     fit_orientation,
     fit_thickness,
     from_experiment,
-    integrate_rocking_curve,
-    mosaicity,
     pipeline,
     run_inference,
-    select_beams,
 )
 from diffBloch.specs import ScoredHklSelection, TrialCoupling
 
@@ -61,7 +58,7 @@ root = Path("examples/experiments/quartz-checkpoint")
 # Boundary: parse experiment.yaml, verify experiment.lock, and read typed CIF/PETS records.
 cfg, experiment_lock = load_experiment(root)
 structure = read_structure(root / cfg.inputs.structure, load_hydrogens=cfg.inputs.load_hydrogens)
-observations = read_observations(root / cfg.inputs.observations)
+observations = read_observations(root / cfg.inputs.exp_data)
 
 # Effects stay at the edge: loggers consume typed events from preprocessing/refinement.
 logger = MultiLogger((ConsoleLogger(), CSVLogger(root / "events.csv")))
@@ -71,31 +68,33 @@ setup = from_experiment(structure, observations, cfg)
 
 # Scientific choices are explicit typed values, not a string registry or hidden CLI behavior.
 trial_coupling = TrialCoupling(
-    policy=cfg.preprocess.coupling.to_policy(),
+    policy=cfg.blochwave.to_policy(),
     scored=ScoredHklSelection(
-        klar=cfg.numerics.to_beam_selection(setup.integration),
-        g_max=cfg.numerics.g_max_refine,
+        klar=cfg.blochwave.to_beam_selection(setup.integration),
+        g_max=cfg.blochwave.g_max_refine,
     ),
 )
 
 # Preprocessing is declarative composition of Plan -> Plan steps.
 prepare = pipeline(
     [
-        select_beams(cfg.numerics.to_beam_selection(setup.integration)),
-        build_orientation_plans(),
-        integrate_rocking_curve(cfg.numerics.to_rocking_curve(setup.integration)),
-        mosaicity(cfg.numerics.mosaicity),
+        build_orientation_plans(
+            cfg.blochwave.to_rocking_curve(setup.integration),
+            cfg.blochwave.mosaicity,
+            coupling=cfg.blochwave.to_policy(),
+            scoring_selection=cfg.blochwave.to_beam_selection(setup.integration),
+        ),
         fit_orientation(
             setup.refinement,
             cfg.preprocess.orientation.to_search(),
-            method=cfg.solver.refine,
+            method=cfg.blochwave.solver.refine,
             coupling=trial_coupling,
             logger=logger,
         ),
         fit_thickness(
             setup.refinement,
             cfg.preprocess.thickness.to_grid(),
-            method=cfg.solver.refine,
+            method=cfg.blochwave.solver.refine,
             logger=logger,
         ),
     ],
@@ -104,14 +103,19 @@ prepare = pipeline(
 plan = prepare(setup.plans.combined)
 
 # Inference is the terminal score-only path: same settled Plan, no optimizer updates.
-inference = run_inference(plan, setup.refinement, method=cfg.solver.inference, logger=logger)
+inference = run_inference(
+    plan,
+    setup.refinement,
+    method=cfg.blochwave.solver.inference,
+    logger=logger,
+)
 
 # Refinement composes a pure engine/context with model/problem values, then runs the optimizer shell.
 engine = build_engine(
     plan,
     setup.refinement,
     loss=cfg.refinement.objective.to_loss(),
-    method=cfg.solver.refine,
+    method=cfg.blochwave.solver.refine,
     precision=cfg.refinement.precision,
 )
 model = build_refinement_model(initial=setup.refinement.params)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -14,6 +14,10 @@ Runs preprocessing and refinement from the ordinary quartz example directory.
 uv run diffbloch run refine examples/experiments/quartz
 ```
 
+The live refinement line reports `wR2`, `R_obs`, and diffraction loss for each epoch. The final
+summary identifies the best epoch, reports matched observed / total matched HKLs, and lists the
+refined CIF, raw parameter snapshot, JSON summary, and plan artifacts.
+
 ### Quartz, checkpointed
 
 Starts from a committed `plan.npz` + `plan.lock`, so it skips preprocessing and reaches refinement
@@ -38,6 +42,7 @@ The example YAMLs choose:
 ```yaml
 refinement:
   precision: fp32
+  steps: 40
 ```
 
 That makes example refines faster and lighter. Switch to `fp64` for the conservative

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,10 @@ Use `infer` to run the forward simulation and scoring pass over a settled `Plan`
 structural parameters. Use `refine` to run the optimization loop, repeatedly simulating, scoring,
 and updating the selected trainable structural parameters.
 
+The default refinement runs for 40 epochs, streams `wR2`, `R_obs`, and diffraction loss, then writes
+the best refined CIF, exact raw parameter snapshot, and JSON summary into the experiment directory.
+The CLI prints aligned preprocess/refinement completion summaries and absolute artifact paths.
+
 Python users can compose preprocessing steps, constraints, penalties, and refinement problems
 directly with the public API; the CLI is the friendly default runner, not the only path.
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -62,3 +62,36 @@ Validate a config from the CLI before launching a longer job:
 ```bash
 uv run diffbloch validate examples/experiments/quartz-checkpoint/experiment.yaml
 ```
+
+## Excluding rotations
+
+Exclude damaged, empty, or diagnostic-only frames with zero-based indices in the original PETS
+rotation order:
+
+```yaml
+blochwave:
+  ignore_orientations: [0, 1, 18, 56]
+```
+
+Excluded rotations never enter beam construction, orientation fitting, thickness fitting,
+inference, or structure refinement. Filtering occurs before the train/validation split, and does
+not renumber later source rotations when deciding split membership. The selection changes the
+scientific result, so it is part of the recorded experiment config and invalidates an incompatible
+preprocess checkpoint.
+
+The two fitting stages in the standard preprocess command can be selected independently:
+
+```yaml
+preprocess:
+  optimize_orientation: true
+  optimize_thickness: false
+```
+
+The fixed stage order is orientation fitting followed by thickness fitting when both are enabled.
+
+## Generated refinement artifacts
+
+`run refine` writes `refined_structure.cif`, `refined_parameters.npz`, and
+`refinement_summary.json` into the experiment directory and prints their absolute paths. The CIF
+contains the best epoch's constrained structural values; the NPZ preserves its exact raw optimizer
+parameters.

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -19,7 +19,7 @@ M_i = R_z(\omega_i)R_x(\alpha_i)R_y(\beta_i)(UB)B^{-1},
 
 where {math}`\alpha` is the main varying goniometer angle.
 
-Using a fixed trial thickness and the starting structure, `fit_orientation` searches nearby
+Using a fixed trial thickness and the starting structure, orientation optimization searches nearby
 orientations for better agreement with experiment. Three approaches are available:
 
 | Method | Difference |
@@ -38,8 +38,14 @@ approaches, both using the starting structure to improve agreement with experime
 | Grid search | Selects the best mean thickness independently for each rotation. |
 | Neural network | Learns how apparent thickness varies smoothly with rotation angle. |
 
-Thickness can be refined before or after orientation; the default workflow refines orientation
-first.
+The default workflow optimizes orientation first and thickness second when both stages are enabled.
+Either stage can be disabled independently:
+
+```yaml
+preprocess:
+  optimize_orientation: true
+  optimize_thickness: false
+```
 
 ## The `Plan`
 
@@ -85,9 +91,10 @@ A `Plan` deliberately separates sets of hkls by purpose or origin:
 ## Rocking curves and mosaicity inside a `Plan`
 
 The virtual frame's angular range is represented by tilt sub-orientations around its central
-orientation. `integrate_rocking_curve` replaces a single static orientation with those samples.
-`mosaicity` applies a moving-average broadening along the tilt axis before their intensities are
-summed.
+orientation. In the default app recipe, `build_orientation_plans` constructs those sub-tilts,
+selects each tilt-dependent SOLVE basis from `g_max` and `sg_max`, builds the Bloch geometry, and
+attaches the configured mosaic reduction. Rocking integration and mosaicity are parts of the built
+orientation plan, not separately displayed default stages.
 
 ## API shape: from experiment records to an initial `Plan`
 
@@ -113,16 +120,19 @@ print(refinement_setup.params.asu_positions.shape)
 
 ## `Plan -> Plan` steps
 
-Preprocessing is a composable `Plan -> Plan` pipeline. A `select_beams` step, for example, is a
-function that takes a `Plan` and adjusts its geometry/data scaffold by replacing each rotation's
-candidate beam set with the reflections selected by the beam-selection policy. More generally, any
-function with that shape can be a step: it receives a `Plan`, does one focused piece of work, and
-returns an updated `Plan`.
+Preprocessing is a composable `Plan -> Plan` pipeline. Any function with that shape receives a
+`Plan`, does one focused piece of work, and returns an updated `Plan`.
+
+The default app recipe begins with one displayed `build_orientation_plans` stage. It calculates the
+shared structure-factor support, constructs every central orientation and rocking sub-tilt,
+calculates excitation errors for reciprocal-lattice points inside the solve cutoff, selects the
+tilt-dependent SOLVE beams, builds the Bloch geometry, and matches the selected scoring reflections
+to PETS observations. It does not use experimental presence to choose the SOLVE basis.
 
 Real steps include:
 
-- {func}`diffBloch.preprocess.steps.beams.select_beams` — choose each rotation's candidate solve beams.
-- {func}`diffBloch.preprocess.steps.beams.build_orientation_plans` — build solvable per-orientation beam geometry.
+- {func}`diffBloch.preprocess.steps.beams.build_orientation_plans` — build the default coupled solve geometry, rocking sub-tilts, reduction, and scoring alignment.
+- {func}`diffBloch.preprocess.steps.beams.select_beams` — lower-level tilt-independent candidate selection for custom API pipelines and convergence work; it is not a separate default app stage.
 - {func}`diffBloch.preprocess.steps.rocking_curve.integrate_rocking_curve` — expand orientations into virtual rocking-curve tilts.
 - {func}`diffBloch.preprocess.steps.mosaicity.mosaicity` — apply tilt-axis mosaic broadening.
 - {func}`diffBloch.preprocess.steps.fit_orientation.fit_orientation` — search nearby orientations and keep the best-scoring one.
@@ -138,16 +148,15 @@ the best updated `Plan`.
 
 ## API example: composing simple steps
 
-This example shows the composition shape. It is intentionally small; the full default recipe also
-captures refinement setup, coupling policy, device/precision choices, and logging.
+This example mirrors the default geometry-build shape. The app additionally handles checkpointing,
+device/precision choices, optional fitting stages, and logging.
 
 ```python
 from pathlib import Path
 
 from diffBloch.config import load_experiment
 from diffBloch.io import read_observations, read_structure
-from diffBloch.preprocess import build_orientation_plans, from_experiment, pipeline, select_beams
-from diffBloch.specs import BeamSelection
+from diffBloch.preprocess import build_orientation_plans, from_experiment, pipeline
 
 root = Path("examples/experiments/quartz-checkpoint")
 cfg, _lock = load_experiment(root)
@@ -158,11 +167,23 @@ setup = from_experiment(structure, observations, cfg)
 base_plan = setup.plans.combined
 
 prepare = pipeline([
-    select_beams(BeamSelection()),
-    build_orientation_plans(),
+    build_orientation_plans(
+        cfg.blochwave.to_rocking_curve(setup.integration),
+        cfg.blochwave.mosaicity,
+        coupling=cfg.blochwave.to_policy(),
+        scoring_selection=cfg.blochwave.to_beam_selection(setup.integration),
+    ),
 ])
 
 prepared_plan = prepare(base_plan)
+```
+
+From the CLI, preprocessing prints each completed stage as
+`Preprocess stage N │ Name │ measurements`, then an aligned completion box, the resolved pipeline,
+and the absolute `plan.npz` / `plan.lock` locations:
+
+```bash
+uv run diffbloch run preprocess examples/experiments/quartz --refresh
 ```
 
 ## API example: loading a checkpointed `Plan`

--- a/docs/refinement.md
+++ b/docs/refinement.md
@@ -37,14 +37,40 @@ parameter or every structure-factor calculation float32.
 
 ```bash
 # Full quartz run, including preprocessing.
-diffbloch run refine examples/experiments/quartz
+uv run diffbloch run refine examples/experiments/quartz
 
 # Faster start from a committed preprocessing checkpoint.
-diffbloch run refine examples/experiments/quartz-checkpoint
+uv run diffbloch run refine examples/experiments/quartz-checkpoint
 
 # Larger checkpointed example on CUDA.
-diffbloch run refine examples/experiments/abiraterone-checkpoint --device cuda
+uv run diffbloch run refine examples/experiments/abiraterone-checkpoint --device cuda
 ```
+
+The default refinement budget is 40 epochs. Set a different recorded budget in the experiment
+config:
+
+```yaml
+refinement:
+  steps: 40
+```
+
+Each live epoch reports `wR2`, `R_obs`, and the diffraction loss. Epoch numbering in the CLI starts
+at 1. At completion, the CLI shows the best epoch and its metrics in an aligned summary.
+`HKLs (Observed/total): X / Y` means matched observed reflections / all matched reflections, where
+the observed classification uses the conventional `I > 3 sigma` test internally.
+
+## Refinement outputs
+
+The default app writes the best recorded epoch, not merely the final optimizer state:
+
+| File | Contents |
+|---|---|
+| `refined_structure.cif` | Best constrained coordinates, occupancies, and ADPs in CIF form. |
+| `refined_parameters.npz` | Exact raw optimizer parameters for the best epoch. |
+| `refinement_summary.json` | Best epoch metrics, the compact HKL count, and artifact paths. |
+| `plan.npz` / `plan.lock` | Settled preprocessing plan and its provenance lock. |
+
+The completion summary prints the absolute location of every output.
 
 ## API example: default app refinement
 
@@ -55,6 +81,8 @@ result = refine_experiment("examples/experiments/quartz-checkpoint")
 
 print(result.losses.shape)
 print(result.best_step, result.best_loss)
+print(result.history[result.best_step].wr2)
+print(result.history[result.best_step].r_obs)
 ```
 
 ## Advanced composition: constraints, penalties, and learned thickness

--- a/examples/experiments/quartz/README.md
+++ b/examples/experiments/quartz/README.md
@@ -1,9 +1,8 @@
 # Example: quartz inference
 
-A complete, runnable experiment directory — the published quartz (SiO₂) precession
-electron-diffraction dataset. It is the canonical end-to-end example: given a structure and observed
-intensities, `diffbloch` preprocesses all 99 rotations and scores the full dynamical Bloch-wave
-forward model against the observations.
+A runnable diagnostic configuration for the published quartz (SiO₂) electron-diffraction dataset.
+It currently retains raw PETS rotation 62 only, runs its orientation fit, and skips thickness
+fitting.
 
 ## Files
 
@@ -19,18 +18,30 @@ forward model against the observations.
 From the repository root:
 
 ```bash
-diffbloch run infer examples/experiments/quartz            # ~6–16 min the first time (the fit)
-diffbloch run infer examples/experiments/quartz --console  # stream per-rotation progress
+uv run diffbloch run preprocess examples/experiments/quartz --refresh
 ```
 
-Expected result: **mean R_obs = 0.0506** over the 99 rotations.
-
-The recipe is the faithful default — beam selection, rocking-curve integration, mosaicity, then the
-per-rotation orientation fit **under the private's per-trial beam coupling**, and the thickness fit.
-The orientation fit is the expensive phase, so the first run writes a preprocess checkpoint
+The recipe selects coupled SOLVE beams from `g_max`/`sg_max`, builds the final rocking-curve plans
+(including the configured mosaic reduction), then matches simulator HKLs to PETS observations and
+runs orientation optimization. Thickness optimization is disabled in `experiment.yaml`.
+The orientation fit writes a preprocess checkpoint
 (`plan.npz` + `plan.lock`) into this directory; a second identical run reuses it in seconds. Both
 checkpoint files are gitignored here. Recompute from scratch with `--refresh`, or skip the
 checkpoint entirely with `--no-checkpoint`.
+
+The command prints polished per-stage progress followed by a completion box, the resolved pipeline,
+and the absolute checkpoint paths.
+
+To run the 40-epoch structure refinement and write its best result:
+
+```bash
+uv run diffbloch run refine examples/experiments/quartz
+```
+
+Each epoch reports `wR2`, `R_obs`, and diffraction loss. The completion box reports the best epoch
+and `HKLs (Observed/total)` as matched observed / all matched reflections, then lists
+`refined_structure.cif`, `refined_parameters.npz`, `refinement_summary.json`, `plan.npz`, and
+`plan.lock`.
 
 For a variant that **ships** a pre-computed checkpoint (so the first run is already instant), see the
 sibling `quartz-checkpoint` example. For the checkpoint machinery itself, see the checkpoint/resume

--- a/examples/experiments/quartz/experiment.yaml
+++ b/examples/experiments/quartz/experiment.yaml
@@ -1,10 +1,8 @@
 # Example experiment: quartz (SiO2) electron-diffraction inference.
 #
-# A complete, runnable experiment directory. `diffbloch run infer examples/experiments/quartz` reads
-# this file, verifies the input bytes against `experiment.lock`, preprocesses the 99 rotations (beam
-# selection, rocking-curve integration, mosaicity, then the per-rotation orientation + thickness
-# fits, with the orientation fit under the faithful per-trial beam coupling) and scores the full
-# dynamical Bloch-wave forward model against the observed intensities (mean R_obs = 0.0506).
+# Diagnostic quartz configuration retaining source PETS rotation 62 only. `run preprocess` performs
+# coupled SOLVE-beam selection from g_max/sg_max, final rocking-curve plan construction, and
+# orientation optimization; thickness optimization is disabled below.
 #
 # The inputs are the published quartz precession-electron-diffraction dataset:
 #   quartz.cif                the SiO2 structure (space group P3_1 21)
@@ -19,6 +17,8 @@ sample:
   thicknesses: [820.0] # crystal thickness (Angstrom); fit_thickness refines around this seed
 
 blochwave:
+  # Keep only source PETS rotation 62 (the frame previously reported as combined index 56).
+  ignore_orientations: [] #[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98]
   g_max_refine: 1.6 # seed beam-pool radius / scoring-resolution cap (1/Angstrom)
   rocking_curve_sampling: 42 # tilt samples per rocking curve
   dsg: 0.0015 # Klar beam-selection excitation-error cutoff
@@ -29,6 +29,9 @@ blochwave:
   # values (SegmentedUnionCoupling defaults).
   g_max: 2.25
   sg_max: 0.01
+preprocess:
+  optimize_orientation: true
+  optimize_thickness: false
 refinement:
   precision: fp32
   split:

--- a/src/diffBloch/app/cli.py
+++ b/src/diffBloch/app/cli.py
@@ -27,6 +27,18 @@ from diffBloch.config import load_config, pack_run
 from diffBloch.observability import NULL_LOGGER, Logger, MultiLogger
 
 
+def _print_summary_box(title: str, rows: tuple[tuple[str, str], ...]) -> None:
+    """Print a consistently aligned 62-column completion summary."""
+    width = 62
+    label_width = 22
+    value_width = width - label_width - 3
+    heading = f" {title} "
+    print(f"╭{heading:─^{width}}╮")
+    for label, value in rows:
+        print(f"│ {label:<{label_width}} {value:<{value_width}} │")
+    print(f"╰{'─' * width}╯")
+
+
 def _add_run_flags(parser: argparse.ArgumentParser) -> None:
     """Add the flags shared by ``run infer`` and ``run preprocess`` (same preprocess surface)."""
     parser.add_argument("experiment_directory", help="Path to the experiment directory")
@@ -184,8 +196,22 @@ def main(argv: list[str] | None = None) -> int:
                 raise
             print(f"error: {exc}", file=sys.stderr)
             return 1
-        recipe = ", ".join(record.name for record in plan.provenance)
-        print(f"preprocessed {len(plan.orientations)} rotations; recipe: {recipe}")
+        print()
+        _print_summary_box(
+            "PREPROCESS COMPLETE",
+            (
+                ("Rotations", str(len(plan.orientations))),
+                ("Stages", str(len(plan.provenance))),
+            ),
+        )
+        print()
+        print("Pipeline")
+        for index, record in enumerate(plan.provenance, start=1):
+            print(f"  {index:>2}. {record.name.replace('_', ' ').title()}")
+        print()
+        print("Output files")
+        print(f"  • {'Plan':<20} {(Path(args.experiment_directory) / 'plan.npz').resolve()}")
+        print(f"  • {'Plan Lock':<20} {(Path(args.experiment_directory) / 'plan.lock').resolve()}")
         return 0
 
     if args.command == "run" and args.run_command == "refine":
@@ -208,11 +234,30 @@ def main(argv: list[str] | None = None) -> int:
                 raise
             print(f"error: {exc}", file=sys.stderr)
             return 1
-        print(
-            f"refined {refined.losses.shape[0]} steps; objective "
-            f"{float(refined.losses[0]):.6f} -> {refined.best_loss:.6f} "
-            f"(best at step {refined.best_step})"
+        best = refined.history[refined.best_step]
+        wr2 = "n/a" if best.wr2 is None else f"{best.wr2:.6g}"
+        r_obs = "n/a" if best.r_obs is None else f"{best.r_obs:.6g}"
+        diff_loss = "n/a" if best.diff_loss is None else f"{best.diff_loss:.6g}"
+        counts = refined.reflection_counts
+        print()
+        _print_summary_box(
+            "REFINEMENT COMPLETE",
+            (
+                ("Best epoch", str(refined.best_step + 1)),
+                ("Objective", f"{refined.best_loss:.6g}"),
+                ("wR2", wr2),
+                ("R_obs", r_obs),
+                ("Diffraction loss", diff_loss),
+                (
+                    "HKLs (Observed/total)",
+                    f"{counts['matched_i_gt_3sigma']} / {counts['matched']}",
+                ),
+            ),
         )
+        print()
+        print("Output files")
+        for name, path in refined.artifacts.items():
+            print(f"  • {name.replace('_', ' ').title():<20} {path}")
         return 0
 
     if args.command == "run" and args.run_command == "converge":

--- a/src/diffBloch/app/loggers/__init__.py
+++ b/src/diffBloch/app/loggers/__init__.py
@@ -30,6 +30,7 @@ from diffBloch.observability import (
     Event,
     Logger,
     OrientationFitted,
+    PlanStepCompleted,
     RefinementStep,
     ThicknessFitted,
 )
@@ -103,11 +104,32 @@ class ConsoleLogger:
             )
             return
         if isinstance(event, OrientationFitted):
-            label = f"orientation refinement[orientation_index={event.index}]"
+            label = f"orientation optimization[orientation_index={event.index}]"
         elif isinstance(event, ThicknessFitted):
-            label = f"thickness refinement[orientation_index={event.index}]"
+            label = f"thickness optimization[orientation_index={event.index}]"
         elif isinstance(event, RefinementStep):
-            label = f"structure refinement[refinement_epoch={event.step}]"
+            wr2 = "n/a" if event.wr2 is None else f"{event.wr2:.6f}"
+            r_obs = "n/a" if event.r_obs is None else f"{event.r_obs:.6f}"
+            diff_loss = "n/a" if event.diff_loss is None else f"{event.diff_loss:.6f}"
+            _log.log(
+                self.level,
+                "Refinement epoch %3d │ wR2 %s │ R_obs %s │ diffraction loss %s",
+                event.iteration + 1,
+                wr2,
+                r_obs,
+                diff_loss,
+            )
+            return
+        elif isinstance(event, PlanStepCompleted):
+            stage = event.channel.replace("_", " ").title()
+            _log.log(
+                self.level,
+                "Preprocess stage %2d │ %-27s │ %s",
+                event.index + 1,
+                stage,
+                format_measurements(event),
+            )
+            return
         else:
             label = event.channel if event.step is None else f"{event.channel}[{event.step}]"
         _log.log(self.level, "%s %s", label, format_measurements(event))

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -1,9 +1,10 @@
 """The default experiment runner the ``run infer`` CLI exposes.
 
 :func:`run_experiment` encodes the default recipe as one ordered ``Plan -> Plan`` pipeline:
-plan-shaping (``select_beams`` -> ``integrate_rocking_curve`` -> ``mosaicity``) followed by
-parameter fitting (``fit_orientation`` -> ``fit_thickness``), then ``run_inference`` evaluates it --
-so a caller with an experiment directory gets a full result in one call. It is a
+plan-shaping (``build_orientation_plans``, selecting coupled SOLVE beams from ``g_max``/``sg_max``
+and building rocking geometry plus its reduction) followed by
+the config-enabled parameter fitting stages (orientation, then thickness), then ``run_inference``
+evaluates it -- so a caller with an experiment directory gets a full result in one call. It is a
 *convenience*, not the only path: every step is ordinary public API, so a Python user who wants a
 different composition composes their own ``pipeline([...])`` with ``from_experiment`` +
 ``run_inference`` directly. The CLI stays thin by delegating here and holds no science.
@@ -21,9 +22,13 @@ load/resume go through stdlib ``logging`` (not the domain-observation ``logger``
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import replace
 from pathlib import Path
+
+import gemmi
+import numpy as np
 
 from diffBloch.config import (
     ExperimentConfig,
@@ -47,7 +52,7 @@ from diffBloch.engine import (
 )
 from diffBloch.io import read_observations, read_structure
 from diffBloch.observability import NULL_LOGGER, Logger
-from diffBloch.params import Device
+from diffBloch.params import Device, constrain
 from diffBloch.preprocess import (
     OPAQUE,
     ConvergenceTest,
@@ -59,8 +64,6 @@ from diffBloch.preprocess import (
     fit_thickness,
     fork,
     from_experiment,
-    integrate_rocking_curve,
-    mosaicity,
     pipeline,
     read_plan,
     resolve_recipe,
@@ -331,7 +334,7 @@ def refine_experiment(
     initial = refinement.params if device is None else refinement.params.to(device)
     model = build_refinement_model(initial=initial)
     problem = build_refinement_problem()
-    return run_refinement_model(
+    result = run_refinement_model(
         engine,
         model,
         problem,
@@ -341,6 +344,122 @@ def refine_experiment(
         lr=cfg.refinement.optimizer.lr,
         logger=logger,
     )
+    result = _write_refinement_outputs(root, cfg, refinement, result)
+    return result
+
+
+def _write_refinement_outputs(
+    root: Path,
+    cfg: ExperimentConfig,
+    refinement: RefinementSetup,
+    result: ModelRefinementResult,
+) -> ModelRefinementResult:
+    """Persist the best structure, raw parameter snapshot, and machine-readable summary."""
+    structure_path = (root / "refined_structure.cif").resolve()
+    params_path = (root / "refined_parameters.npz").resolve()
+    summary_path = (root / "refinement_summary.json").resolve()
+    state = constrain(result.best_params, refinement.spec)
+    source_path = root / cfg.inputs.structure
+    document = gemmi.cif.read_file(str(source_path))
+    block = document.sole_block()
+    structure = read_structure(source_path, load_hydrogens=cfg.inputs.load_hydrogens)
+    positions = state.positions.detach().cpu().numpy()
+    occupancies = state.occupancies.detach().cpu().numpy()
+    uij_star = state.uij_star.detach().cpu().numpy()
+    reciprocal_basis = refinement.spec.reciprocal_basis
+    assert reciprocal_basis is not None
+    reciprocal = reciprocal_basis.detach().cpu().numpy()
+    reciprocal_lengths = np.linalg.norm(reciprocal, axis=1)
+    reciprocal_metric = reciprocal @ reciprocal.T
+    atom_loop = block.find_loop("_atom_site_label").get_loop()
+    tags = list(atom_loop.tags)
+    label_column = tags.index("_atom_site_label")
+    atom_rows = {
+        atom_loop.values[row * atom_loop.width() + label_column]: row
+        for row in range(atom_loop.length())
+    }
+    for index, label in enumerate(structure.labels):
+        row = atom_rows[label]
+        updates = {
+            "_atom_site_fract_x": positions[index, 0],
+            "_atom_site_fract_y": positions[index, 1],
+            "_atom_site_fract_z": positions[index, 2],
+            "_atom_site_occupancy": occupancies[index],
+        }
+        if structure.adp.kind[index] == "Uiso":
+            updates["_atom_site_U_iso_or_equiv"] = np.sum(
+                uij_star[index] * reciprocal_metric
+            ) / np.sum(reciprocal_metric * reciprocal_metric)
+        for tag, value in updates.items():
+            if tag in tags:
+                column = tags.index(tag)
+                atom_loop.values[row * atom_loop.width() + column] = f"{float(value):.10g}"
+
+    aniso_column = block.find_loop("_atom_site_aniso_label")
+    if aniso_column:
+        aniso_loop = aniso_column.get_loop()
+        aniso_tags = list(aniso_loop.tags)
+        label_column = aniso_tags.index("_atom_site_aniso_label")
+        aniso_rows = {
+            aniso_loop.values[row * aniso_loop.width() + label_column]: row
+            for row in range(aniso_loop.length())
+        }
+        components = {
+            "_atom_site_aniso_U_11": (0, 0),
+            "_atom_site_aniso_U_22": (1, 1),
+            "_atom_site_aniso_U_33": (2, 2),
+            "_atom_site_aniso_U_12": (0, 1),
+            "_atom_site_aniso_U_13": (0, 2),
+            "_atom_site_aniso_U_23": (1, 2),
+        }
+        scale = reciprocal_lengths[:, None] * reciprocal_lengths[None, :]
+        for index, label in enumerate(structure.labels):
+            if structure.adp.kind[index] != "Uani" or label not in aniso_rows:
+                continue
+            row = aniso_rows[label]
+            uij_cif = uij_star[index] / scale
+            for tag, (i, j) in components.items():
+                if tag in aniso_tags:
+                    column = aniso_tags.index(tag)
+                    aniso_loop.values[row * aniso_loop.width() + column] = (
+                        f"{float(uij_cif[i, j]):.10g}"
+                    )
+    document.write_file(str(structure_path))
+
+    params = result.best_params
+    empty = np.empty((0,), dtype=np.float64)
+    np.savez_compressed(
+        str(params_path),
+        asu_positions=params.asu_positions.detach().cpu().numpy(),
+        uij_raw=empty if params.uij_raw is None else params.uij_raw.detach().cpu().numpy(),
+        u_iso_raw=(empty if params.u_iso_raw is None else params.u_iso_raw.detach().cpu().numpy()),
+        occupancy_raw=(
+            empty if params.occupancy_raw is None else params.occupancy_raw.detach().cpu().numpy()
+        ),
+    )
+
+    best = result.history[result.best_step]
+    artifacts: dict[str, str] = {
+        "refined_structure": str(structure_path),
+        "refined_parameters": str(params_path),
+        "summary": str(summary_path),
+        "plan": str((root / _PLAN_NPZ).resolve()),
+        "plan_lock": str((root / _PLAN_LOCK).resolve()),
+    }
+    summary = {
+        "best_epoch": result.best_step,
+        "objective": result.best_loss,
+        "wr2": best.wr2,
+        "r_obs": best.r_obs,
+        "diff_loss": best.diff_loss,
+        "total_hkl": (
+            f"{result.reflection_counts['matched_i_gt_3sigma']} / "
+            f"{result.reflection_counts['matched']}"
+        ),
+        "artifacts": artifacts,
+    }
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n")
+    return replace(result, artifacts=artifacts)
 
 
 def _preprocess(
@@ -399,8 +518,10 @@ def _recipe_steps(
 ) -> list[PlanStep]:
     """The default recipe as an inspectable step list (its provenance keys the lock).
 
-    The orientation fit runs under per-trial coupling (:func:`_trial_coupling`). The tilt-independent
-    fit is not offered here; compose it directly if needed.
+    ``preprocess.optimize_orientation`` and ``preprocess.optimize_thickness`` select which fitting
+    stages join the fixed recipe order. When enabled, the orientation fit runs under per-trial
+    coupling (:func:`_trial_coupling`). The tilt-independent fit is not offered here; compose it
+    directly if needed.
 
     The fit tail is a :func:`~diffBloch.preprocess.fork` on unit-cell volume: a **large cell**
     (> ``_LARGE_CELL_THRESHOLD_A3``) takes the coarse fp32 search with the gather integrity checks
@@ -447,23 +568,31 @@ def _recipe_steps(
             logger=logger,  # per-rotation thickness-fit progress (the memory-heavy tail phase)
         )
 
-    return [
-        select_beams(cfg.blochwave.to_beam_selection(integration)),
-        build_orientation_plans(),
-        integrate_rocking_curve(cfg.blochwave.to_rocking_curve(integration)),
-        mosaicity(cfg.blochwave.mosaicity),
-        fork(
-            lambda grid: grid.cell_volume > _LARGE_CELL_THRESHOLD_A3,
-            when_true=[  # large cell: coarse fp32 search, integrity checks skipped
-                orientation_fit(precision="fp32", validate=False),
-                thickness_fit(precision="fp32"),
-            ],
-            when_false=[  # small cell: exact fp64 path
-                orientation_fit(precision="fp64", validate=True),
-                thickness_fit(precision="fp64"),
-            ],
+    steps: list[PlanStep] = [
+        build_orientation_plans(
+            cfg.blochwave.to_rocking_curve(integration),
+            cfg.blochwave.mosaicity,
+            coupling=cfg.blochwave.to_policy(),
+            scoring_selection=cfg.blochwave.to_beam_selection(integration),
         ),
     ]
+    small_cell_fits: list[PlanStep] = []
+    large_cell_fits: list[PlanStep] = []
+    if cfg.preprocess.optimize_orientation:
+        small_cell_fits.append(orientation_fit(precision="fp64", validate=True))
+        large_cell_fits.append(orientation_fit(precision="fp32", validate=False))
+    if cfg.preprocess.optimize_thickness:
+        small_cell_fits.append(thickness_fit(precision="fp64"))
+        large_cell_fits.append(thickness_fit(precision="fp32"))
+    if small_cell_fits:
+        steps.append(
+            fork(
+                lambda grid: grid.cell_volume > _LARGE_CELL_THRESHOLD_A3,
+                when_true=large_cell_fits,
+                when_false=small_cell_fits,
+            )
+        )
+    return steps
 
 
 def _trial_coupling(cfg: ExperimentConfig, integration: IntegrationGeometry) -> TrialCoupling:

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -393,7 +393,7 @@ def _write_refinement_outputs(
         for tag, value in updates.items():
             if tag in tags:
                 column = tags.index(tag)
-                atom_loop.values[row * atom_loop.width() + column] = f"{float(value):.10g}"
+                atom_loop[row, column] = f"{float(value):.10g}"
 
     aniso_column = block.find_loop("_atom_site_aniso_label")
     if aniso_column:
@@ -421,9 +421,7 @@ def _write_refinement_outputs(
             for tag, (i, j) in components.items():
                 if tag in aniso_tags:
                     column = aniso_tags.index(tag)
-                    aniso_loop.values[row * aniso_loop.width() + column] = (
-                        f"{float(uij_cif[i, j]):.10g}"
-                    )
+                    aniso_loop[row, column] = f"{float(uij_cif[i, j]):.10g}"
     document.write_file(str(structure_path))
 
     params = result.best_params

--- a/src/diffBloch/config/schema.py
+++ b/src/diffBloch/config/schema.py
@@ -24,6 +24,7 @@ from diffBloch.specs import (
     HexagonalSearch,
     IntegrationGeometry,
     Mosaicity,
+    OrientationSelection,
     RockingCurve,
     SegmentedUnionCoupling,
     ThicknessGrid,
@@ -88,6 +89,7 @@ class BlochwaveConfig(_StrictConfig):
     sg_max: float = 0.01
     union_adaptive: bool = True
     union_max_new_beams_pct: float = 0.01
+    ignore_orientations: tuple[int, ...] = ()
 
     def to_beam_selection(self, integration: IntegrationGeometry) -> BeamSelection:
         """Assemble the ``select_beams`` value-type: the Klar cutoffs + the shared integration."""
@@ -111,6 +113,10 @@ class BlochwaveConfig(_StrictConfig):
             union_max_new_beams_pct=self.union_max_new_beams_pct,
         )
 
+    def to_orientation_selection(self) -> OrientationSelection:
+        """Parse zero-based source PETS indices excluded from the whole Bloch experiment."""
+        return OrientationSelection(ignore_orientations=self.ignore_orientations)
+
     @model_validator(mode="after")
     def _parse_fails_fast(self) -> BlochwaveConfig:
         if self.rsg <= 0.0:
@@ -118,6 +124,7 @@ class BlochwaveConfig(_StrictConfig):
         if self.rocking_curve_sampling < 1:
             raise ValueError("rocking_curve_sampling must be >= 1")
         self.to_policy()
+        self.to_orientation_selection()
         return self
 
 
@@ -219,7 +226,7 @@ class RefinementConfig(_StrictConfig):
     in complex64 for faster/lower-memory refines at reduced decimal precision.
     """
 
-    steps: int = 500
+    steps: int = 40
     trainable: TrainableConfig = Field(default_factory=TrainableConfig)
     optimizer: OptimizerConfig = Field(default_factory=OptimizerConfig)
     objective: ObjectiveConfig = Field(default_factory=ObjectiveConfig)
@@ -296,6 +303,8 @@ class PreprocessConfig(_StrictConfig):
     defaults). Opt-in step config lives with the step, not in an always-present block.
     """
 
+    optimize_orientation: bool = True
+    optimize_thickness: bool = True
     orientation: OrientationFitConfig = Field(default_factory=OrientationFitConfig)
     thickness: ThicknessFitConfig = Field(default_factory=ThicknessFitConfig)
 

--- a/src/diffBloch/engine/forward.py
+++ b/src/diffBloch/engine/forward.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Protocol
 
@@ -25,7 +25,7 @@ import torch
 from torch import Tensor
 
 from diffBloch.core.dynamical import build_bloch_system, build_bloch_systems, stack_beam_plans
-from diffBloch.core.losses import optimal_scale
+from diffBloch.core.losses import optimal_scale, rbragg
 from diffBloch.core.products import (
     AlignedIntensities,
     BlochSolution,
@@ -234,6 +234,57 @@ class RefinementEngine:
             forward_context_for=_component_forward_context_for(model) if model.components else None,
         )
 
+    def refinement_metrics(self, model: RefinementModel) -> tuple[float, int, int, int, int]:
+        """Return mean R_obs and reflection counts for one refinement-model snapshot.
+
+        Counts are over PETS rows in the selected rotations: matched rows enter the diffraction
+        alignment, unmatched rows do not; strong/weak split matched rows at ``I > 3 sigma``.
+        """
+        with torch.no_grad():
+            state = self.physical_state(model.structure.initial)
+            for constraint in model.structure.constraints:
+                state = constraint.apply(state)
+            fgb = self._structure_factors_from_state(state)
+            r_values: list[float] = []
+            n_matched = 0
+            n_strong = 0
+            n_weak = 0
+            n_unmatched = 0
+            for rotation_index, orientation in enumerate(self.orientations):
+                context = _forward_context(
+                    model, rotation_index=rotation_index, orientation=orientation
+                )
+                thickness = context.thickness
+                if thickness is None:
+                    thickness = self._thickness_for(orientation, model.structure.initial)
+                aligned = align(
+                    self._solve(orientation, fgb, thickness),
+                    orientation.pattern,
+                    orientation.alignment,
+                )
+                scores = torch.stack(
+                    [
+                        optimal_scale(
+                            aligned.calculated[t],
+                            aligned.observed[t],
+                            aligned.sigmas[t],
+                            metric=rbragg,
+                        )[1]
+                        for t in range(aligned.calculated.shape[0])
+                    ]
+                )
+                finite = scores[torch.isfinite(scores)]
+                if finite.numel():
+                    r_values.append(float(finite.min()))
+                strong = aligned.observed[0] > 3.0 * aligned.sigmas[0]
+                matched = int(strong.numel())
+                n_matched += matched
+                n_strong += int(strong.sum())
+                n_weak += matched - int(strong.sum())
+                n_unmatched += int(orientation.pattern.hkl.shape[0]) - matched
+        mean_r_obs = sum(r_values) / len(r_values) if r_values else float("nan")
+        return mean_r_obs, n_matched, n_strong, n_weak, n_unmatched
+
     def _objective_value(
         self,
         params: RefinableParams,
@@ -253,6 +304,7 @@ class RefinementEngine:
             state = constraint.apply(state)
         fgb = self._structure_factors_from_state(state)
         total = params.asu_positions.new_zeros(())
+        r_obs_values: list[float] = []
         for rotation_index, orientation in enumerate(self.orientations):
             context = (
                 ForwardContext()
@@ -264,6 +316,21 @@ class RefinementEngine:
                 thickness = self._thickness_for(orientation, params)
             solution = self._solve(orientation, fgb, thickness)
             aligned = align(solution, orientation.pattern, orientation.alignment)
+            with torch.no_grad():
+                scores = torch.stack(
+                    [
+                        optimal_scale(
+                            aligned.calculated[t].detach(),
+                            aligned.observed[t],
+                            aligned.sigmas[t],
+                            metric=rbragg,
+                        )[1]
+                        for t in range(aligned.calculated.shape[0])
+                    ]
+                )
+                finite = scores[torch.isfinite(scores)]
+                if finite.numel():
+                    r_obs_values.append(float(finite.min()))
             term = self.loss(aligned)
             if term.ndim != 0:
                 raise ValueError(f"loss must return a scalar, got shape {tuple(term.shape)}")
@@ -275,7 +342,12 @@ class RefinementEngine:
             components[penalty.name] = ObjectiveComponent(
                 raw=penalty.value(state), weight=penalty.weight
             )
-        return ObjectiveValue(components)
+        return ObjectiveValue(
+            components,
+            diagnostics={
+                "r_obs": (sum(r_obs_values) / len(r_obs_values) if r_obs_values else float("nan"))
+            },
+        )
 
     def _thickness_for(self, orientation: OrientationPlanLike, params: RefinableParams) -> Tensor:
         """The thickness ``(T,)`` the forward model uses for one orientation.
@@ -540,6 +612,9 @@ class ModelRefinementResult:
     losses: Tensor
     best_model: RefinementModel
     best_step: int
+    history: tuple[RefinementStep, ...] = ()
+    reflection_counts: Mapping[str, int] = field(default_factory=dict)
+    artifacts: Mapping[str, str] = field(default_factory=dict)
 
     @property
     def params(self) -> RefinableParams:
@@ -672,6 +747,7 @@ def run_refinement_model(
         return float(loss.detach())
 
     losses: list[float] = []
+    history: list[RefinementStep] = []
     best_loss = float("inf")
     best_step = 0
     best_model = _detach_model(current_model())
@@ -684,26 +760,38 @@ def run_refinement_model(
         if reported_objective is None:
             raise RuntimeError("optimizer did not evaluate the refinement objective")
         losses.append(loss_value)
-        logger.report(
-            RefinementStep(
-                iteration=step,
-                loss=loss_value,
-                wr2=(
-                    _scalar_float(reported_objective.components["diffraction"].raw)
-                    / len(engine.orientations)
-                    if engine.loss is scaled_w_rbragg_loss
-                    else None
-                ),
-                objective_total=_scalar_float(reported_objective.total),
-                components=_component_measurements(reported_objective),
-            )
+        diffraction_loss = _scalar_float(reported_objective.components["diffraction"].raw)
+        event = RefinementStep(
+            iteration=step,
+            loss=loss_value,
+            wr2=(
+                diffraction_loss / len(engine.orientations)
+                if engine.loss is scaled_w_rbragg_loss
+                else None
+            ),
+            r_obs=reported_objective.diagnostics["r_obs"],
+            diff_loss=diffraction_loss,
+            objective_total=_scalar_float(reported_objective.total),
+            components=_component_measurements(reported_objective),
         )
+        history.append(event)
+        logger.report(event)
         if loss_value < best_loss:
             best_loss, best_step, best_model = loss_value, step, snapshot
     logger.report(RefinementCompleted(n_steps=steps, best_step=best_step, best_loss=best_loss))
+    _, n_matched, n_strong, n_weak, n_unmatched = engine.refinement_metrics(best_model)
     return ModelRefinementResult(
         model=_detach_model(current_model()),
         losses=torch.tensor(losses, dtype=torch.float64),
         best_model=best_model,
         best_step=best_step,
+        history=tuple(history),
+        reflection_counts=MappingProxyType(
+            {
+                "matched": n_matched,
+                "matched_i_gt_3sigma": n_strong,
+                "matched_i_le_3sigma": n_weak,
+                "unmatched_observed": n_unmatched,
+            }
+        ),
     )

--- a/src/diffBloch/engine/refine.py
+++ b/src/diffBloch/engine/refine.py
@@ -162,8 +162,13 @@ class ObjectiveValue:
 
     total: Tensor
     components: Mapping[str, ObjectiveComponent]
+    diagnostics: Mapping[str, float]
 
-    def __init__(self, components: Mapping[str, ObjectiveComponent]) -> None:
+    def __init__(
+        self,
+        components: Mapping[str, ObjectiveComponent],
+        diagnostics: Mapping[str, float] = MappingProxyType({}),
+    ) -> None:
         if not components:
             raise ValueError("at least one objective component is required")
         copied = dict(components)
@@ -180,6 +185,7 @@ class ObjectiveValue:
             total = total + contribution
         object.__setattr__(self, "total", total)
         object.__setattr__(self, "components", MappingProxyType(copied))
+        object.__setattr__(self, "diagnostics", MappingProxyType(dict(diagnostics)))
 
 
 class PenaltyTerm(Protocol):

--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -224,7 +224,7 @@ class ThicknessFitted:
     candidate (Angstrom). Emitted in plan order (the fit is sequential).
     """
 
-    channel: ClassVar[str] = "fit_thickness"
+    channel: ClassVar[str] = "optimize_thickness"
     index: int
     wr2: float
     thickness: float
@@ -347,6 +347,8 @@ class RefinementStep:
     iteration: int
     loss: float
     wr2: float | None = None
+    r_obs: float | None = None
+    diff_loss: float | None = None
     objective_total: float | None = None
     components: Mapping[str, Mapping[str, float]] = field(default_factory=dict)
 
@@ -360,7 +362,16 @@ class RefinementStep:
 
     @property
     def measurements(self) -> Mapping[str, float]:
-        return {"wr2": self.wr2} if self.wr2 is not None else {"loss": self.loss}
+        values: dict[str, float] = {}
+        if self.wr2 is not None:
+            values["wr2"] = self.wr2
+        if self.r_obs is not None:
+            values["r_obs"] = self.r_obs
+        if self.diff_loss is not None:
+            values["diff_loss"] = self.diff_loss
+        if not values:
+            values["loss"] = self.loss
+        return values
 
 
 @dataclass(frozen=True)

--- a/src/diffBloch/preprocess/experiment.py
+++ b/src/diffBloch/preprocess/experiment.py
@@ -190,7 +190,7 @@ def from_experiment(
         observations.betas,
         observations.omegas,
     )
-    plans = tuple(
+    all_plans = tuple(
         CandidatePlan.seed(
             beam_hkl,
             PatternBatch.from_observation_record(observations, zone_axis_id=int(zone_id)),
@@ -201,9 +201,23 @@ def from_experiment(
         for index, zone_id in enumerate(observations.zone_axis_ids)
     )
 
-    validation = _validation_mask(len(plans), config.refinement.split)
-    train_orientations = tuple(p for p, v in zip(plans, validation, strict=True) if not v)
-    val_orientations = tuple(p for p, v in zip(plans, validation, strict=True) if v)
+    selection = config.blochwave.to_orientation_selection()
+    ignored = set(selection.ignore_orientations)
+    out_of_range = sorted(index for index in ignored if index >= len(all_plans))
+    if out_of_range:
+        raise ValueError(
+            "ignore_orientations contains indices outside the PETS rotation range "
+            f"0..{len(all_plans) - 1}: {out_of_range}"
+        )
+    selected = tuple((index, plan) for index, plan in enumerate(all_plans) if index not in ignored)
+    if not selected:
+        raise ValueError("ignore_orientations excludes every PETS rotation")
+
+    # Split membership is defined on the original PETS order. Ignoring a rotation must not renumber
+    # later frames and silently move them between train and validation.
+    validation = _validation_mask(len(all_plans), config.refinement.split)
+    train_orientations = tuple(plan for index, plan in selected if not validation[index])
+    val_orientations = tuple(plan for index, plan in selected if validation[index])
     return ExperimentSetup(
         plans=PlanSplit(
             train=Plan(structure_factor_grid=grid, orientations=train_orientations),

--- a/src/diffBloch/preprocess/steps/beams.py
+++ b/src/diffBloch/preprocess/steps/beams.py
@@ -27,12 +27,15 @@ from numpy.typing import NDArray
 
 from diffBloch.core.crystal import orientation_basis
 from diffBloch.core.dynamical import excitation_errors
+from diffBloch.core.products import PLAIN_SUM, MosaicSmoothed, TiltReduction
 from diffBloch.core.reciprocal import g_vectors
-from diffBloch.engine.plan import OrientationPlan
+from diffBloch.engine.plan import CoupledOrientationPlan, OrientationPlan, StructureFactorGrid
+from diffBloch.preprocess.coupling import build_coupling_segments
 from diffBloch.preprocess.experiment import seed_beam_hkl
+from diffBloch.preprocess.orientation import rocking_curve_tilts
 from diffBloch.preprocess.pipeline import PlanStep, as_step
 from diffBloch.preprocess.plan import CandidatePlan, Plan, require_candidate_plans
-from diffBloch.specs import BeamSelection
+from diffBloch.specs import BeamSelection, Mosaicity, RockingCurve, SegmentedUnionCoupling
 
 __all__ = ["build_orientation_plans", "klar_beam_mask", "reseed_pool", "select_beams"]
 
@@ -63,34 +66,145 @@ def select_beams(selection: BeamSelection) -> PlanStep:
     return as_step("select_beams", selection, run)
 
 
-def build_orientation_plans() -> PlanStep:
-    """Return a ``Plan -> Plan`` step that builds each candidate into a solvable orientation plan.
+def build_orientation_plans(
+    rocking: RockingCurve | None = None,
+    mosaicity: Mosaicity | None = None,
+    *,
+    coupling: SegmentedUnionCoupling | None = None,
+    scoring_selection: BeamSelection | None = None,
+) -> PlanStep:
+    """Build each candidate's final tilted Bloch geometry and intensity reduction.
 
     The single *build* boundary of the preprocess pipeline: it materialises each orientation's
     structure-factor gather (the dominant cost) over its beam set via ``OrientationPlan.build``, and
-    the rebuilt ``AlignmentPlan`` re-bridges the observed ``pattern`` to that set. Composed *after*
-    :func:`select_beams`, so the gather is built once over the small Klar-active set -- never the
-    full candidate pool ``from_experiment`` lays down (which is intractable for a large cell). The
-    engine consumes only these built plans; a :class:`~diffBloch.preprocess.plan.CandidatePlan` has
-    no ``beam_plans`` and is unsolvable by construction.
+    the rebuilt ``AlignmentPlan`` re-bridges the simulator output to the observed ``pattern``. A
+    custom pipeline may compose it after :func:`select_beams`; the default coupled path instead
+    derives the SOLVE beams directly from ``g_max``/``sg_max`` and the explicit sub-tilts. The
+    engine consumes only these built plans; a
+    :class:`~diffBloch.preprocess.plan.CandidatePlan` has no ``beam_plans`` and is unsolvable by
+    construction.
+
+    When ``rocking`` is supplied, the builder directly creates its complete sub-tilt geometry
+    instead of first building a temporary central-orientation plan and rebuilding it later.
+    ``mosaicity`` selects the reduction applied to those sub-tilt intensities and therefore requires
+    ``rocking``. When ``coupling`` is supplied, each segment's beam set is selected from the full
+    support grid by ``|g| < g_max`` and ``|Sg| < sg_max`` at its boundary tilts, then the ordinary
+    alignment intersects the resulting simulator HKLs with the PETS observations.
+    ``scoring_selection`` optionally applies the former Klar ``rsg``/``dsg``/semiangle filter to
+    the candidate scoring pool before that intersection; it does not alter the coupled SOLVE beams.
+    Omitting ``coupling`` preserves the simple builder used by focused APIs/tests.
     """
+    if mosaicity is not None and rocking is None:
+        raise ValueError("mosaicity requires rocking-curve geometry")
+    if coupling is not None and rocking is None:
+        raise ValueError("coupling requires rocking-curve geometry")
+    tilts = (
+        None
+        if rocking is None
+        else rocking_curve_tilts(
+            rocking.integration.semiangle,
+            rocking.sampling,
+            geometry=rocking.integration.geometry,
+        )
+    )
+    if mosaicity is not None:
+        assert rocking is not None  # narrowed by the construction guard above
+        if mosaicity.window > rocking.sampling:
+            raise ValueError(
+                f"mosaicity window {mosaicity.window} exceeds the {rocking.sampling} "
+                "rocking-curve tilts"
+            )
+    reduction = PLAIN_SUM if mosaicity is None else MosaicSmoothed(mosaicity.window)
 
     def run(plan: Plan) -> Plan:
-        built = tuple(
-            OrientationPlan.build(
-                plan.structure_factor_grid,
-                np.asarray(cp.beam_hkl),
-                cp.pattern,
-                energy=cp.energy,
-                thickness=cp.thickness,
-                u0=cp.u0,
-                orientation=cp.orientation,
+        candidates = require_candidate_plans(plan)
+        built: tuple[OrientationPlan | CoupledOrientationPlan, ...]
+        if coupling is None:
+            built = tuple(
+                OrientationPlan.build(
+                    plan.structure_factor_grid,
+                    np.asarray(cp.beam_hkl),
+                    cp.pattern,
+                    energy=cp.energy,
+                    thickness=cp.thickness,
+                    u0=cp.u0,
+                    orientation=cp.orientation,
+                    tilts=tilts,
+                    tilt_reduction=reduction,
+                )
+                for cp in candidates
             )
-            for cp in require_candidate_plans(plan)
-        )
+        else:
+            assert tilts is not None
+            grid = plan.structure_factor_grid
+            built = tuple(
+                _build_coupled_candidate(
+                    grid,
+                    cp,
+                    tilts,
+                    reduction,
+                    coupling,
+                    scoring_selection=scoring_selection,
+                )
+                for cp in candidates
+            )
         return replace(plan, orientations=built)
 
-    return as_step("build_orientation_plans", None, run)
+    return as_step(
+        "build_orientation_plans",
+        (
+            None
+            if rocking is None and coupling is None
+            else {
+                "rocking": rocking,
+                "mosaicity": mosaicity,
+                "coupling": coupling,
+                "scoring_selection": scoring_selection,
+            }
+        ),
+        run,
+    )
+
+
+def _build_coupled_candidate(
+    grid: StructureFactorGrid,
+    candidate: CandidatePlan,
+    tilts: NDArray[np.float64],
+    reduction: TiltReduction,
+    coupling: SegmentedUnionCoupling,
+    *,
+    scoring_selection: BeamSelection | None,
+) -> CoupledOrientationPlan:
+    """Build one simulator plan from geometric coupling only; alignment handles observations."""
+    segments = build_coupling_segments(
+        coupling,
+        np.asarray(grid.structure_factor_hkl, dtype=np.int64),
+        cell=np.asarray(grid.cell, dtype=np.float64),
+        orientation=np.asarray(candidate.orientation, dtype=np.float64),
+        tilts=tilts,
+        energy=candidate.energy,
+        u0=candidate.u0,
+    )
+    scored_hkl = (
+        None
+        if scoring_selection is None
+        else np.asarray(
+            _reselect(np.asarray(grid.cell), candidate, scoring_selection).beam_hkl,
+            dtype=np.int64,
+        )
+    )
+    return CoupledOrientationPlan.build(
+        grid,
+        [(segment.union_hkl, segment.covered_tilt_indices) for segment in segments],
+        candidate.pattern,
+        energy=candidate.energy,
+        thickness=candidate.thickness,
+        u0=candidate.u0,
+        orientation=candidate.orientation,
+        tilts=tilts,
+        tilt_reduction=reduction,
+        scored_hkl=scored_hkl,
+    )
 
 
 def reseed_pool(seed: Plan, selection: BeamSelection, *, g_max_refine: float) -> Plan:

--- a/src/diffBloch/preprocess/steps/fit_orientation.py
+++ b/src/diffBloch/preprocess/steps/fit_orientation.py
@@ -13,23 +13,21 @@ re-orthonormalisation). The captured ``refinement`` is read-only context
 the step never mutates; the simulation inside is
 deterministic and depends only on its inputs, so it is ordinary computation, not a side effect.
 
-The active beam set is held fixed at each orientation's seed selection across the search -- it is
-*not* re-filtered per trial *unless* the fit is opted into
-coupling via ``coupling=`` (see below). The rocking-curve tilt set carried by the ``Plan`` is
+The SCORED reflection set is held fixed at each orientation's seed selection across the search.
+With ``coupling=`` the additional SOLVE beams are re-derived per trial, while every scored
+reflection is retained in each segment's solve basis. The rocking-curve tilt set carried by the
+``Plan`` is
 threaded through every trial unchanged, so each candidate is scored under the *same* integration as
 the seed -- the fit/eval consistency invariant. Ordering ``integrate_rocking_curve`` before this
 step therefore couples the fit to the integrated model; with rocking off the tilt set is a single
 identity, identical to a static fit.
 
-**Coupling (opt-in, ``coupling=TrialCoupling(...)``)** re-derives both reflection sets at every
-trial: at *every* trial orientation both the SOLVE union (the per-tilt-segment excitation coupling)
-and the SCORED set (the Klar window intersected with a resolution cap) are re-derived from scratch,
-so both track the trial rather than staying pinned to the seed. The seed is rebuilt through the same
-builder so the greedy comparison is always coupled-vs-coupled, and the last accepted trial is
-already the coupled-at-fitted-orientation plan -- no separate ``couple_beams`` step is needed.
-Per-trial re-selection makes the objective **deliberately non-stationary**: consecutive trials score
-different reflection sets (different wR2 denominators). This is intended, not a bug -- each trial's
-wR2 is over that trial's own filtered set. It is affordable because the atomic ``F_gb`` is
+**Coupling (opt-in, ``coupling=TrialCoupling(...)``)** re-derives the excitation-selected SOLVE
+beams at every trial while pinning the SCORED set to the seed alignment. Pinning is required for a
+valid greedy comparison: otherwise a trial can lower wR2 merely by deleting reflections and reach
+the degenerate one-reflection ``wr2=0`` minimum. The seed is rebuilt through the same builder, and
+the last accepted trial is already the coupled-at-fitted-orientation plan -- no separate
+``couple_beams`` step is needed. It is affordable because the atomic ``F_gb`` is
 computed once and every segment's structure-factor matrix is a cheap gather-index into it, not a
 re-derivation.
 
@@ -48,13 +46,11 @@ import numpy as np
 from numpy.typing import NDArray
 from torch import Tensor
 
-from diffBloch.core.crystal import orientation_basis
 from diffBloch.core.dynamical import (
     StructureFactorGather,
     build_structure_factor_gather,
     grid_source_indices,
 )
-from diffBloch.core.reciprocal import g_vectors, gmax_mask
 from diffBloch.core.solver import FloatFormat, SolverMethod
 from diffBloch.engine import RefinementEngine
 from diffBloch.engine.plan import CoupledOrientationPlan, OrientationPlanLike, StructureFactorGrid
@@ -66,7 +62,6 @@ from diffBloch.preprocess.orientation import hexagonal_tilt
 from diffBloch.preprocess.pipeline import PlanStep, as_step
 from diffBloch.preprocess.plan import Plan, require_built_plans
 from diffBloch.preprocess.scoring import build_engine
-from diffBloch.preprocess.steps.beams import klar_beam_mask
 from diffBloch.specs import HexagonalSearch, TrialCoupling, assert_grid_covers_coupling
 
 __all__ = ["fit_orientation"]
@@ -173,7 +168,13 @@ def fit_orientation(
 
         def refine(op: OrientationPlanLike) -> tuple[OrientationPlanLike, float, int, int]:
             return _refine_one(
-                engine, fgb, plan, op, search=search, coupling=coupling, validate=validate
+                engine,
+                fgb,
+                plan,
+                op,
+                search=search,
+                coupling=coupling,
+                validate=validate,
             )
 
         built = require_built_plans(plan)
@@ -226,7 +227,7 @@ def fit_orientation(
     # search rides in the config digest too, but coupling is a composition-site kwarg (not config),
     # so it MUST be in the recipe identity; workers/logger/device are execution-only (device shifts
     # output only to solver tolerance -- see the docstring -- so it stays out of the identity).
-    return as_step("fit_orientation", {"search": search, "coupling": coupling}, run)
+    return as_step("optimize_orientation", {"search": search, "coupling": coupling}, run)
 
 
 def _refine_one(
@@ -292,7 +293,8 @@ def _refine_one(
                 )
             n_trials += 1
             trial_score = float(engine.score_orientation(trial, fgb))
-            if trial_score < current_score:  # greedy first-improvement; restart at this radius
+            accepted = trial_score < current_score
+            if accepted:  # greedy first-improvement; restart at this radius
                 current, current_score = trial, trial_score
                 improved = True
                 break
@@ -312,15 +314,13 @@ def _coupled_trial(
     *,
     validate: bool = True,
 ) -> CoupledOrientationPlan:
-    """Re-couple the solve union and re-select the scored set at ``orientation`` (one coupled trial).
+    """Re-couple the solve union while pinning the scored set at ``orientation`` (one trial).
 
     One objective evaluation: (1) ``build_coupling_segments`` re-derives
-    the per-tilt-segment excitation union at ``orientation`` (the SOLVE set); (2) the Klar window
-    (:func:`klar_beam_mask`) intersected with the scoring-resolution cap
-    (:func:`~diffBloch.core.reciprocal.gmax_mask`, an ideal-cell ``|g|`` metric) selects the SCORED
-    set from that union, with ``000`` retained
-    (it anchors ``psi0`` and is dropped later on pattern intersection). The observed ``pattern``,
-    ``thickness``, and ``tilt_reduction`` are carried from ``op`` unchanged. The atomic ``F_gb`` is
+    the per-tilt-segment excitation union at ``orientation`` (the changing SOLVE set); (2) the seed
+    alignment is added to every segment and retained as the fixed SCORED set. Thus every trial's
+    wR2 compares the same observations. The observed ``pattern``, ``thickness``, and
+    ``tilt_reduction`` are carried from ``op`` unchanged. The atomic ``F_gb`` is
     untouched either way; ``gather_cache`` (keyed by a segment's beam-set bytes) reuses the
     orientation-free per-segment F-gathers across a search's trials -- identical beam set, identical
     gather -- collapsing the per-trial rebuild cost.
@@ -342,20 +342,19 @@ def _coupled_trial(
         energy=op.energy,
         u0=op.u0,
     )
-    union = np.unique(np.concatenate([segment.union_hkl for segment in segments]), axis=0)
-    scored = coupling.scored
-    basis = orientation_basis(cell, orientation)
-    keep = klar_beam_mask(
-        g_vectors(union, basis),
-        energy=op.energy,
-        u0=op.u0,
-        rsg=scored.klar.rsg,
-        dsg=scored.klar.dsg,
-        semiangle=scored.klar.integration.semiangle,
-        geometry=scored.klar.integration.geometry,
+    scored_hkl = np.asarray(op.alignment.hkl, dtype=np.int64)
+    # A trial must not improve merely by dropping scored reflections. Keep the seed objective
+    # domain fixed and include it in every segment so scored ⊆ solved holds throughout the curve.
+    segments = tuple(
+        replace(
+            segment,
+            union_hkl=np.unique(
+                np.concatenate([segment.union_hkl, scored_hkl]),
+                axis=0,
+            ),
+        )
+        for segment in segments
     )
-    keep |= (union == 0).all(axis=1)  # 000 anchors psi0; dropped later on pattern intersection
-    keep &= gmax_mask(union, np.asarray(grid.reciprocal_basis), scored.g_max)  # resolution cap
     gathers = None
     if gather_cache is not None:
         structure_factor_hkl = np.asarray(grid.structure_factor_hkl)
@@ -391,6 +390,6 @@ def _coupled_trial(
         orientation=orientation,
         tilts=tilts,
         tilt_reduction=op.tilt_reduction,
-        scored_hkl=union[keep],
+        scored_hkl=scored_hkl,
         gathers=gathers,
     )

--- a/src/diffBloch/preprocess/steps/fit_thickness.py
+++ b/src/diffBloch/preprocess/steps/fit_thickness.py
@@ -100,7 +100,7 @@ def fit_thickness(
         return replace(plan, orientations=tuple(fitted))
 
     # method rides in the config digest (cfg.solver.refine); the grid is the step's own param.
-    return as_step("fit_thickness", grid, run)
+    return as_step("optimize_thickness", grid, run)
 
 
 def _fit_one(

--- a/src/diffBloch/specs.py
+++ b/src/diffBloch/specs.py
@@ -29,6 +29,7 @@ __all__ = [
     "HexagonalSearch",
     "IntegrationGeometry",
     "Mosaicity",
+    "OrientationSelection",
     "RockingCurve",
     "ScoredHklSelection",
     "ThicknessGrid",
@@ -37,6 +38,26 @@ __all__ = [
     "TrialCoupling",
     "assert_grid_covers_coupling",
 ]
+
+
+@dataclass(frozen=True)
+class OrientationSelection:
+    """Original PETS rotation indices excluded from every downstream experiment stage.
+
+    Indices are zero-based in the source ``.cif_pets`` rotation order. Filtering happens before
+    the train/validation split, beam construction, orientation/thickness fitting, inference, and
+    structure refinement. Duplicate or negative indices are rejected so the recorded experiment
+    selection has one unambiguous identity; the experiment boundary checks the data-dependent upper
+    bound once the number of PETS rotations is known.
+    """
+
+    ignore_orientations: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        if any(index < 0 for index in self.ignore_orientations):
+            raise ValueError("ignore_orientations indices must be non-negative")
+        if len(set(self.ignore_orientations)) != len(self.ignore_orientations):
+            raise ValueError("ignore_orientations must not contain duplicate indices")
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -234,8 +234,8 @@ class _FakePlan:
     def __init__(self) -> None:
         self.orientations = (object(), object())
         self.provenance = (
-            SimpleNamespace(name="fit_orientation"),
-            SimpleNamespace(name="fit_thickness"),
+            SimpleNamespace(name="optimize_orientation"),
+            SimpleNamespace(name="optimize_thickness"),
         )
 
 
@@ -271,8 +271,10 @@ def test_run_preprocess_delegates_and_reports_without_scoring(
     assert captured["checkpoint"] is True and captured["refresh"] is False
     assert captured["workers"] == 1 and captured["device"] == "cuda"
     out = capsys.readouterr().out
-    assert "preprocessed 2 rotations" in out
-    assert "fit_orientation, fit_thickness" in out  # recipe echoed; no R_obs (no scoring)
+    assert "PREPROCESS COMPLETE" in out
+    assert "Rotations              2" in out
+    assert "Optimize Orientation" in out
+    assert "Optimize Thickness" in out
     assert "R_obs" not in out
 
 
@@ -332,7 +334,23 @@ def test_run_preprocess_missing_experiment_reports_concise_error(
 
 def _fake_refinement_result() -> SimpleNamespace:
     """Minimal stand-in for a RefinementResult: enough for the CLI's summary line."""
-    return SimpleNamespace(losses=torch.tensor([2.0, 1.0]), best_loss=1.0, best_step=1)
+    history = [
+        SimpleNamespace(wr2=0.2, r_obs=0.3, diff_loss=2.0),
+        SimpleNamespace(wr2=0.1, r_obs=0.2, diff_loss=1.0),
+    ]
+    return SimpleNamespace(
+        losses=torch.tensor([2.0, 1.0]),
+        best_loss=1.0,
+        best_step=1,
+        history=history,
+        reflection_counts={
+            "matched": 12,
+            "matched_i_gt_3sigma": 8,
+            "matched_i_le_3sigma": 4,
+            "unmatched_observed": 3,
+        },
+        artifacts={"refined_structure": "/tmp/refined_structure.cif"},
+    )
 
 
 def test_run_refine_delegates_and_reports(
@@ -362,8 +380,14 @@ def test_run_refine_delegates_and_reports(
     assert captured["dir"] == "/some/experiment"
     assert isinstance(captured["logger"], ConsoleLogger)  # console on by default (no --quiet)
     out = capsys.readouterr().out
-    assert "refined 2 steps" in out
-    assert "objective 2.000000 -> 1.000000 (best at step 1)" in out
+    assert "REFINEMENT COMPLETE" in out
+    assert "Best epoch             2" in out
+    assert "wR2                    0.1" in out
+    assert "R_obs                  0.2" in out
+    assert "Diffraction loss       1" in out
+    assert "HKLs (Observed/total)  8 / 12" in out
+    assert "Refined Structure" in out
+    assert "/tmp/refined_structure.cif" in out
 
 
 def test_run_refine_flags_thread_through(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -78,13 +78,9 @@ def test_ignore_orientations_parses_to_validated_source_indices() -> None:
     assert cfg.blochwave.to_orientation_selection() == OrientationSelection((0, 18, 56))
 
     with pytest.raises(ValidationError, match="non-negative"):
-        ExperimentConfig.model_validate(
-            {**base, "blochwave": {"ignore_orientations": [-1]}}
-        )
+        ExperimentConfig.model_validate({**base, "blochwave": {"ignore_orientations": [-1]}})
     with pytest.raises(ValidationError, match="duplicate"):
-        ExperimentConfig.model_validate(
-            {**base, "blochwave": {"ignore_orientations": [2, 2]}}
-        )
+        ExperimentConfig.model_validate({**base, "blochwave": {"ignore_orientations": [2, 2]}})
 
 
 def test_sample_thicknesses_are_positive_and_nonempty() -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -17,6 +17,7 @@ from diffBloch.engine.refine import _TRAINABLE_FIELDS
 from diffBloch.specs import (
     HexagonalSearch,
     IntegrationGeometry,
+    OrientationSelection,
     RockingCurve,
     SegmentedUnionCoupling,
     ThicknessGrid,
@@ -40,6 +41,9 @@ def test_minimal_config_validates_with_defaults() -> None:
     assert cfg.refinement.objective.data_term == "scaled_weighted_r"
     assert cfg.refinement.precision == "fp64"
     assert cfg.refinement.split.validation == "every_10th_rotation"
+    assert cfg.blochwave.ignore_orientations == ()
+    assert cfg.preprocess.optimize_orientation is True
+    assert cfg.preprocess.optimize_thickness is True
 
 
 def test_solver_method_must_be_a_known_method() -> None:
@@ -64,6 +68,23 @@ def test_unknown_key_is_rejected_not_ignored() -> None:
         ExperimentConfig.model_validate({**base, "blochwave": {"g_max_sf": 5.0}})
     with pytest.raises(ValidationError, match="[Ee]xtra"):
         ExperimentConfig.model_validate({**base, "nonsense": True})  # unknown top-level key
+
+
+def test_ignore_orientations_parses_to_validated_source_indices() -> None:
+    base = {"name": "q", "inputs": {"structure": "q.cif", "exp_data": "q.cif_pets"}}
+    cfg = ExperimentConfig.model_validate(
+        {**base, "blochwave": {"ignore_orientations": [0, 18, 56]}}
+    )
+    assert cfg.blochwave.to_orientation_selection() == OrientationSelection((0, 18, 56))
+
+    with pytest.raises(ValidationError, match="non-negative"):
+        ExperimentConfig.model_validate(
+            {**base, "blochwave": {"ignore_orientations": [-1]}}
+        )
+    with pytest.raises(ValidationError, match="duplicate"):
+        ExperimentConfig.model_validate(
+            {**base, "blochwave": {"ignore_orientations": [2, 2]}}
+        )
 
 
 def test_sample_thicknesses_are_positive_and_nonempty() -> None:

--- a/tests/unit/test_coupling_step.py
+++ b/tests/unit/test_coupling_step.py
@@ -356,14 +356,8 @@ def test_recouple_accepts_a_segmented_plan_and_preserves_the_scored_set() -> Non
     assert recoupled.alignment.hkl.tolist() == once.orientations[0].alignment.hkl.tolist()
 
 
-def test_fit_orientation_couples_and_reselects_per_trial() -> None:
-    """coupling=TrialCoupling re-couples + re-selects at every trial (the private's objective).
-
-    Two claims: (1) a coupled trial at a tilted orientation re-selects a *different* scored set than
-    at the seed -- the deliberately non-stationary objective the module docstring records; (2) the
-    seed is rebuilt through the coupled builder, so an opted-in fit returns a segmented plan. A
-    short search keeps the end-to-end run fast.
-    """
+def test_fit_orientation_recouples_solve_beams_but_pins_scored_hkl_per_trial() -> None:
+    """Coupled trials may change SOLVE beams but always compare the same scored reflections."""
     from diffBloch.preprocess.orientation import hexagonal_tilt
     from diffBloch.preprocess.steps.fit_orientation import _coupled_trial
 
@@ -374,9 +368,14 @@ def test_fit_orientation_couples_and_reselects_per_trial() -> None:
     seed_trial = _coupled_trial(grid, op, seed_o, coupling)
     tilt_trial = _coupled_trial(grid, op, seed_o @ hexagonal_tilt(0.0, 3.0), coupling)
     assert isinstance(seed_trial, CoupledOrientationPlan)
-    # union AND scored set are re-derived per trial (the non-stationary objective)
+    # Additional SOLVE beams track the trial, but the objective domain stays fixed.
     assert seed_trial.beam_hkl.tolist() != tilt_trial.beam_hkl.tolist()
-    assert seed_trial.alignment.hkl.tolist() != tilt_trial.alignment.hkl.tolist()
+    assert seed_trial.alignment.hkl.tolist() == tilt_trial.alignment.hkl.tolist()
+    assert seed_trial.alignment.hkl.tolist() == op.alignment.hkl.tolist()
+    for trial in (seed_trial, tilt_trial):
+        for segment in trial.segments:
+            segment_hkl = {tuple(row) for row in segment.plan.beam_hkl.tolist()}
+            assert all(tuple(row) in segment_hkl for row in op.alignment.hkl.tolist())
 
     search = HexagonalSearch(max_search_angle=0.5, min_search_angle=0.25)
     (fitted,) = fit_orientation(refinement, search, method=_METHOD, coupling=coupling)(

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -447,7 +447,7 @@ def test_refine_emits_a_step_stream_and_a_completion_event() -> None:
     first = steps[0]
     assert first.objective_total == first.loss
     assert first.components.keys() == {"diffraction"}
-    assert first.measurements == {"loss": first.loss}
+    assert first.measurements == {"r_obs": first.r_obs, "diff_loss": first.loss}
     assert completed.n_steps == 6
     assert completed.best_step == result.best_step
     assert completed.best_loss == result.best_loss
@@ -470,7 +470,7 @@ def test_refine_lbfgs_step_diagnostics_match_reported_pre_update_loss() -> None:
     (step,) = [e for e in recorder.events if isinstance(e, RefinementStep)]
     assert step.loss == float(result.losses[0])
     assert step.objective_total == step.loss
-    assert step.measurements == {"loss": step.loss}
+    assert step.measurements == {"r_obs": step.r_obs, "diff_loss": step.loss}
 
 
 def test_refine_element_selection_freezes_excluded_position_rows() -> None:

--- a/tests/unit/test_fit_orientation.py
+++ b/tests/unit/test_fit_orientation.py
@@ -268,7 +268,16 @@ def test_fit_orientation_workers_abort_cancels_pending_rotations(
 
     calls: list[int] = []
 
-    def stub(engine, fgb, plan, op, *, search, coupling, validate=True):  # type: ignore[no-untyped-def]
+    def stub(  # type: ignore[no-untyped-def]
+        engine,
+        fgb,
+        plan,
+        op,
+        *,
+        search,
+        coupling,
+        validate=True,
+    ):
         calls.append(1)
         time.sleep(0.03)  # a window in which the abort can cancel the still-queued rotations
         return op, 0.5, 1, 1

--- a/tests/unit/test_from_experiment.py
+++ b/tests/unit/test_from_experiment.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 import torch
 
 from diffBloch.config import load_config
@@ -33,6 +34,63 @@ def test_from_experiment_builds_grid_sharing_train_val_split() -> None:
     assert len(train.orientations) + len(val.orientations) == observations.n_rotations
     assert len(val.orientations) == 9
     assert len(train.orientations) == 90
+
+
+def test_from_experiment_ignores_original_pets_indices_before_split() -> None:
+    structure = read_structure(QUARTZ / "enantiomer_1.cif")
+    observations = read_observations(QUARTZ / "exp_data.cif_pets")
+    base = load_config(QUARTZ / "experiment.yaml")
+    config = base.model_copy(
+        update={
+            "blochwave": base.blochwave.model_copy(
+                update={"ignore_orientations": (0, 9, 56)}
+            )
+        }
+    )
+
+    setup = from_experiment(structure, observations, config)
+
+    # Raw index 9 remains a validation member when removed; later rotations are not renumbered.
+    assert len(setup.plans.train.orientations) == 88
+    assert len(setup.plans.validation.orientations) == 8
+    expected = orientation_matrices(
+        observations.ub_matrix,
+        observations.cell_parameters,
+        observations.alphas,
+        observations.betas,
+        observations.omegas,
+    )
+    assert np.allclose(setup.plans.train.orientations[0].orientation, expected[1])
+    assert not any(
+        np.allclose(plan.orientation, expected[56])
+        for plan in setup.plans.combined.orientations
+    )
+
+
+def test_from_experiment_rejects_invalid_data_dependent_ignore_selection() -> None:
+    structure = read_structure(QUARTZ / "enantiomer_1.cif")
+    observations = read_observations(QUARTZ / "exp_data.cif_pets")
+    base = load_config(QUARTZ / "experiment.yaml")
+
+    out_of_range = base.model_copy(
+        update={
+            "blochwave": base.blochwave.model_copy(
+                update={"ignore_orientations": (observations.n_rotations,)}
+            )
+        }
+    )
+    with pytest.raises(ValueError, match="outside the PETS rotation range"):
+        from_experiment(structure, observations, out_of_range)
+
+    all_ignored = base.model_copy(
+        update={
+            "blochwave": base.blochwave.model_copy(
+                update={"ignore_orientations": tuple(range(observations.n_rotations))}
+            )
+        }
+    )
+    with pytest.raises(ValueError, match="excludes every PETS rotation"):
+        from_experiment(structure, observations, all_ignored)
 
 
 def test_from_experiment_seeds_native_orientation_and_000_beam() -> None:

--- a/tests/unit/test_from_experiment.py
+++ b/tests/unit/test_from_experiment.py
@@ -41,11 +41,7 @@ def test_from_experiment_ignores_original_pets_indices_before_split() -> None:
     observations = read_observations(QUARTZ / "exp_data.cif_pets")
     base = load_config(QUARTZ / "experiment.yaml")
     config = base.model_copy(
-        update={
-            "blochwave": base.blochwave.model_copy(
-                update={"ignore_orientations": (0, 9, 56)}
-            )
-        }
+        update={"blochwave": base.blochwave.model_copy(update={"ignore_orientations": (0, 9, 56)})}
     )
 
     setup = from_experiment(structure, observations, config)
@@ -62,8 +58,7 @@ def test_from_experiment_ignores_original_pets_indices_before_split() -> None:
     )
     assert np.allclose(setup.plans.train.orientations[0].orientation, expected[1])
     assert not any(
-        np.allclose(plan.orientation, expected[56])
-        for plan in setup.plans.combined.orientations
+        np.allclose(plan.orientation, expected[56]) for plan in setup.plans.combined.orientations
     )
 
 

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -167,6 +167,21 @@ def test_console_logger_formats_refinement_epoch_metrics(
     )
 
 
+def test_console_logger_formats_preprocess_stage(caplog: pytest.LogCaptureFixture) -> None:
+    logger = ConsoleLogger(level=logging.INFO)
+    event = PlanStepCompleted(
+        channel="build_orientation_plans",
+        index=0,
+        measurements={"n_orientations": 2.0},
+    )
+    with caplog.at_level(logging.INFO, logger="diffBloch.loggers"):
+        logger.report(event)
+
+    assert caplog.records[-1].getMessage() == (
+        "Preprocess stage  1 │ Build Orientation Plans     │ n_orientations=2"
+    )
+
+
 def test_console_logger_labels_orientation_refinement_index(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -64,7 +64,7 @@ def test_events_expose_a_uniform_channel_and_measurements_surface() -> None:
     }
 
     thickness = ThicknessFitted(index=7, wr2=0.031, thickness=1460.0)
-    assert thickness.channel == "fit_thickness"
+    assert thickness.channel == "optimize_thickness"
     assert thickness.step == 7  # a thickness fit's step is its rotation index
     assert thickness.measurements == {"wr2": 0.031, "thickness": 1460.0}
 
@@ -92,8 +92,10 @@ def test_events_expose_a_uniform_channel_and_measurements_surface() -> None:
     assert coupling_summary.measurements == {"n_orientations": 55.0}
 
     # PlanStepCompleted carries the step NAME as a per-instance channel (not a class constant).
-    plan_step = PlanStepCompleted(channel="fit_orientation", index=4, measurements={"beams": 641.0})
-    assert plan_step.channel == "fit_orientation"
+    plan_step = PlanStepCompleted(
+        channel="optimize_orientation", index=4, measurements={"beams": 641.0}
+    )
+    assert plan_step.channel == "optimize_orientation"
     assert plan_step.step == 4
     assert plan_step.measurements == {"beams": 641.0}
 
@@ -153,14 +155,16 @@ def test_console_logger_logs_channel_step_and_measurements(
     assert inference_msg.startswith("inference ")  # aggregate has no step bracket
 
 
-def test_console_logger_labels_refinement_epochs_and_shows_only_wr2(
+def test_console_logger_formats_refinement_epoch_metrics(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     logger = ConsoleLogger(level=logging.INFO)
     with caplog.at_level(logging.INFO, logger="diffBloch.loggers"):
         logger.report(RefinementStep(iteration=7, loss=4.95, wr2=0.05))
 
-    assert caplog.records[-1].getMessage() == ("structure refinement[refinement_epoch=7] wr2=0.05")
+    assert caplog.records[-1].getMessage() == (
+        "Refinement epoch   8 │ wR2 0.050000 │ R_obs n/a │ diffraction loss n/a"
+    )
 
 
 def test_console_logger_labels_orientation_refinement_index(
@@ -173,7 +177,7 @@ def test_console_logger_labels_orientation_refinement_index(
     assert (
         caplog.records[-1]
         .getMessage()
-        .startswith("orientation refinement[orientation_index=10] wr2=0.025 n_matched_hkl=42")
+        .startswith("orientation optimization[orientation_index=10] wr2=0.025 n_matched_hkl=42")
     )
 
 
@@ -185,7 +189,7 @@ def test_console_logger_labels_thickness_refinement_index(
         logger.report(ThicknessFitted(index=10, wr2=0.025, thickness=820.0))
 
     assert caplog.records[-1].getMessage() == (
-        "thickness refinement[orientation_index=10] wr2=0.025 thickness=820"
+        "thickness optimization[orientation_index=10] wr2=0.025 thickness=820"
     )
 
 

--- a/tests/unit/test_program_recipe.py
+++ b/tests/unit/test_program_recipe.py
@@ -62,7 +62,7 @@ def test_coupling_config_flows_into_the_fit_orientation_record() -> None:
     setup = from_experiment(structure, observations, cfg)
     steps = _recipe_steps(cfg, setup.refinement, setup.integration, NULL_LOGGER)
     records = step_records(resolve_recipe(steps, SimpleNamespace(cell_volume=100.0)))
-    fit = next(r for r in records if r.name == "fit_orientation")
+    fit = next(r for r in records if r.name == "optimize_orientation")
     assert fit.params["coupling"]["policy"]["fixed_n_segments"] == 4
 
 
@@ -79,13 +79,38 @@ def test_fork_is_transparent_to_recipe_identity() -> None:
     small = step_records(resolve_recipe(steps, SimpleNamespace(cell_volume=100.0)))
     large = step_records(resolve_recipe(steps, SimpleNamespace(cell_volume=5000.0)))
     names = [
-        "select_beams",
         "build_orientation_plans",
-        "integrate_rocking_curve",
-        "mosaicity",
-        "fit_orientation",
-        "fit_thickness",
+        "optimize_orientation",
+        "optimize_thickness",
     ]
     assert [r.name for r in small] == names == [r.name for r in large]
     # identical params too (fit_orientation records only {search, coupling}; no precision/validate)
     assert [r.params for r in small] == [r.params for r in large]
+
+
+def test_fit_stages_can_be_enabled_independently() -> None:
+    root = FIXTURES / "quartz_anchor"
+    cfg, _ = load_experiment(root)
+    cfg = cfg.model_copy(
+        update={
+            "preprocess": cfg.preprocess.model_copy(
+                update={
+                    "optimize_orientation": True,
+                    "optimize_thickness": False,
+                }
+            )
+        }
+    )
+    structure = read_structure(root / cfg.inputs.structure)
+    observations = read_observations(root / cfg.inputs.exp_data)
+    setup = from_experiment(structure, observations, cfg)
+    records = step_records(
+        resolve_recipe(
+            _recipe_steps(cfg, setup.refinement, setup.integration, NULL_LOGGER),
+            SimpleNamespace(cell_volume=100.0),
+        )
+    )
+    assert [record.name for record in records] == [
+        "build_orientation_plans",
+        "optimize_orientation",
+    ]

--- a/tests/unit/test_refine_precision.py
+++ b/tests/unit/test_refine_precision.py
@@ -1,12 +1,19 @@
 """Refinement precision wiring for the app-level refine path."""
 
+import json
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
+import numpy as np
 import torch
 
-from diffBloch.app.program import refine_experiment
+from diffBloch.app.program import _write_refinement_outputs, refine_experiment
 from diffBloch.config.schema import ExperimentConfig
+from diffBloch.engine import ModelRefinementResult, build_refinement_model
+from diffBloch.io import read_structure
+from diffBloch.observability import RefinementStep
+from diffBloch.preprocess import RefinementSetup
 
 
 def test_refine_experiment_threads_config_precision_to_engine(monkeypatch) -> None:
@@ -63,3 +70,94 @@ def test_refine_experiment_threads_config_precision_to_engine(monkeypatch) -> No
     assert seen["max_batch"] == 7
     assert seen["engine"] == "engine"
     assert seen["initial"] == "moved"
+
+
+def test_write_refinement_outputs_persists_best_cif_params_and_summary(tmp_path: Path) -> None:
+    source = tmp_path / "q.cif"
+    source.write_text(
+        """data_q
+_cell_length_a 5
+_cell_length_b 5
+_cell_length_c 5
+_cell_angle_alpha 90
+_cell_angle_beta 90
+_cell_angle_gamma 90
+_symmetry_space_group_name_H-M 'P 1'
+_symmetry_Int_Tables_number 1
+loop_
+_symmetry_equiv_pos_as_xyz
+x,y,z
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_atom_site_U_iso_or_equiv
+_atom_site_thermal_displace_type
+C1 C 0.1 0.2 0.3 1.0 0.02 Uiso
+O1 O 0.4 0.5 0.6 1.0 0.03 Uani
+loop_
+_atom_site_aniso_label
+_atom_site_aniso_U_11
+_atom_site_aniso_U_22
+_atom_site_aniso_U_33
+_atom_site_aniso_U_23
+_atom_site_aniso_U_13
+_atom_site_aniso_U_12
+O1 0.03 0.04 0.05 0.001 0.002 0.003
+"""
+    )
+    cfg = ExperimentConfig.model_validate(
+        {"name": "q", "inputs": {"structure": "q.cif", "exp_data": "q.cif_pets"}}
+    )
+    refinement = RefinementSetup.from_structure(read_structure(source))
+    params = replace(
+        refinement.params,
+        asu_positions=refinement.params.asu_positions
+        + torch.tensor([[0.01, 0.0, 0.0], [0.0, 0.01, 0.0]], dtype=torch.float64),
+        occupancy_raw=torch.zeros(2, dtype=torch.float64),
+    )
+    model = build_refinement_model(initial=params)
+    event = RefinementStep(
+        iteration=0,
+        loss=0.2,
+        wr2=0.1,
+        r_obs=0.05,
+        diff_loss=0.2,
+    )
+    result = ModelRefinementResult(
+        model=model,
+        losses=torch.tensor([0.2], dtype=torch.float64),
+        best_model=model,
+        best_step=0,
+        history=(event,),
+        reflection_counts={
+            "matched": 12,
+            "matched_i_gt_3sigma": 8,
+            "matched_i_le_3sigma": 4,
+            "unmatched_observed": 3,
+        },
+    )
+
+    written = _write_refinement_outputs(tmp_path, cfg, refinement, result)
+
+    assert set(written.artifacts) == {
+        "refined_structure",
+        "refined_parameters",
+        "summary",
+        "plan",
+        "plan_lock",
+    }
+    refined = read_structure(tmp_path / "refined_structure.cif")
+    assert np.allclose(refined.frac_positions, [[0.11, 0.2, 0.3], [0.4, 0.51, 0.6]])
+    assert np.allclose(refined.occupancies, [0.5, 0.5])
+    assert np.isfinite(refined.adp.u_iso[0])
+    assert np.all(np.isfinite(refined.adp.uij_cif[1]))
+    with np.load(tmp_path / "refined_parameters.npz") as params_file:
+        assert params_file["asu_positions"].shape == (2, 3)
+        assert params_file["occupancy_raw"].shape == (2,)
+    summary = json.loads((tmp_path / "refinement_summary.json").read_text())
+    assert summary["best_epoch"] == 0
+    assert summary["total_hkl"] == "8 / 12"

--- a/tests/unit/test_refine_precision.py
+++ b/tests/unit/test_refine_precision.py
@@ -48,6 +48,10 @@ def test_refine_experiment_threads_config_precision_to_engine(monkeypatch) -> No
         return SimpleNamespace(losses=torch.tensor([1.0]), best_loss=1.0, best_step=0)
 
     monkeypatch.setattr("diffBloch.app.program.run_refinement_model", fake_run_refinement_model)
+    monkeypatch.setattr(
+        "diffBloch.app.program._write_refinement_outputs",
+        lambda root, cfg, refinement, result: result,
+    )
 
     result = refine_experiment(Path("/experiment"), device="cuda", max_batch=7)
 

--- a/tests/unit/test_select_beams.py
+++ b/tests/unit/test_select_beams.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from diffBloch.config import load_config
 from diffBloch.core.products import MosaicSmoothed
@@ -16,6 +17,7 @@ from diffBloch.preprocess import (
     select_beams,
 )
 from diffBloch.preprocess.plan import CandidatePlan
+from diffBloch.specs import IntegrationGeometry, Mosaicity, RockingCurve, SegmentedUnionCoupling
 
 QUARTZ = Path(__file__).parent.parent / "fixtures" / "quartz_anchor"
 
@@ -124,6 +126,22 @@ def test_build_orientation_plans_directly_builds_final_rocking_geometry() -> Non
     assert built.tilts.shape == (config.blochwave.rocking_curve_sampling, 3, 3)
     assert len(built.beam_plans) == config.blochwave.rocking_curve_sampling
     assert isinstance(built.tilt_reduction, MosaicSmoothed)
+
+
+def test_build_orientation_plans_rejects_reduction_or_coupling_without_rocking() -> None:
+    with pytest.raises(ValueError, match="mosaicity requires"):
+        build_orientation_plans(mosaicity=Mosaicity(window=1))
+    with pytest.raises(ValueError, match="coupling requires"):
+        build_orientation_plans(coupling=SegmentedUnionCoupling())
+
+
+def test_build_orientation_plans_rejects_mosaic_window_larger_than_sampling() -> None:
+    rocking = RockingCurve(
+        integration=IntegrationGeometry(semiangle=1.0, geometry="continuous_rotation"),
+        sampling=2,
+    )
+    with pytest.raises(ValueError, match="exceeds"):
+        build_orientation_plans(rocking, Mosaicity(window=3))
 
 
 def test_build_orientation_plans_builds_coupled_solve_geometry_before_alignment() -> None:

--- a/tests/unit/test_select_beams.py
+++ b/tests/unit/test_select_beams.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import numpy as np
 
 from diffBloch.config import load_config
+from diffBloch.core.products import MosaicSmoothed
 from diffBloch.io import read_observations, read_structure
 from diffBloch.preprocess import (
     build_orientation_plans,
@@ -109,3 +110,33 @@ def test_select_beams_preserves_source_and_defers_the_build() -> None:
     # build_orientation_plans then bridges the pruned beams to the pattern via the alignment.
     built = build_orientation_plans()(pruned).orientations[0]
     assert built.alignment.hkl.shape[1] == 3
+
+
+def test_build_orientation_plans_directly_builds_final_rocking_geometry() -> None:
+    plan, config, integration = _quartz_train_plan()
+    pruned = select_beams(config.blochwave.to_beam_selection(integration))(plan)
+
+    built = build_orientation_plans(
+        config.blochwave.to_rocking_curve(integration),
+        config.blochwave.mosaicity,
+    )(pruned).orientations[0]
+
+    assert built.tilts.shape == (config.blochwave.rocking_curve_sampling, 3, 3)
+    assert len(built.beam_plans) == config.blochwave.rocking_curve_sampling
+    assert isinstance(built.tilt_reduction, MosaicSmoothed)
+
+
+def test_build_orientation_plans_builds_coupled_solve_geometry_before_alignment() -> None:
+    plan, config, integration = _quartz_train_plan()
+
+    built = build_orientation_plans(
+        config.blochwave.to_rocking_curve(integration),
+        config.blochwave.mosaicity,
+        coupling=config.blochwave.to_policy(),
+    )(plan).orientations[0]
+
+    observed = {tuple(row) for row in plan.orientations[0].pattern.hkl.tolist()}
+    scored = {tuple(row) for row in built.alignment.hkl.tolist()}
+    simulated = {tuple(row) for row in built.beam_hkl.tolist()}
+    assert scored == observed & simulated
+    assert (0, 0, 0) in simulated


### PR DESCRIPTION
## Summary

- Restores explicit orientation filtering across the complete Bloch-wave workflow.
  - Adds `blochwave.ignore_orientations`.
  - Uses zero-based indices from the original PETS rotation order.
  - Applies filtering before train/validation splitting.
  - Excludes selected rotations from plan construction, orientation optimization, thickness optimization, inference, and structural refinement.
  - Rejects negative, duplicate, out-of-range, and all-excluded selections.

- Consolidates the default preprocessing geometry workflow.
  - Makes `build_orientation_plans` the principal displayed geometry stage.
  - Constructs central orientations and rocking-curve sub-tilts together.
  - Selects tilt-dependent SOLVE beams using `g_max` and `sg_max`.
  - Builds coupled Bloch geometry directly from the reciprocal-lattice support.
  - Keeps SOLVE-beam selection independent of experimentally observed reflections.
  - Applies the Klar filter only to the scored reflection candidate set.
  - Incorporates rocking-curve integration and mosaic reduction into the built orientation plans instead of exposing them as misleading standalone default stages.

- Restores configurable preprocessing optimization stages.
  - Adds `preprocess.optimize_orientation`.
  - Adds `preprocess.optimize_thickness`.
  - Preserves the fixed orientation-then-thickness order when both are enabled.
  - Allows either optimization stage to be disabled independently.
  - Keeps orientation and thickness settings recorded in the experiment configuration.

- Stabilizes orientation optimization scoring.
  - Preserves a fixed scored reflection set while evaluating trial orientations.
  - Prevents trial geometry changes from silently shrinking the objective to a very small number of matched reflections.
  - Retains the distinction between dynamically solved beams and experimentally scored reflections.

- Improves refinement diagnostics.
  - Reduces the default refinement budget from 500 epochs to 40.
  - Reports `wR2`, `R_obs`, and diffraction loss for every epoch.
  - Displays user-facing epoch numbers starting from 1.
  - Retains structured per-epoch metric history.
  - Records the best pre-update model snapshot and its complete metrics.

- Adds persistent best-result artifacts.
  - Writes `refined_structure.cif`.
  - Writes `refined_parameters.npz`.
  - Writes `refinement_summary.json`.
  - Exports the best epoch rather than blindly exporting the final optimizer state.
  - Writes constrained fractional coordinates, occupancies, isotropic ADPs, and anisotropic ADPs into the refined CIF.
  - Preserves the exact raw optimizer parameters in the NPZ artifact.
  - Reports absolute paths for the refined outputs, preprocessing plan, and plan lock.

- Improves terminal output.
  - Adds polished live refinement lines containing epoch, `wR2`, `R_obs`, and diffraction loss.
  - Adds polished preprocess-stage progress lines.
  - Adds aligned preprocess and refinement completion boxes.
  - Reports `HKLs (Observed/total)` as matched reflections satisfying the observation threshold divided by all matched reflections.
  - Prints the resolved preprocessing pipeline and artifact locations.

- Updates documentation and examples.
  - Documents orientation exclusion.
  - Documents the preprocessing optimization switches.
  - Documents the consolidated orientation-plan build stage.
  - Documents the 40-epoch default.
  - Documents live refinement metrics and final summaries.
  - Documents all generated refinement artifacts.
  - Updates architecture and API examples to use the current configuration and preprocessing interfaces.
  - Updates the quartz example documentation and configuration.

## Scientific behavior

- SOLVE and SCORED reflection sets remain separate.
  - SOLVE beams determine the basis used in the dynamical Bloch calculation.
  - SCORED reflections determine which calculated/observed overlap enters the objective.
  - Experimental presence does not determine which beams are allowed to couple dynamically.

- The coupled SOLVE basis is selected for rocking-curve sub-tilts using the configured reciprocal-space and excitation-error limits.

- The scoring alignment is kept stable during orientation trials so a low residual cannot be obtained merely by dropping difficult observed reflections.

- `R_obs` uses the conventional observed-reflection threshold internally, while the terminal summary presents the compact observed/total matched-HKL count.

## Validation

- `ruff check`: passed.
- `mypy`: passed with no issues across 62 source files.
- Test suite: 582 passed, 3 skipped, 1 deselected.
- Strict Sphinx documentation build: passed.
- Generated local quartz refinement outputs were intentionally left untracked and are not included in this PR.