### PR TITLE
Rewrite docsite in a physics-first style

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@
 
 Differentiable Bloch-wave structure refinement for rotating-stage 3D electron diffraction.
 
-diffBloch refines crystal structures against continuous-rotation 3DED observations: diffraction
-frames collected as the crystal is tilted/rocked through reciprocal space and reduced upstream by
-PETS2 into `.cif_pets`. Because the diffraction is dynamical — a multiple-scattering problem —
-diffBloch uses a Bloch-wave simulation rather than a kinematical approximation.
+Electrons scatter far more strongly than X-rays, so even a submicron crystal re-scatters a
+diffracted beam before it exits — dynamical, multiple-scattering diffraction rather than the
+kinematical single-scattering approximation X-ray refinement relies on. diffBloch refines crystal
+structures directly against that dynamical simulation, using continuous-rotation 3DED observations:
+diffraction frames collected as the crystal is tilted/rocked through reciprocal space and reduced
+upstream by PETS2 into `.cif_pets`.
 
-The central model is a raw crystal structure plus a settled `Plan`: the structure supplies the
-differentiable crystallographic parameters, while the `Plan` supplies the reusable geometry/data
-scaffold around them. The refinement engine iteratively minimizes a scalar R-loss so simulated and
-observed diffraction intensities agree.
+Because the Bloch-wave calculation is extremely sensitive to the exact orientation and thickness at
+each rotation, diffBloch fits both against the data first and freezes the result into a `Plan`, then
+refines the structure — atomic positions, ADPs, occupancies — against that fixed geometry by
+gradient descent on a scaling-optimized weighted R-factor.
 
 📖 **Documentation:** <https://differentiable-electron-crystallography.github.io/diffBloch/> — API reference (Sphinx + furo), rendered from the source on every green `main`.
 
@@ -100,15 +102,13 @@ This work is funded by [Schmidt Sciences](https://www.schmidtsciences.org/) and 
 the [Scientific Software Engineering Center (SSEC)](https://ai.jhu.edu/ssec/) at Johns Hopkins
 University.
 
-## Layers
+## What happens where
 
-| Layer | Role | Guide |
-|---|---|---|
-| IO | Parse CIF/PETS files into validated typed records. | [Inputs](https://differentiable-electron-crystallography.github.io/diffBloch/inputs.html) |
-| Config | Validate experiment settings and lock input/checkpoint identity. | [Inputs](https://differentiable-electron-crystallography.github.io/diffBloch/inputs.html), [Reproducibility](https://differentiable-electron-crystallography.github.io/diffBloch/reproducibility.html) |
-| Preprocess | Build and improve the immutable `Plan` the simulator consumes. | [Preprocessing](https://differentiable-electron-crystallography.github.io/diffBloch/preprocessing.html) |
-| Core | Repeatable crystallographic and Bloch-wave numerical kernels. | [Architecture](https://differentiable-electron-crystallography.github.io/diffBloch/architecture.html) |
-| Params | Differentiable structural parameters and physical constraints. | [Refinement](https://differentiable-electron-crystallography.github.io/diffBloch/refinement.html) |
-| Engine | Combine `Plan` + parameters, simulate, score, and refine. | [Refinement](https://differentiable-electron-crystallography.github.io/diffBloch/refinement.html) |
-| Observability | Track progress and debug refinements with typed events/loggers. | [Observability](https://differentiable-electron-crystallography.github.io/diffBloch/observability-guide.html) |
-| App | CLI and default orchestration around the reusable API. | [Examples](https://differentiable-electron-crystallography.github.io/diffBloch/examples.html) |
+| Physical role | Guide |
+|---|---|
+| Read the starting structure and rocking-curve data | [Inputs](https://differentiable-electron-crystallography.github.io/diffBloch/inputs.html) |
+| Fit orientation and thickness into a `Plan` | [Preprocessing](https://differentiable-electron-crystallography.github.io/diffBloch/preprocessing.html) |
+| Choose beam/rocking-curve resolution by convergence testing | [Hyperparameter selection](https://differentiable-electron-crystallography.github.io/diffBloch/hyperparameter-selection.html) |
+| Structure factors, the Bloch-wave propagator, and the refinement loop | [Architecture](https://differentiable-electron-crystallography.github.io/diffBloch/architecture.html), [Refinement](https://differentiable-electron-crystallography.github.io/diffBloch/refinement.html) |
+| Pin a fitted `Plan` so a result reproduces exactly | [Reproducibility](https://differentiable-electron-crystallography.github.io/diffBloch/reproducibility.html) |
+| Track wR2/R_obs/loss as a run progresses | [Observability](https://differentiable-electron-crystallography.github.io/diffBloch/observability-guide.html) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,38 +1,53 @@
 # Architecture
 
-diffBloch is organized around its core module: Bloch-wave simulation of multiple electron scattering.
-The surrounding layers prepare inputs, build reusable geometry, run optimization, and report
-progress without making those concerns part of the numerical core.
+Electrons interact with matter far more strongly than X-rays, so a crystal only a few tens to a few
+hundred nanometres thick already scatters a diffracted beam strongly enough to re-scatter again
+before it exits. That multiple-scattering — dynamical diffraction — means the intensity of a
+reflection is not simply proportional to \(|F_{hkl}|^2\) the way it is in the kinematical
+(single-scattering) approximation used for X-ray and neutron work. diffBloch simulates the full
+multiple-scattering problem with a Bloch-wave calculation, and makes that simulation differentiable
+so a structure can be refined against it directly, the same way X-ray refinement fits against a
+kinematical model.
 
-## End-to-end flow
+## What gets computed, in order
 
-The end-to-end flow is:
+1. A starting structure (`.cif`) and reduced rocking-curve diffraction data (`.cif_pets`) are read in.
+2. Because the Bloch-wave calculation is extremely sensitive to the exact crystal orientation and
+   specimen thickness at each rotation, both are fitted against the data before the structure is
+   touched — this is what diffBloch calls preprocessing, and its result is stored as a `Plan`.
+3. Structure factors \(F_{hkl}\) are computed from the current atomic positions, ADPs, and
+   occupancies.
+4. For each rotation, the beam set within the chosen resolution is propagated through the crystal
+   thickness — an eigenvalue problem for a static tilt, or a matrix exponential when refining, since
+   it stays stable under backpropagation — and the tilts spanning that rotation's rocking curve are
+   summed to give one simulated intensity per reflection.
+5. Simulated and observed intensities are compared with a scaling-optimized weighted R-factor.
+6. Gradients of that R-factor flow back through the whole calculation to the atomic parameters, and
+   an ordinary PyTorch optimizer (Adam or L-BFGS) updates them. Steps 3–6 repeat until the structure
+   converges.
 
-1. `.cif` + `.cif_pets` + config are parsed into typed records.
-2. Preprocessing turns those records into a reusable `Plan`.
-3. The `Plan` and differentiable structural parameters feed the Bloch-wave simulation.
-4. The simulated diffraction intensities are compared with experiment and loss is calculated. 
-5. Gradients from that loss update the differentiable structural parameters, then the loop repeats, improving the agreement between simulation and experiment.
+Preprocessing (step 2) and refinement (steps 3–6) are deliberately separate: a `Plan` is expensive to
+compute but describes only geometry, not the structure, so it can be checkpointed once and reused
+across many refinements of the same dataset. See [Preprocessing](preprocessing.md) for how orientation
+and thickness are fitted, and [Refinement](refinement.md) for the optimization loop itself.
 
-## Layers
+## Where each piece lives
 
-| Layer | Role | Guide |
+| Physical role | Code | Guide |
 |---|---|---|
-| [IO](api/io.md) | Parse CIF/PETS files into validated typed records. | [Inputs](inputs.md) |
-| [Config](api/config.md) | Validate experiment settings and lock input/checkpoint identity. | [Inputs](inputs.md), [Reproducibility](reproducibility.md) |
-| [Preprocess](api/preprocess.md) | Build and improve the immutable `Plan` the simulator consumes. | [Preprocessing](preprocessing.md) |
-| [Core](api/core.md) | Bloch-wave numerical kernels. | [Architecture](architecture.md), [Refinement](refinement.md) |
-| [Params](api/params.md) | Differentiable structural parameters and physical constraints. | [Refinement](refinement.md) |
-| [Engine](api/engine.md) | Combine `Plan` + parameters, simulate, score, and refine. | [Refinement](refinement.md) |
-| [Observability](api/observability.md) | Emit typed events without coupling the core to logger backends. | [Observability](observability-guide.md) |
-| [App](api/app.md) | CLI and default orchestration around the reusable API. | [Examples](examples.md), [Refinement](refinement.md) |
+| Parse `.cif` / `.cif_pets` into validated records | [`io`](api/io.md) | [Inputs](inputs.md) |
+| Validate `experiment.yaml`, pin input identity | [`config`](api/config.md) | [Inputs](inputs.md), [Reproducibility](reproducibility.md) |
+| Fit orientation and thickness, build the `Plan` | [`preprocess`](api/preprocess.md) | [Preprocessing](preprocessing.md) |
+| Structure factors and the Bloch-wave propagator | [`core`](api/core.md) | [Refinement](refinement.md) |
+| Atomic positions, ADPs, occupancies, and their crystallographic constraints | [`params`](api/params.md) | [Refinement](refinement.md) |
+| Simulate, score, and run the optimization loop | [`engine`](api/engine.md) | [Refinement](refinement.md) |
+| Report per-rotation R-factors and progress | [`observability`](api/observability.md) | [Observability](observability-guide.md) |
+| CLI and default recipes | [`app`](api/app.md) | [Examples](examples.md) |
 
-## API shape
+## Running the whole calculation from Python
 
-This pseudocode shows the declarative public API shape underneath the CLI: load typed inputs,
-compose a `Plan -> Plan` preprocessing recipe, build an engine from the settled `Plan`, then run the
-refinement model while typed progress events flow to loggers. The example is close to runnable code,
-but it is shown as API shape rather than a recipe to copy verbatim.
+The CLI (`diffbloch run refine ...`) is a thin wrapper over the same public functions shown below:
+read the inputs, fit orientation/thickness into a `Plan`, then simulate and refine against it.
 
 ```python
 from pathlib import Path
@@ -55,18 +70,18 @@ from diffBloch.specs import ScoredHklSelection, TrialCoupling
 
 root = Path("examples/experiments/quartz-checkpoint")
 
-# Boundary: parse experiment.yaml, verify experiment.lock, and read typed CIF/PETS records.
+# Read the starting structure and the rocking-curve observations.
 cfg, experiment_lock = load_experiment(root)
 structure = read_structure(root / cfg.inputs.structure, load_hydrogens=cfg.inputs.load_hydrogens)
 observations = read_observations(root / cfg.inputs.exp_data)
 
-# Effects stay at the edge: loggers consume typed events from preprocessing/refinement.
+# Progress (per-rotation wR2/R_obs, orientation-search steps, ...) streams to these loggers.
 logger = MultiLogger((ConsoleLogger(), CSVLogger(root / "events.csv")))
 
-# Initial construction: raw input records become a Plan scaffold plus structure-side params/specs.
+# Build the initial (unfitted) geometry scaffold and the differentiable structural parameters.
 setup = from_experiment(structure, observations, cfg)
 
-# Scientific choices are explicit typed values, not a string registry or hidden CLI behavior.
+# The beam set re-derived at every trial orientation during the search below.
 trial_coupling = TrialCoupling(
     policy=cfg.blochwave.to_policy(),
     scored=ScoredHklSelection(
@@ -75,7 +90,7 @@ trial_coupling = TrialCoupling(
     ),
 )
 
-# Preprocessing is declarative composition of Plan -> Plan steps.
+# Fit orientation, then specimen thickness, per rotation.
 prepare = pipeline(
     [
         build_orientation_plans(
@@ -102,7 +117,7 @@ prepare = pipeline(
 )
 plan = prepare(setup.plans.combined)
 
-# Inference is the terminal score-only path: same settled Plan, no optimizer updates.
+# Simulate and score the settled Plan without changing the structure.
 inference = run_inference(
     plan,
     setup.refinement,
@@ -110,7 +125,7 @@ inference = run_inference(
     logger=logger,
 )
 
-# Refinement composes a pure engine/context with model/problem values, then runs the optimizer shell.
+# Refine: simulate, compare with experiment, and update atomic parameters by gradient descent.
 engine = build_engine(
     plan,
     setup.refinement,

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -37,12 +37,17 @@ uv run diffbloch run refine examples/experiments/abiraterone-checkpoint --device
 
 ## Catalog
 
-| Example | Purpose |
+The four bundled examples span the two axes that matter most for cost and behavior: unit-cell size
+(which sets the beam count, and with it the O(N³) eigensolve cost and whether the large-cell fork
+routes past it — see [Preprocessing](preprocessing.md#routing-on-cell-size)) and structural
+complexity (whether hydrogens and their riding-model treatment are in play).
+
+| Example | What it demonstrates |
 |---|---|
-| `examples/experiments/quartz` | Small full run from input files through preprocessing and refinement. |
-| `examples/experiments/quartz-checkpoint` | Fast-start quartz run from a committed preprocess checkpoint. |
-| `examples/experiments/abiraterone-checkpoint` | Larger molecular example; good CUDA/refine demonstration. |
-| `examples/experiments/lta` | Larger zeolite example. |
+| `examples/experiments/quartz` | Small unit cell (~113 Å³), no hydrogens; a full run from raw inputs, and the reproducibility anchor other changes are checked against. |
+| `examples/experiments/quartz-checkpoint` | Same structure, starting from a committed fitted `Plan` — the fast path once orientation/thickness are already settled. |
+| `examples/experiments/abiraterone-checkpoint` | A larger organic molecule with hydrogens, so the hydrogen riding-model constraint (see [Refinement](refinement.md#advanced-composition-constraints-restraints-and-learned-thickness)) is exercised; a CUDA/refine demonstration. |
+| `examples/experiments/lta` | A zeolite well above the large-cell threshold — routes through the faster orientation-search branch and benefits most from a GPU. |
 
 ## Python API example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,13 +27,13 @@ diffBloch performs the refinement as two complementary values: a crystal structu
 
 | Guide | What it covers |
 |---|---|
-| [Architecture](architecture.md) | Code Structure. |
-| [Inputs](inputs.md) | Data needed to refine a structure. |
-| [Preprocessing](preprocessing.md) | Initial steps before refinement. |
+| [Architecture](architecture.md) | Why dynamical diffraction needs a Bloch-wave simulation, and how the pieces fit together. |
+| [Inputs](inputs.md) | The starting structure and rocking-curve data a refinement needs. |
+| [Preprocessing](preprocessing.md) | Fitting crystal orientation and specimen thickness before the structure is touched. |
 | [Hyperparameter selection](hyperparameter-selection.md) | Choosing beam and rocking-curve settings using convergence tests. |
-| [Refinement](refinement.md) | Optimizing crystal structure |
-| [Reproducibility](reproducibility.md) | How `experiment.lock`, `plan.npz`, and `plan.lock` let later runs verify and reuse expensive preprocessing results. |
-| [Observability](observability-guide.md) | How to track progress and debug refinements. |
+| [Refinement](refinement.md) | The optimization loop: constraints, restraints, and thickness models alongside the structure. |
+| [Reproducibility](reproducibility.md) | How `experiment.lock`, `plan.npz`, and `plan.lock` pin a fitted `Plan` so a result can be reproduced exactly. |
+| [Observability](observability-guide.md) | Tracking wR2, R_obs, and diffraction loss as a run progresses. |
 | [Examples](examples.md) | Runnable example experiments for small and large compounds, and implementations of papers that demonstrate doing science with diffBloch. |
 
 For day-to-day use, start with the CLI quickstart below. For custom scientific workflows, the same

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -24,11 +24,14 @@ Bundled binary artifacts such as `.cif_pets` observations and committed `plan.np
 tracked with Git LFS. After cloning, run `git lfs pull` before validating or running checkpointed
 examples so these files are present as real data rather than LFS pointer files.
 
-## Typed IO boundary
+## Reading the structure and the observations
 
-diffBloch does not pass parser output directly into numerical kernels. It parses CIF/PETS inputs
-into typed Pydantic records first, so unsupported shapes, units, missing fields, or invalid values
-fail at the boundary.
+Reading a CIF gives fractional atomic coordinates, ADPs (isotropic or anisotropic, per atom), site
+occupancies, and the space-group symmetry operations. Reading a `.cif_pets` gives the reduced
+rocking-curve data: the UB matrix, cell parameters, per-rotation goniometer angles, and the observed
+hkl/intensity/sigma triples. Both are parsed into validated records before anything numerical touches
+them, so a malformed CIF, an unsupported ADP type, or a unit mismatch fails immediately at read time
+rather than surfacing later as a silently wrong simulation.
 
 The public records are:
 

--- a/docs/observability-guide.md
+++ b/docs/observability-guide.md
@@ -1,13 +1,16 @@
 # Observability and loggers
 
-diffBloch reports progress by emitting typed events. A logger is any object with one method:
+A refinement run reports the quantities that matter to a crystallographer as it goes: wR2 and R_obs
+per rotation during orientation fitting, thickness and its residual per rotation during thickness
+fitting, and the epoch-by-epoch loss, wR2, and R_obs during structure refinement. diffBloch keeps
+that reporting separate from the simulation itself — the numerical core never decides how or whether
+a value gets displayed, it just hands out plain event objects, and whatever loggers you attach decide
+what to do with them: print to the console, write a CSV row, or send to an experiment tracker such as
+Weights & Biases. A logger is any object with one method:
 
 ```python
 def report(event): ...
 ```
-
-The scientific core hands loggers plain event objects; logger backends decide whether to print,
-write CSV rows, or send values to an experiment tracker.
 
 ## Built-in loggers
 
@@ -42,6 +45,9 @@ print(result.mean_r_obs)
 
 ## API example: custom logger
 
+A minimal logger that just remembers the last event — enough to inspect, e.g., the final epoch's wR2
+after a run:
+
 ```python
 from dataclasses import dataclass, field
 
@@ -61,6 +67,6 @@ Every event exposes:
 
 - `channel` — e.g. `rotation`, `coupling`, `refinement`;
 - `step` — a rotation index, refinement iteration, or `None` for run-level summaries;
-- `measurements` — numeric values suitable for plotting or logging.
+- `measurements` — numeric values such as wR2, R_obs, or diffraction loss.
 
 See the [observability API](api/observability.md) for the event classes.

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -120,8 +120,8 @@ print(refinement_setup.params.asu_positions.shape)
 
 ## `Plan -> Plan` steps
 
-Preprocessing is a composable `Plan -> Plan` pipeline. Any function with that shape receives a
-`Plan`, does one focused piece of work, and returns an updated `Plan`.
+Preprocessing is a sequence of small, focused steps, each taking a `Plan` and returning an updated
+one — one step builds the tilt geometry, another fits orientation, another fits thickness.
 
 The default app recipe begins with one displayed `build_orientation_plans` stage. It calculates the
 shared structure-factor support, constructs every central orientation and rocking sub-tilt,
@@ -138,13 +138,6 @@ Real steps include:
 - {func}`diffBloch.preprocess.steps.fit_orientation.fit_orientation` — search nearby orientations and keep the best-scoring one.
 - {func}`diffBloch.preprocess.steps.fit_thickness.fit_thickness` — search mean specimen thickness and keep the best-scoring value.
 - {func}`diffBloch.preprocess.driver.converge_numerics` — test convergence over `g_max`, `sg_max`, and `tilt_steps`.
-
-The pipeline also provides composition helpers such as {func}`diffBloch.preprocess.pipeline.fork`,
-{func}`diffBloch.preprocess.pipeline.iterate_until`, and
-{func}`diffBloch.preprocess.pipeline.stateful_plan_step` for conditional, repeated, or stateful
-preprocess logic. More advanced steps use the same contract: convergence sweeps repeatedly improve
-numerical plan values, while `fit_orientation` and `fit_thickness` score candidate plans and return
-the best updated `Plan`.
 
 ## API example: composing simple steps
 
@@ -203,68 +196,19 @@ print(len(orientations))
 print(plan.structure_factor_grid.structure_factor_hkl.shape)
 ```
 
-## API shape: branching, looping, and stateful drivers
+## Routing on cell size
 
-Advanced branching and looping pipelines can be composed with
-{func}`diffBloch.preprocess.pipeline.fork`,
-{func}`diffBloch.preprocess.pipeline.iterate_until`, and
-{func}`diffBloch.preprocess.pipeline.stateful_plan_step`.
+The coupled orientation search's cost scales roughly as \(N^3\) in the beam count \(N\), and \(N\)
+grows with unit-cell volume. Above a fixed volume threshold, diffBloch skips a per-trial integrity
+check in the search that costs proportionally more on a large coupled beam set, without changing the
+search itself — the fitted orientation is always re-scored under the full check once the search
+settles. Below the threshold (quartz, at \(\sim 113\ \text{Å}^3\), included) the check runs on every
+trial. This routing is built with {func}`diffBloch.preprocess.pipeline.fork`, which picks one of two
+step lists from the structure-factor grid before the recipe is checkpointed, so a committed `Plan` is
+unaffected by which branch produced it.
 
-`fork` constructs a {class}`diffBloch.preprocess.pipeline.Fork` value: the lowercase function is the
-user-facing combinator, while uppercase `Fork` is the returned dataclass/type used for recipe
-resolution. It chooses one of two step lists from the immutable structure-factor grid, so the chosen
-recipe can still be resolved before checkpointing; the default app recipe uses this shape to route
-large cells through a faster orientation-fit branch that skips per-trial gather integrity checks.
-`iterate_until` wraps a repeated
-`Plan -> Plan` improvement behind the same step shape.
-
-The convergence path is the stateful version of this idea. Its public pipeline surface is still a
-single `Plan -> Plan` step, but internally {func}`diffBloch.preprocess.driver.converge_numerics`
-varies `g_max`, `sg_max`, and `tilt_steps`, rebuilding the simulation at each setting. The generic
-shape is formalized as
-{data}`diffBloch.preprocess.pipeline.StatefulPlanStep`,
-{func}`diffBloch.preprocess.pipeline.stateful_pipeline`, and
-{func}`diffBloch.preprocess.pipeline.stateful_plan_step`: an explicit immutable state threaded
-between phases and dropped again at the `Plan -> Plan` boundary.
-
-```python
-from dataclasses import dataclass
-
-from diffBloch.preprocess import (
-    fork,
-    identity,
-    iterate_until,
-    stateful_pipeline,
-    stateful_plan_step,
-)
-
-large_cell_branch = fork(
-    lambda grid: grid.cell_volume > 1000.0,
-    when_true=[identity()],   # e.g. coarse/faster steps for large cells
-    when_false=[identity()],  # e.g. exact/default steps for small cells
-)
-
-repeat_until_stable = iterate_until(
-    identity(),
-    until=lambda previous, current: previous is current,
-    max_iterations=1,
-)
-
-@dataclass(frozen=True)
-class SearchState:
-    tried: int = 0
-
-
-def bump_trial_count(plan, state: SearchState):
-    # A real driver would rebuild a candidate Plan from state, score it, and return the new carry.
-    return plan, SearchState(tried=state.tried + 1)
-
-
-stateful_driver = stateful_plan_step(
-    init_state=lambda plan: SearchState(),
-    step=stateful_pipeline([bump_trial_count, bump_trial_count]),
-)
-```
-
-For real convergence, prefer the provided convergence steps and driver rather than the trivial
-`identity` placeholders above.
+Numerical convergence testing — sweeping `g_max`, `sg_max`, and rocking-curve sampling until the
+simulated intensities stop changing — uses the same `Plan -> Plan` step shape, built with
+{func}`diffBloch.preprocess.driver.converge_numerics`. See
+[Hyperparameter selection](hyperparameter-selection.md) for the physics behind that sweep and a
+runnable example.

--- a/docs/refinement.md
+++ b/docs/refinement.md
@@ -72,23 +72,26 @@ print(result.history[result.best_step].wr2)
 print(result.history[result.best_step].r_obs)
 ```
 
-## Advanced composition: constraints, penalties, and learned thickness
+## Advanced composition: constraints, restraints, and learned thickness
 
 The default CLI refinement is intentionally conservative: it refines selected structural parameter
-groups against diffraction. The lower-level API also supports richer composition:
+groups against diffraction alone. Real structures often need more of the machinery familiar from
+X-ray least-squares refinement, and the lower-level Python API exposes it directly:
 
-- **crystallographic constraints** are built into `RefinementSetup.from_structure(...)`; special-
-  position coordinates and ADP equality constraints are always enforced by the parameter
-  `constrain(...)` path;
-- **hard molecular constraints** are per-atom/structure transforms applied after crystallographic
-  constraints, such as hydrogen riding, where H atoms stay in the forward scattering but ride on
-  their parent heavy atoms;
-- **soft penalties** are additive objective terms across atoms, such as bond-length penalties;
-- **components** are trainable non-structural model pieces that provide dependent forward-model
-  values, such as apparent thickness, alongside the structural parameters.
+- **special-position and ADP symmetry constraints** are enforced automatically wherever
+  `RefinementSetup.from_structure(...)` builds the parameters — an atom on a special position never
+  acquires an unphysical degree of freedom, and symmetry-equivalent ADPs never drift apart;
+- **hard constraints** fix the geometric relationship between atoms exactly, e.g. a riding model
+  where hydrogens keep contributing to the calculated scattering but move rigidly with their parent
+  heavy atom rather than refining independent coordinates;
+- **restraints** (soft penalties) pull a quantity toward a target without fixing it, e.g. keeping a
+  bond length close to a chemically reasonable value; the optimizer can still trade the restraint off
+  against the diffraction fit, unlike a hard constraint;
+- **thickness models** treat the apparent specimen thickness at each tilt as a trainable quantity
+  alongside the atomic parameters, rather than a fixed value fitted once during preprocessing.
 
-Compose a structure component, optional hard constraints, optional soft penalties, and optional
-forward-model components, then optimize all selected leaves through one objective.
+Compose a structure, optional hard constraints, optional restraints, and an optional thickness model,
+then refine every selected parameter through one objective.
 
 ```python
 from pathlib import Path

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -1,15 +1,20 @@
 # Reproducibility and checkpoints
 
-diffBloch separates input identity from generated artifacts.
+Fitting orientation and thickness (see [Preprocessing](preprocessing.md)) is a greedy, local search
+over a bumpy objective — the coupled wR2 landscape has many nearby local minima, so a small
+floating-point difference between two runs can occasionally send the search into a different basin
+and change the fitted orientation, and with it the reported R-factor. Reproducing a specific result
+therefore means more than reproducing the code: it means starting from the exact same fitted `Plan`,
+not merely re-running the same search and hoping it lands in the same place. diffBloch checkpoints
+that fitted geometry and locks it to everything that determined it, so a later run can either verify
+it is reusing the identical starting point or refuse to.
 
 - `experiment.lock` pins the input structure and observation files by content hash.
 - `plan.lock` ties a `plan.npz` checkpoint to the input lock, resolved preprocess-determining config,
   ordered preprocess recipe, producing code version, and checkpoint artifact hash.
 
-This gives inference and refinement a verifiable starting point: a reused `plan.npz` is known to
-match the inputs and preprocessing recipe that produced it. In committed examples, `plan.npz` and
-`.cif_pets` files are Git LFS artifacts; `plan.lock` verifies the realized file bytes after LFS
-checkout, not the small pointer file.
+In committed examples, `plan.npz` and `.cif_pets` files are Git LFS artifacts; `plan.lock` verifies
+the realized file bytes after LFS checkout, not the small pointer file.
 
 ## What this guarantees
 
@@ -22,9 +27,11 @@ A valid preprocess checkpoint verifies:
 
 ## What this does not guarantee
 
-The locks do not claim hardware-independent optimizer determinism. Device, thread scheduling,
-precision, and optimizer implementation details can still affect floating-point trajectories,
-especially for refinement. The lock guarantees the identity of the preprocessed starting point.
+The lock guarantees the identity of the fitted starting point, not hardware-independent optimizer
+determinism downstream of it. Device, thread scheduling, and optimizer implementation details can
+still shift the refinement's floating-point trajectory — most consequentially for a fresh orientation
+search, since that is exactly the bumpy-landscape case above; a *reused* checkpoint sidesteps it
+entirely, since the search was already run and its result is frozen.
 
 ## API example
 


### PR DESCRIPTION
Reframes the docs guides and README around the underlying dynamical-diffraction physics (why Bloch-wave, orientation/thickness fitting, reproducibility of the fitted geometry, etc.) rather than software-architecture vocabulary. Verified with `sphinx-build -W` — clean build, no broken cross-references.