### PR TITLE
feat(preprocess): add per-orientation optimizer portfolio

### DIFF
--- a/src/diffBloch/preprocess/__init__.py
+++ b/src/diffBloch/preprocess/__init__.py
@@ -83,6 +83,7 @@ from diffBloch.preprocess.steps.import_orientations import import_orientations
 from diffBloch.preprocess.steps.mosaicity import mosaicity
 from diffBloch.preprocess.steps.optimize_orientation import optimize_orientation
 from diffBloch.preprocess.steps.optimize_thickness import optimize_thickness
+from diffBloch.preprocess.steps.orientation_portfolio import select_orientation_portfolio
 from diffBloch.preprocess.steps.report_coupling import report_coupling
 from diffBloch.preprocess.steps.rocking_curve import integrate_rocking_curve
 from diffBloch.specs import (
@@ -128,6 +129,7 @@ __all__ = [
     "converge_scalar",
     "cover_beams",
     "optimize_orientation",
+    "select_orientation_portfolio",
     "optimize_thickness",
     "import_orientations",
     "fork",

--- a/src/diffBloch/preprocess/steps/orientation_portfolio.py
+++ b/src/diffBloch/preprocess/steps/orientation_portfolio.py
@@ -1,0 +1,196 @@
+"""``select_orientation_portfolio``: choose among Ben-style orientation optimizers per rotation.
+
+This is an opt-in typed Python composition step for orientation-recreation experiments, not part of
+the default app recipe. It does not implement a second orientation optimizer. Instead it runs Ben's
+canonical :func:`optimize_orientation` step multiple times from the same built seed plan, changing
+only the labelled :class:`~diffBloch.specs.NelderMeadSearch` parameters supplied by
+:class:`~diffBloch.specs.OrientationPortfolioSearch`.
+
+For each rotation independently, the step chooses the candidate with the lowest terminal wR2 loss
+under ``selection_method``. This is what "portfolio" means here: different orientations in the
+returned ``Plan`` may have been produced by different optimizer-parameter policies. The selector is
+non-oracle; reference orientation CSVs are not accepted or consulted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from math import isfinite
+
+from diffBloch.core.solver import SolverMethod
+from diffBloch.engine.plan import OrientationPlanLike
+from diffBloch.params import Device
+from diffBloch.preprocess.experiment import RefinementSetup
+from diffBloch.preprocess.pipeline import PlanStep, as_step
+from diffBloch.preprocess.plan import Plan, require_built_plans
+from diffBloch.preprocess.scoring import build_engine
+from diffBloch.preprocess.steps.beams import build_orientation_plans
+from diffBloch.preprocess.steps.optimize_orientation import optimize_orientation
+from diffBloch.specs import (
+    NO_ABSORPTION,
+    Absorption,
+    Mosaicity,
+    NelderMeadSearch,
+    OrientationPortfolioSearch,
+    RockingCurve,
+    TrialCoupling,
+)
+
+__all__ = ["select_orientation_portfolio"]
+
+
+@dataclass(frozen=True)
+class _VariantResult:
+    """One labelled optimizer variant plus terminal per-rotation wR2 losses."""
+
+    label: str
+    plan: Plan
+    wr2: tuple[float, ...]
+
+
+def select_orientation_portfolio(
+    refinement: RefinementSetup,
+    search: OrientationPortfolioSearch | None = None,
+    *,
+    rocking: RockingCurve,
+    mosaicity: Mosaicity | None = None,
+    coupling: TrialCoupling,
+    orientation_method: SolverMethod = "matrix_exp",
+    selection_method: SolverMethod = "bloch_eigen",
+    validate: bool = True,
+    workers: int = 1,
+    device: Device | None = None,
+    max_batch: int | None = None,
+    absorption: Absorption = NO_ABSORPTION,
+) -> PlanStep:
+    """Return a ``Plan -> Plan`` step selecting an orientation optimizer per rotation.
+
+    The input ``plan`` must be in the candidate phase. The step first builds the same rocking,
+    mosaic, coupled seed geometry that each optimizer variant will refine. It then applies
+    :func:`optimize_orientation` once per configured variant and evaluates each resulting plan with
+    terminal wR2. The returned plan splices together the best-scoring orientation at each rotation
+    position.
+
+    ``orientation_method`` controls the solver used during each Nelder-Mead search.
+    ``selection_method`` controls the solver used for terminal wR2 winner selection. In the quartz
+    anchor diagnostics this mirrors the e2e shape: matrix-exponential search, Bloch-eigen terminal
+    scoring. ``validate``, ``workers``, ``device``, and ``max_batch`` are execution controls
+    forwarded to the optimizer/evaluator; the portfolio spec and scientific geometry knobs are
+    recorded in the step provenance.
+    """
+    portfolio = OrientationPortfolioSearch() if search is None else search
+    build = build_orientation_plans(
+        rocking,
+        mosaicity,
+        coupling=coupling.policy,
+        scoring_selection=coupling.scored.klar,
+    )
+
+    def run(plan: Plan) -> Plan:
+        seed_plan = build(plan)
+        variant_results = tuple(
+            _run_variant(
+                label,
+                seed_plan,
+                refinement,
+                search_variant,
+                coupling=coupling,
+                orientation_method=orientation_method,
+                selection_method=selection_method,
+                validate=validate,
+                workers=workers,
+                device=device,
+                max_batch=max_batch,
+                absorption=absorption,
+            )
+            for label, search_variant in portfolio.variants
+        )
+        selected = _select_by_wr2(variant_results)
+        return replace(seed_plan, orientations=selected)
+
+    return as_step(
+        "select_orientation_portfolio",
+        {
+            "search": portfolio,
+            "rocking": rocking,
+            "mosaicity": mosaicity,
+            "coupling": coupling,
+            "orientation_method": orientation_method,
+            "selection_method": selection_method,
+            "absorption": absorption,
+        },
+        run,
+    )
+
+
+def _run_variant(
+    label: str,
+    seed_plan: Plan,
+    refinement: RefinementSetup,
+    search: NelderMeadSearch,
+    *,
+    coupling: TrialCoupling,
+    orientation_method: SolverMethod,
+    selection_method: SolverMethod,
+    validate: bool,
+    workers: int,
+    device: Device | None,
+    max_batch: int | None,
+    absorption: Absorption,
+) -> _VariantResult:
+    step = optimize_orientation(
+        refinement,
+        search,
+        method=orientation_method,
+        coupling=coupling,
+        validate=validate,
+        workers=workers,
+        device=device,
+        max_batch=max_batch,
+        absorption=absorption,
+    )
+    fitted = step(seed_plan)
+    engine = build_engine(
+        fitted,
+        refinement,
+        method=selection_method,
+        max_batch=max_batch,
+        absorption=absorption,
+    )
+    params = refinement.params if device is None else refinement.params.to(device)
+    fgb = engine.fgb(params)
+    return _VariantResult(
+        label=label,
+        plan=fitted,
+        wr2=tuple(
+            float(engine.score_orientation(orientation, fgb))
+            for orientation in require_built_plans(fitted)
+        ),
+    )
+
+
+def _select_by_wr2(results: tuple[_VariantResult, ...]) -> tuple[OrientationPlanLike, ...]:
+    """Choose the lowest finite terminal wR2 independently at each plan position.
+
+    Finite candidates always beat non-finite candidates; if every variant is non-finite for a
+    rotation, the first variant wins deterministically rather than making the whole preprocess step
+    fail.
+    """
+    if not results:
+        raise ValueError("orientation portfolio needs at least one variant result")
+    n_orientations = len(results[0].plan.orientations)
+    if any(len(result.plan.orientations) != n_orientations for result in results):
+        raise ValueError("orientation portfolio variant plans must have the same length")
+    if any(len(result.wr2) != n_orientations for result in results):
+        raise ValueError("orientation portfolio scores must match variant plan length")
+
+    selected = []
+    for index in range(n_orientations):
+        best = min(results, key=lambda result: _wr2_key(result.wr2[index]))
+        selected.append(require_built_plans(best.plan)[index])
+    return tuple(selected)
+
+
+def _wr2_key(value: float) -> tuple[bool, float]:
+    """Sort key: finite scores first, lower scores better, all non-finite tied."""
+    return (not isfinite(value), value if isfinite(value) else 0.0)

--- a/src/diffBloch/specs.py
+++ b/src/diffBloch/specs.py
@@ -32,6 +32,7 @@ __all__ = [
     "IntegrationGeometry",
     "Mosaicity",
     "NelderMeadSearch",
+    "OrientationPortfolioSearch",
     "OrientationSelection",
     "PerTiltCoupling",
     "RockingCurve",
@@ -243,6 +244,48 @@ class NelderMeadSearch:
             raise ValueError("max_iterations must be >= 1")
         if self.x_tolerance <= 0.0 or self.f_tolerance <= 0.0:
             raise ValueError("x_tolerance and f_tolerance must be positive")
+
+
+@dataclass(frozen=True)
+class OrientationPortfolioSearch:
+    """Fixed portfolio of Ben-style orientation optimizers for non-oracle selection.
+
+    This is an opt-in Python/API experiment spec, not default-path config. It records a small set
+    of labelled :class:`NelderMeadSearch` variants. A portfolio run applies Ben's canonical
+    ``optimize_orientation`` step once per variant, then chooses a result independently for each
+    rotation.
+
+    "Portfolio" is literal here: different orientations in one returned ``Plan`` may come from
+    different optimizer-parameter policies. Selection is intentionally narrow and non-oracle:
+    choose the candidate with the lowest terminal wR2 loss for that rotation. Reference
+    orientation CSVs are not an input to this spec or selector.
+    """
+
+    variants: tuple[tuple[str, NelderMeadSearch], ...] = field(
+        default_factory=lambda: (
+            ("default_step_0.05_penalty", NelderMeadSearch()),
+            ("fine_step_0.01_penalty", NelderMeadSearch(step_size=0.01)),
+            ("finer_step_0.005_penalty", NelderMeadSearch(step_size=0.005)),
+        )
+    )
+    selector: Literal["lowest_terminal_wr2"] = "lowest_terminal_wr2"
+
+    def __post_init__(self) -> None:
+        if self.selector != "lowest_terminal_wr2":
+            raise ValueError("orientation portfolio only supports selector='lowest_terminal_wr2'")
+        if not self.variants:
+            raise ValueError("orientation portfolio needs at least one variant")
+        names = [name for name, _search in self.variants]
+        if any(not name for name in names):
+            raise ValueError("orientation portfolio variant names must be non-empty")
+        if len(set(names)) != len(names):
+            raise ValueError("orientation portfolio variant names must be unique")
+        for name, search in self.variants:
+            if not search.penalize_fewer_reflections:
+                raise ValueError(
+                    "orientation portfolio variants must keep penalize_fewer_reflections=True; "
+                    f"{name!r} disables it"
+                )
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_orientation_portfolio.py
+++ b/tests/unit/test_orientation_portfolio.py
@@ -1,0 +1,171 @@
+"""Unit coverage for the opt-in orientation-optimizer portfolio step."""
+
+from __future__ import annotations
+
+from math import nan
+from types import SimpleNamespace
+
+import pytest
+
+from diffBloch.preprocess.pipeline import spec_to_params, step_records
+from diffBloch.preprocess.plan import Plan
+from diffBloch.preprocess.steps.orientation_portfolio import _select_by_wr2, _VariantResult
+from diffBloch.specs import NelderMeadSearch, OrientationPortfolioSearch
+
+
+def _plan(*tokens: object) -> Plan:
+    return Plan(structure_factor_grid=None, orientations=tokens)  # type: ignore[arg-type]
+
+
+def test_orientation_portfolio_search_defaults_are_labelled_ben_optimizer_variants() -> None:
+    search = OrientationPortfolioSearch()
+
+    assert [name for name, _variant in search.variants] == [
+        "default_step_0.05_penalty",
+        "fine_step_0.01_penalty",
+        "finer_step_0.005_penalty",
+    ]
+    assert search.variants[0][1] == NelderMeadSearch()
+    assert all(variant.penalize_fewer_reflections for _name, variant in search.variants)
+
+
+def test_orientation_portfolio_search_rejects_ambiguous_variant_labels() -> None:
+    duplicate = (
+        ("same", NelderMeadSearch()),
+        ("same", NelderMeadSearch(step_size=0.01)),
+    )
+
+    with pytest.raises(ValueError, match="variant names must be unique"):
+        OrientationPortfolioSearch(variants=duplicate)
+
+
+def test_orientation_portfolio_search_requires_matched_count_penalty() -> None:
+    with pytest.raises(ValueError, match="penalize_fewer_reflections=True"):
+        OrientationPortfolioSearch(
+            variants=(("raw", NelderMeadSearch(penalize_fewer_reflections=False)),)
+        )
+
+
+def test_orientation_portfolio_provenance_records_every_variant() -> None:
+    params = spec_to_params(
+        {
+            "search": OrientationPortfolioSearch(
+                variants=(
+                    ("default", NelderMeadSearch()),
+                    ("fine", NelderMeadSearch(step_size=0.01)),
+                )
+            )
+        }
+    )
+
+    assert params == {
+        "search": {
+            "__type__": "OrientationPortfolioSearch",
+            "variants": [
+                [
+                    "default",
+                    {
+                        "__type__": "NelderMeadSearch",
+                        "step_size": 0.05,
+                        "max_iterations": 60,
+                        "x_tolerance": 0.001,
+                        "f_tolerance": 0.001,
+                        "penalize_fewer_reflections": True,
+                    },
+                ],
+                [
+                    "fine",
+                    {
+                        "__type__": "NelderMeadSearch",
+                        "step_size": 0.01,
+                        "max_iterations": 60,
+                        "x_tolerance": 0.001,
+                        "f_tolerance": 0.001,
+                        "penalize_fewer_reflections": True,
+                    },
+                ],
+            ],
+            "selector": "lowest_terminal_wr2",
+        }
+    }
+
+
+def test_select_by_wr2_chooses_independently_per_orientation() -> None:
+    a0 = SimpleNamespace(name="a0")
+    a1 = SimpleNamespace(name="a1")
+    b0 = SimpleNamespace(name="b0")
+    b1 = SimpleNamespace(name="b1")
+    c0 = SimpleNamespace(name="c0")
+    c1 = SimpleNamespace(name="c1")
+
+    selected = _select_by_wr2(
+        (
+            _VariantResult("a", _plan(a0, a1), (0.10, 0.40)),
+            _VariantResult("b", _plan(b0, b1), (0.20, 0.20)),
+            _VariantResult("c", _plan(c0, c1), (0.30, 0.30)),
+        )
+    )
+
+    assert selected == (a0, b1)
+
+
+def test_select_by_wr2_rejects_mismatched_plan_lengths() -> None:
+    with pytest.raises(ValueError, match="same length"):
+        _select_by_wr2(
+            (
+                _VariantResult("a", _plan(object()), (0.1,)),
+                _VariantResult("b", _plan(object(), object()), (0.1, 0.2)),
+            )
+        )
+
+
+def test_select_by_wr2_prefers_finite_scores_and_falls_back_deterministically() -> None:
+    finite = SimpleNamespace(name="finite")
+    nan_first = SimpleNamespace(name="nan_first")
+    nan_second = SimpleNamespace(name="nan_second")
+
+    selected = _select_by_wr2(
+        (
+            _VariantResult("nan_first", _plan(nan_first, nan_first), (nan, nan)),
+            _VariantResult("finite", _plan(finite, nan_second), (0.5, nan)),
+            _VariantResult("nan_second", _plan(nan_second, nan_second), (nan, nan)),
+        )
+    )
+
+    assert selected == (finite, nan_first)
+
+
+def test_select_orientation_portfolio_step_record_names_the_selector() -> None:
+    from tests.unit.synthetic import seed_system
+
+    from diffBloch.preprocess import select_orientation_portfolio
+    from diffBloch.specs import (
+        BeamSelection,
+        IntegrationGeometry,
+        RockingCurve,
+        ScoredHklSelection,
+        TrialCoupling,
+        UnionCoupling,
+    )
+
+    refinement, seed = seed_system()
+    integration = IntegrationGeometry()
+    step = select_orientation_portfolio(
+        refinement,
+        OrientationPortfolioSearch(variants=(("default", NelderMeadSearch(max_iterations=1)),)),
+        rocking=RockingCurve(sampling=1, integration=integration),
+        coupling=TrialCoupling(
+            policy=UnionCoupling(g_max=1.0),
+            scored=ScoredHklSelection(
+                klar=BeamSelection(rsg=1.0, integration=integration),
+                g_max=1.0,
+            ),
+        ),
+    )
+
+    (record,) = step_records([step])
+
+    assert record.name == "select_orientation_portfolio"
+    assert record.params is not None
+    assert record.params["search"]["selector"] == "lowest_terminal_wr2"
+    assert seed.orientations


### PR DESCRIPTION
## Summary

Adds an opt-in `Plan -> Plan` orientation portfolio step that composes Ben's canonical Nelder-Mead orientation optimizer with a labelled set of `NelderMeadSearch` parameter variants. The step chooses the lowest terminal wR2 candidate independently for each rotation, so different orientations in one returned `Plan` may come from different optimizer-parameter policies without using any reference CSV/oracle target.

## What changed

### Portfolio spec

- Added `OrientationPortfolioSearch` in `src/diffBloch/specs.py` as a frozen value-type for a labelled tuple of `NelderMeadSearch` variants.
- The default candidate menu keeps only matched-count-penalty variants so portfolio selection cannot choose a candidate that wins by matching fewer/easier reflections:
  - `default_step_0.05_penalty`
  - `fine_step_0.01_penalty`
  - `finer_step_0.005_penalty`
- The selector is fixed to `lowest_terminal_wr2`, with validation for empty portfolios, duplicate/empty labels, and variants that disable `penalize_fewer_reflections`.
- This is deliberately not config. It is still experimental scientific composition, so callers opt in through typed Python API rather than making it part of the default recipe or experiment lock surface.

### Portfolio Plan step

- Added `select_orientation_portfolio` in `src/diffBloch/preprocess/steps/orientation_portfolio.py`.
- The step builds the same rocking/mosaic/coupled seed geometry once, then runs existing `optimize_orientation` once per configured variant.
- Each fitted variant plan is terminal-scored through `build_engine` + `score_orientation`, and the returned plan splices together the best-scoring orientation at each rotation position. `R_obs` remains a diagnostic table/reporting metric, not the selector.
- The implementation preserves Ben's moving SOLVE/SCORED behavior by delegating candidate generation to `optimize_orientation(..., coupling=TrialCoupling(...))`; it does not reintroduce pinned scored-set trials.
- Finite terminal wR2 values always beat non-finite values. If every variant is non-finite for a rotation, the first configured variant wins deterministically.

### Public API and tests

- Exported `select_orientation_portfolio` from `diffBloch.preprocess`.
- Added unit coverage for default variant labels, variant validation, provenance serialization, per-orientation winner selection, non-finite score handling, and public step record shape.

## Architecture & data flow

```mermaid
flowchart LR
    A[Candidate Plan from CIF/PETS] --> B[build_orientation_plans\nrocking + mosaic + coupling]
    B --> C[Seed built Plan]
    C --> D1[optimize_orientation\nvariant: default penalty]
    C --> D2[optimize_orientation\nvariant: fine penalty]
    C --> D3[optimize_orientation\nvariant: finer penalty]
        D1 --> E1[build_engine + score_orientation\nterminal wR2 per rotation]
    D2 --> E2[build_engine + score_orientation\nterminal wR2 per rotation]
    D3 --> E3[build_engine + score_orientation\nterminal wR2 per rotation]
    E1 --> F[Per-rotation lowest finite wR2 selector]
    E2 --> F
    E3 --> F
    F --> G[Returned Plan\norientations spliced from winning variants]
```

```mermaid
sequenceDiagram
    participant Caller
    participant Portfolio as select_orientation_portfolio
    participant Build as build_orientation_plans
    participant Optim as optimize_orientation
    participant Score as build_engine + score_orientation

    Caller->>Portfolio: candidate Plan + OrientationPortfolioSearch
    Portfolio->>Build: build seed geometry with rocking/mosaic/coupling
    Build-->>Portfolio: built seed Plan
    loop each labelled NelderMeadSearch variant
        Portfolio->>Optim: run Ben canonical optimizer from seed Plan
        Optim-->>Portfolio: fitted variant Plan
        Portfolio->>Score: score fitted Plan with selection_method
        Score-->>Portfolio: per-rotation wR2
    end
    Portfolio-->>Caller: Plan with per-rotation winning orientations
```

## Design decisions & tradeoffs

**Decision: compose Ben's optimizer instead of adding another orientation fitter**

- **Alternatives considered**: replay the earlier pinned-scored E063 optimizer, add a Palatinus-style step, or copy private optimizer internals into the portfolio.
- **Tradeoff**: this runs whole optimizer passes per variant, so it is not the fastest possible implementation. The gain is correctness and reviewability: all candidates retain the canonical moving SOLVE/SCORED behavior from Ben's branch.
- **Rationale**: the current goal is a mergeable primitive that demonstrates the portfolio hypothesis without weakening the canonical orientation optimizer path.

**Decision: select by terminal wR2 only**

- **Alternatives considered**: include CSV distance, matched-count guards, combined objectives, or smoothing penalties.
- **Tradeoff**: terminal wR2 can still prefer a candidate farther from the reference orientation CSV. The gain is that the selector remains non-oracle and directly tied to the downstream physics metric, while the matched-count penalty prevents selecting variants that win by shrinking the experimental evidence domain.
- **Rationale**: reference orientations are allowed as investigation/evaluation data, not as mainline pipeline truth.

**Decision: keep this out of config**

- **Alternatives considered**: add `preprocess.orientation_portfolio` config fields or a default recipe flag.
- **Tradeoff**: users must call the Python API explicitly. The gain is that the public config surface does not grow around an experimental search policy before the team has settled the scientific recipe.
- **Rationale**: AGENTS.md says scientific composition should be typed-Python-first until stable default behavior is committed.

**Decision: deterministic fallback for all-non-finite scores**

- **Alternatives considered**: raise an error or keep `min` over raw float values.
- **Tradeoff**: an all-NaN rotation silently falls back to the first variant for that rotation. The gain is that one non-finite score set does not abort a long portfolio run.
- **Rationale**: wR2 can be non-finite when a trial produces a degenerate scoring comparison; finite candidates should win, but all-non-finite is not enough evidence to choose anything smarter.

## Honest assessment

1. **What**: The implementation runs full `optimize_orientation` plus terminal wR2 scoring once per variant.
   **Where**: `src/diffBloch/preprocess/steps/orientation_portfolio.py`, `_run_variant` and `select_orientation_portfolio`.
   **Why it's wrong**: It is computationally expensive and repeats work that could be shared across variants. A reviewer could reasonably ask for gather/Fgb reuse across variants or a lower-level candidate API.
   **What right looks like**: A future candidate-generation API in `optimize_orientation` that can evaluate a labelled menu while sharing the engine/Fgb/gather caches and returning both candidate plans and scores.
   **Severity**: tech debt to track; acceptable for an opt-in experimental step.

2. **What**: The default portfolio menu is evidence-driven from the quartz diagnostic, not a principled exhaustive search.
   **Where**: `src/diffBloch/specs.py`, `OrientationPortfolioSearch.variants`.
   **Why it's wrong**: The defaults may overfit the current quartz e2e scope and are not guaranteed to generalize to other materials or rotation regimes; they also intentionally exclude raw no-penalty variants even though those can improve scalar wR2 because they can select fewer/easier reflections.
   **What right looks like**: A follow-up experiment grid over `step_size`, penalty mode, and iteration/tolerance settings, recorded as investigation data before changing defaults.
   **Severity**: fix soon after if this becomes a default recipe; acceptable for opt-in API.

3. **What**: Selection has no continuity/smoothing or adjacent-orientation candidate source.
   **Where**: `src/diffBloch/preprocess/steps/orientation_portfolio.py`, `_select_by_wr2`.
   **Why it's wrong**: Real orientation series are usually smooth, and a per-rotation greedy selector can introduce local discontinuities if a candidate gets a lucky lower scalar score.
   **What right looks like**: A separate Plan -> Plan smoothing/interpolation candidate step or a second-stage policy that flags outlier rotations using neighbor continuity plus physics diagnostics.
   **Severity**: tech debt to track; not required for this primitive.

4. **What**: There is no observability event reporting which variant won each rotation.
   **Where**: `src/diffBloch/preprocess/steps/orientation_portfolio.py`.
   **Why it's wrong**: The manual diagnostics show selected variant counts are essential for interpreting the portfolio. Without events, a normal app run cannot inspect this easily.
   **What right looks like**: Add typed `OrientationPortfolioSelected` / summary events once this moves beyond experiment API.
   **Severity**: fix soon after if used outside local investigation.

5. **What**: The test suite does not run a real synthetic optimization through `select_orientation_portfolio`.
   **Where**: `tests/unit/test_orientation_portfolio.py`.
   **Why it's wrong**: Current unit tests cover spec/provenance/selector behavior but rely on the existing `optimize_orientation`, engine scoring, and inference tests for the heavy numerical path.
   **What right looks like**: A very small synthetic integration test with two variants and one/two rotations proving that the public step can execute end-to-end without the quartz fixture cost.
   **Severity**: fix soon after; manual quartz diagnostic and full suite reduce immediate risk.

## File-by-file changes

| File | Change |
|---|---|
| `src/diffBloch/specs.py` | Adds `OrientationPortfolioSearch`, a validated labelled tuple of `NelderMeadSearch` variants plus fixed selector identity. |
| `src/diffBloch/preprocess/steps/orientation_portfolio.py` | Adds the opt-in portfolio Plan step, variant runner, terminal score selector, and finite-score handling. |
| `src/diffBloch/preprocess/__init__.py` | Exports `select_orientation_portfolio` from the preprocess public API. |
| `tests/unit/test_orientation_portfolio.py` | Adds focused unit tests for default variants, validation, provenance, per-rotation selection, NaN fallback, and step record shape. |

## Testing

Automated validation on the rebased branch:

- `uv run ruff check src/diffBloch tests/unit/test_orientation_portfolio.py` — passed.
- `uv run mypy src/diffBloch` — passed, no issues in 67 source files.
- `uv run pytest -q` — `607 passed, 4 skipped, 1 deselected`.

Manual scientific diagnostic before PR:

Ran the sample quartz 10-rotation e2e scope once for each penalty-preserving orientation-optimization flavor (`26, 33, 56, 18, 70, 84, 85, 96, 20, 34`). The reference CSV/JSON was used only as an evaluator, not as an input to candidate generation or portfolio selection. The portfolio row is selected by terminal wR2; R_obs is reported as a secondary diagnostic.

| condition | mean wR2 | median wR2 | mean R_obs | median R_obs | mean norm to CSV | max norm to CSV |
|---|---:|---:|---:|---:|---:|---:|
| CIF/PETS seed | 0.117098649 | 0.081501578 | 0.080613765 | 0.078179759 | 0.025264565 | 0.057409450 |
| Ben default `step=0.05`, matched-count penalty | 0.080804737 | 0.044946077 | 0.069324434 | 0.055462592 | 0.023887170 | 0.056267186 |
| Ben fine `step=0.01`, matched-count penalty | 0.091767564 | 0.055737020 | 0.074660629 | 0.069085178 | 0.024892329 | 0.057694085 |
| Ben finer `step=0.005`, matched-count penalty | 0.091768478 | 0.057049239 | 0.074624019 | 0.068547296 | 0.024820586 | 0.057712752 |
| Ben penalty-only portfolio, wR2-selected | 0.080448424 | 0.044946077 | 0.068859895 | 0.055462592 | 0.023739407 | 0.056267186 |
| reference CSV orientations | 0.081381642 | 0.045593187 | 0.062716628 | 0.056253738 | 0.000000000 | 0.000000000 |

Expressed as percentage improvement relative to the CIF/PETS seed baseline:

| condition | mean wR2 improvement | mean R_obs improvement | mean norm-to-CSV improvement |
|---|---:|---:|---:|
| Ben default `step=0.05`, matched-count penalty | 30.99% | 14.00% | 5.45% |
| Ben fine `step=0.01`, matched-count penalty | 21.63% | 7.38% | 1.47% |
| Ben finer `step=0.005`, matched-count penalty | 21.63% | 7.43% | 1.76% |
| Ben penalty-only portfolio, wR2-selected | 31.30% | 14.58% | 6.04% |
| reference CSV orientations | 30.50% | 22.20% | 100.00% |

Portfolio selections in that run: matched-count-penalty Ben default won 7/10 rotations, finer penalty won 2/10, and fine penalty won 1/10.

| rotation | selected policy | terminal wR2 | R_obs | norm to CSV | matched |
|---:|---|---:|---:|---:|---:|
| 26 | `ben_default_step_0.05_penalty` | 0.095508013 | 0.069707961 | 0.005776092 | 25 |
| 33 | `ben_fine_step_0.01_penalty` | 0.039353691 | 0.035274691 | 0.006316896 | 23 |
| 56 | `ben_default_step_0.05_penalty` | 0.152828952 | 0.107075236 | 0.004596951 | 28 |
| 18 | `ben_default_step_0.05_penalty` | 0.275139195 | 0.192365296 | 0.035196517 | 28 |
| 70 | `ben_default_step_0.05_penalty` | 0.045053358 | 0.036542990 | 0.056267186 | 29 |
| 84 | `ben_default_step_0.05_penalty` | 0.022453661 | 0.030147743 | 0.007649529 | 25 |
| 85 | `ben_default_step_0.05_penalty` | 0.041825704 | 0.057416591 | 0.046945410 | 22 |
| 96 | `ben_default_step_0.05_penalty` | 0.044838795 | 0.053508593 | 0.006765702 | 29 |
| 20 | `ben_finer_step_0.005_penalty` | 0.062618764 | 0.069630342 | 0.023644226 | 29 |
| 34 | `ben_finer_step_0.005_penalty` | 0.024864104 | 0.036929511 | 0.044235557 | 26 |

Full diagnostic log: `/private/tmp/ben_orientation_portfolio_compare_10_penalty_only_wr2_selected.json` on the local machine.

## Migration & compatibility

No breaking change. The new portfolio is an opt-in Python API and is not wired into the default CLI recipe or experiment config. Existing checkpoints and default preprocess behavior are unchanged.
