### PR TITLE
fix(app): fall back to CPU when CUDA is unavailable

### DIFF
--- a/src/diffBloch/app/loggers/__init__.py
+++ b/src/diffBloch/app/loggers/__init__.py
@@ -30,6 +30,7 @@ from diffBloch.observability import (
     ConvergencePassStarted,
     ConvergenceSweepStarted,
     ConvergenceTrial,
+    DeviceSelected,
     Event,
     Logger,
     OrientationOptimizationStarted,
@@ -87,6 +88,16 @@ def _format_eta(seconds: float) -> str:
     return f"{hours}:{minutes:02d}:{secs:02d}" if hours else f"{minutes}:{secs:02d}"
 
 
+def _format_device_selection(event: DeviceSelected) -> str:
+    if event.selected.startswith("cuda"):
+        return "CUDA detected, using CUDA"
+    if event.selected == "cpu" and event.requested.startswith("cuda"):
+        return "No CUDA detected, using CPU, diffBloch is optimized for CUDA"
+    if event.selected == "cpu":
+        return "Using CPU, diffBloch is optimized for CUDA"
+    return f"Using {event.selected}"
+
+
 def _render_progress_bar(current: int, total: int, elapsed: float, suffix: str) -> None:
     """Write an in-place (``\\r``-updated) progress bar + ETA to stdout; newline once it completes.
 
@@ -135,6 +146,9 @@ class ConsoleLogger:
     _thickness_started_at: float = field(default=0.0, init=False, repr=False)
 
     def report(self, event: Event) -> None:
+        if isinstance(event, DeviceSelected):
+            _log.log(self.level, _format_device_selection(event))
+            return
         if isinstance(event, RefinementStarted):
             self._refinement_total = event.total_steps
             self._refinement_started_at = time.perf_counter()

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 import gemmi
 import numpy as np
+import torch
 
 from diffBloch.config import (
     ExperimentConfig,
@@ -61,7 +62,7 @@ from diffBloch.engine import (
     run_refinement_model,
 )
 from diffBloch.io import read_experimental_data, read_structure
-from diffBloch.observability import NULL_LOGGER, Logger, MultiLogger
+from diffBloch.observability import NULL_LOGGER, DeviceSelected, Logger, MultiLogger
 from diffBloch.params import Device, constrain
 from diffBloch.preprocess import (
     OPAQUE,
@@ -119,6 +120,24 @@ def _reproducibility_dir(root: Path) -> Path:
     return directory
 
 
+def _select_device(device: Device | None, *, logger: Logger = NULL_LOGGER) -> Device:
+    """Resolve the execution device, falling back from CUDA to CPU when this host lacks CUDA."""
+    requested = "cpu" if device is None else str(device)
+    cuda_available = torch.cuda.is_available()
+    selected: Device = "cpu" if device is None else device
+    if torch.device(requested).type == "cuda" and not cuda_available:
+        selected = "cpu"
+    selected_name = str(selected)
+    logger.report(
+        DeviceSelected(
+            requested=requested,
+            selected=selected_name,
+            cuda_available=cuda_available,
+        )
+    )
+    return selected
+
+
 # Above this unit-cell volume the coupled orientation search runs its coarse pass with the
 # gather integrity checks skipped (the large-cell fast path); at or below it the search stays the
 # exact, fully-validated path. The eigensolve is O(N^3) in the beam count
@@ -151,6 +170,7 @@ def converge_experiment(
     smallest settled values found.
     """
     root = Path(experiment_dir)
+    device = _select_device(device, logger=logger)
     cfg, _lock = load_experiment(root)
 
     structure = read_structure(
@@ -207,7 +227,7 @@ def preprocess_experiment(
     logger: Logger = NULL_LOGGER,
     checkpoint: bool = True,
     refresh: bool = False,
-    device: Device | None = None,
+    device: Device | None = "cuda",
     workers: int = 1,
     max_batch: int | None = None,
     orientations_csv: str | Path | None = None,
@@ -236,10 +256,11 @@ def preprocess_experiment(
     writes a fresh one after computing; ``refresh`` forces a full recompute (ignoring any snapshot)
     while still regenerating the checkpoint. ``checkpoint=False`` neither reads nor writes.
 
-    ``device`` (default ``None`` = CPU) runs the forward solve on the given accelerator (e.g.
-    ``"cuda"``) for the coupled preprocess fits. The preprocess *geometry* (beam selection, coupling
-    unions) stays CPU-side numpy; only the eigensolve -- the O(N^3) cost -- moves to the device (the
-    fits move the seed params, so ``fgb`` and every per-trial score co-locate there). Device is
+    ``device`` (default ``"cuda"``) runs the forward solve on the selected accelerator for the
+    coupled preprocess fits. If CUDA is requested on a host without CUDA, the app falls back to CPU
+    and emits a device-selection event. The preprocess *geometry* (beam selection, coupling unions)
+    stays CPU-side numpy; only the eigensolve -- the O(N^3) cost -- moves to the device (the fits
+    move the seed params, so ``fgb`` and every per-trial score co-locate there). Device is
     execution-only: it does not enter the checkpoint lock, so a committed CPU checkpoint is still
     reused when a run moves to GPU.
 
@@ -275,6 +296,7 @@ def preprocess_experiment(
     Execution-only like ``device``/``workers``, out of the checkpoint lock.
     """
     root = Path(experiment_dir)
+    device = _select_device(device, logger=logger)
     cfg, _lock = load_experiment(root)
     _refinement, _integration, prepared, _validation_rotation_indices = _preprocess(
         root,
@@ -298,7 +320,7 @@ def run_experiment(
     logger: Logger = NULL_LOGGER,
     checkpoint: bool = True,
     refresh: bool = False,
-    device: Device | None = None,
+    device: Device | None = "cuda",
     workers: int = 1,
     max_batch: int | None = None,
     orientations_csv: str | Path | None = None,
@@ -317,6 +339,7 @@ def run_experiment(
     ``device`` also runs the terminal eigensolve on the accelerator.
     """
     root = Path(experiment_dir)
+    device = _select_device(device, logger=logger)
     cfg, _lock = load_experiment(root)
     refinement, _integration, prepared, _validation_rotation_indices = _preprocess(
         root,
@@ -348,7 +371,7 @@ def refine_experiment(
     logger: Logger = NULL_LOGGER,
     checkpoint: bool = True,
     refresh: bool = False,
-    device: Device | None = None,
+    device: Device | None = "cuda",
     workers: int = 1,
     max_batch: int | None = None,
     verbose: bool = False,
@@ -398,6 +421,7 @@ def refine_experiment(
     """
     started = time.perf_counter()
     root = Path(experiment_dir)
+    device = _select_device(device, logger=logger)
     cfg, _lock = load_experiment(root)
     refinement, integration, prepared, validation_rotation_indices = _preprocess(
         root,

--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -32,6 +32,7 @@ __all__ = [
     "ConvergenceTrial",
     "ConvergencePassStarted",
     "ConvergenceSweepStarted",
+    "DeviceSelected",
     "Event",
     "InferenceCompleted",
     "Logger",
@@ -84,6 +85,34 @@ class Logger(Protocol):
     """
 
     def report(self, event: Event) -> None: ...
+
+
+@dataclass(frozen=True)
+class DeviceSelected:
+    """Execution-device selection for an app run.
+
+    Device placement is an execution knob, not scientific provenance. This run-level event makes the
+    selected backend visible to console/CSV/vendor sinks without entering config or checkpoint
+    identity. Presentation wording stays with concrete logger backends; this event carries only
+    stable selection data plus numeric measurements for generic metric sinks.
+    """
+
+    requested: str
+    selected: str
+    cuda_available: bool
+
+    channel: ClassVar[str] = "device"
+
+    @property
+    def step(self) -> int | None:
+        return None
+
+    @property
+    def measurements(self) -> Mapping[str, float]:
+        return {
+            "cuda_available": float(self.cuda_available),
+            "selected_cuda": float(self.selected.startswith("cuda")),
+        }
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -26,6 +26,7 @@ from diffBloch.app.loggers.comet import CometLogger
 from diffBloch.app.loggers.wandb import WandbLogger
 from diffBloch.observability import (
     CouplingSummary,
+    DeviceSelected,
     Event,
     InferenceCompleted,
     Logger,
@@ -60,6 +61,11 @@ def _fitted(index: int, score: float, residual: str = "wr2") -> OrientationOptim
 
 
 def test_events_expose_a_uniform_channel_and_measurements_surface() -> None:
+
+    device = DeviceSelected(requested="cuda", selected="cpu", cuda_available=False)
+    assert device.channel == "device"
+    assert device.step is None
+    assert device.measurements == {"cuda_available": 0.0, "selected_cuda": 0.0}
 
     rotation = RotationScored(index=3, r_obs=0.42, n_observed=12, n_beams=20)
     assert rotation.channel == "rotation"
@@ -235,6 +241,16 @@ def test_console_logger_logs_channel_step_and_measurements(
     assert "rotation[47]" in rotation_msg  # the step pins the line to a rotation
     assert "r_obs=0.5" in rotation_msg
     assert inference_msg.startswith("inference ")  # aggregate has no step bracket
+
+
+def test_console_logger_formats_device_selection(caplog: pytest.LogCaptureFixture) -> None:
+    logger = ConsoleLogger(level=logging.INFO)
+    with caplog.at_level(logging.INFO, logger="diffBloch.loggers"):
+        logger.report(DeviceSelected(requested="cuda", selected="cpu", cuda_available=False))
+
+    assert caplog.records[-1].getMessage() == (
+        "No CUDA detected, using CPU, diffBloch is optimized for CUDA"
+    )
 
 
 def test_console_logger_formats_refinement_epoch_metrics(

--- a/tests/unit/test_program_recipe.py
+++ b/tests/unit/test_program_recipe.py
@@ -12,10 +12,18 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
-from diffBloch.app.program import _LARGE_CELL_THRESHOLD_A3, _preprocess, _recipe_steps
+import pytest
+
+from diffBloch.app.program import (
+    _LARGE_CELL_THRESHOLD_A3,
+    _preprocess,
+    _recipe_steps,
+    _select_device,
+    preprocess_experiment,
+)
 from diffBloch.config import load_experiment
 from diffBloch.io import read_experimental_data, read_structure
-from diffBloch.observability import NULL_LOGGER
+from diffBloch.observability import NULL_LOGGER, DeviceSelected, RecordingLogger
 from diffBloch.preprocess import from_experiment, resolve_recipe, step_records
 from diffBloch.preprocess.pipeline import Fork
 
@@ -35,6 +43,46 @@ def _the_fork() -> Fork:
     forks = [s for s in _steps() if isinstance(s, Fork)]
     assert len(forks) == 1, "the fit tail should be exactly one fork"
     return forks[0]
+
+
+def test_select_device_falls_back_from_cuda_to_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = RecordingLogger()
+    monkeypatch.setattr("diffBloch.app.program.torch.cuda.is_available", lambda: False)
+
+    selected = _select_device("cuda", logger=logger)
+
+    assert selected == "cpu"
+    assert logger.events == [DeviceSelected(requested="cuda", selected="cpu", cuda_available=False)]
+
+
+def test_select_device_keeps_cuda_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    logger = RecordingLogger()
+    monkeypatch.setattr("diffBloch.app.program.torch.cuda.is_available", lambda: True)
+
+    selected = _select_device("cuda", logger=logger)
+
+    assert selected == "cuda"
+    assert logger.events == [DeviceSelected(requested="cuda", selected="cuda", cuda_available=True)]
+
+
+def test_preprocess_experiment_default_device_falls_back_to_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+    plan = SimpleNamespace()
+
+    def fake_preprocess(*args: object, **kwargs: object) -> tuple[object, object, object, object]:
+        seen["device"] = kwargs["device"]
+        return object(), object(), plan, object()
+
+    monkeypatch.setattr("diffBloch.app.program.torch.cuda.is_available", lambda: False)
+    monkeypatch.setattr("diffBloch.app.program.load_experiment", lambda _root: (object(), object()))
+    monkeypatch.setattr("diffBloch.app.program._preprocess", fake_preprocess)
+
+    assert preprocess_experiment("experiment-dir") is plan
+    assert seen["device"] == "cpu"
 
 
 def test_fork_predicate_routes_at_the_threshold() -> None:


### PR DESCRIPTION
Default the public app runners to request CUDA while resolving the effective execution device at the imperative app boundary. This keeps CUDA as the preferred path for real runs while letting CPU-only machines execute preprocess, inference, refinement, and convergence without a torch device error.

API execution policy:

- Add _select_device() in app.program and call it from preprocess_experiment, run_experiment, refine_experiment, and converge_experiment before any params are moved onto a device.

- Keep device placement as an execution-only function parameter: no config field, no lock input, no recipe identity, and no Plan provenance change.

- Preserve explicit caller overrides; only requested CUDA falls back when torch.cuda.is_available() is false.

Observability:

- Add a typed DeviceSelected event carrying requested/selected/cuda_available data for generic sinks.

- Render the human CUDA/CPU message in ConsoleLogger so presentation text stays in the logger backend, not in the event data type.

Caveat: the fallback makes CPU-only demonstration and API runs graceful, but diffBloch remains optimized for CUDA and CPU execution can be substantially slower for realistic coupled solves.

Tests: ruff on touched files clean; mypy src/diffBloch clean; pytest tests/unit/test_observability.py tests/unit/test_program_recipe.py -q (39 passed); uv run diffbloch run preprocess examples/experiments/papers/colmey_et_al_2026_Acta_Cryst_A/data/quartz-absorption completed on CPU after emitting the fallback message.

diffBloch_private analog: none (2.0-native execution boundary; the private code reads device from config and calls bloch_nn.to(cfg.*.device) without an app-level CUDA fallback/event).