### PR TITLE
Select the best refinement epoch on the held-out validation split

### DIFF
--- a/docs/refinement.md
+++ b/docs/refinement.md
@@ -54,14 +54,29 @@ the observed classification uses the conventional `I > 3 sigma` test internally.
 
 ## Refinement outputs
 
-The default app writes the best recorded epoch, not merely the final optimizer state. With the default `refinement.split.train_test = false`, “best” means the lowest recorded training objective in the optimizer loop. When `train_test` is enabled, validation rotations are genuinely held out from the training engine and the best epoch is selected by the held-out validation objective. Validation still does not stop the run early; the loop always runs the configured `refinement.steps`.
+The default app writes the best recorded epoch, not merely the final optimizer state. With the
+default `refinement.split.train_test = false`, "best" means the lowest recorded training objective
+in the optimizer loop. When `train_test` is enabled, validation rotations are genuinely held out
+from the training engine and the best epoch is selected by the held-out validation objective.
+Validation still does not stop the run early; the loop always runs the configured
+`refinement.steps`.
+
+Which objective did the selecting is reported, not implied: `refinement_report.txt` carries a
+`Best epoch selection` row, and the `RefinementCompleted` event reports its number under
+`best_training_loss` or `best_validation_loss` accordingly. The per-epoch stream is always the
+training objective.
 
 | File | Contents |
 |---|---|
 | `refined_structure.cif` | Best constrained coordinates, occupancies, and ADPs in CIF form. |
+| `refinement_report.txt` | Best epoch metrics, which objective selected it, and the compact HKL count. |
 | `refined_parameters.npz` | Exact raw optimizer parameters for the best epoch. |
-| `refinement_summary.json` | Best epoch metrics, the compact HKL count, and artifact paths. |
+| `refined_components.npz` | Trainable component tensors for the best epoch, when components are composed. |
 | `plan.npz` / `plan.lock` | Settled preprocessing plan and its provenance lock. |
+| `refinement.lock` | Binds the refined outputs to the plan lock, config digest, and code version. |
+
+`refined_structure.cif` and `refinement_report.txt` land in the experiment directory; the `.npz`
+snapshots and locks go under `reproducibility/`.
 
 The completion summary prints the absolute location of every output.
 

--- a/docs/refinement.md
+++ b/docs/refinement.md
@@ -54,7 +54,7 @@ the observed classification uses the conventional `I > 3 sigma` test internally.
 
 ## Refinement outputs
 
-The default app writes the best recorded epoch, not merely the final optimizer state:
+The default app writes the best recorded epoch, not merely the final optimizer state. With the default `refinement.split.train_test = false`, “best” means the lowest recorded training objective in the optimizer loop. When `train_test` is enabled, validation rotations are genuinely held out from the training engine and the best epoch is selected by the held-out validation objective. Validation still does not stop the run early; the loop always runs the configured `refinement.steps`.
 
 | File | Contents |
 |---|---|

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -427,14 +427,30 @@ def refine_experiment(
         checkpoint_activations=checkpoint_activations,
     )
     train_engine = engine
+    selection_engine = None
     if validation_rotation_indices:
         train_only = tuple(
             op
             for op in prepared.orientations
             if op.pattern.rotation_index not in validation_rotation_indices
         )
+        validation_only = tuple(
+            op
+            for op in prepared.orientations
+            if op.pattern.rotation_index in validation_rotation_indices
+        )
         train_engine = build_engine(
             replace(prepared, orientations=train_only),
+            refinement,
+            loss=cfg.loss_metrics.to_loss(),
+            method=cfg.blochwave.solver.refine,
+            max_batch=max_batch,
+            absorption=cfg.blochwave.to_absorption(),
+            profile=profile,
+            checkpoint_activations=checkpoint_activations,
+        )
+        selection_engine = build_engine(
+            replace(prepared, orientations=validation_only),
             refinement,
             loss=cfg.loss_metrics.to_loss(),
             method=cfg.blochwave.solver.refine,
@@ -485,6 +501,7 @@ def refine_experiment(
         logger=logger,
         verbose=verbose,
         profile=profile,
+        selection_engine=selection_engine,
     )
     elapsed_seconds = time.perf_counter() - started
     result = _write_refinement_outputs(root, cfg, refinement, result)
@@ -738,6 +755,13 @@ def _write_refinement_report(
         ["Seed thickness (A)", ", ".join(f"{t:g}" for t in cfg.sample.thicknesses)],
         ["Epochs (configured)", f"{cfg.refinement.steps:g}"],
         ["Best epoch", f"{result.best_step + 1:g}"],
+        [
+            "Best epoch selection",
+            "held-out validation objective"
+            if result.selection_losses is not None
+            else "training objective",
+        ],
+        ["Best selection objective", f"{result.best_loss:.6g}"],
         ["Optimizer", cfg.refinement.optimizer.name],
         ["Learning rate", f"{cfg.refinement.optimizer.lr:g}"],
         ["R_obs (%)", r_obs_pct],

--- a/src/diffBloch/engine/forward.py
+++ b/src/diffBloch/engine/forward.py
@@ -825,6 +825,7 @@ class ModelRefinementResult:
     losses: Tensor
     best_model: RefinementModel
     best_step: int
+    selection_losses: Tensor | None = None
     history: tuple[RefinementStep, ...] = ()
     reflection_counts: Mapping[str, int] = field(default_factory=dict)
     artifacts: Mapping[str, str] = field(default_factory=dict)
@@ -841,8 +842,14 @@ class ModelRefinementResult:
 
     @property
     def best_loss(self) -> float:
-        """The lowest recorded (pre-update) loss."""
-        return float(self.losses[self.best_step])
+        """The loss used to select ``best_step``.
+
+        By default this is the training objective. When ``run_refinement_model`` is given a
+        selection engine (the app's held-out validation split), it is the corresponding selection
+        objective instead.
+        """
+        losses = self.selection_losses if self.selection_losses is not None else self.losses
+        return float(losses[self.best_step])
 
 
 @dataclass(frozen=True)
@@ -923,6 +930,7 @@ def run_refinement_model(
     logger: Logger = NULL_LOGGER,
     verbose: bool = False,
     profile: bool = False,
+    selection_engine: RefinementEngine | None = None,
 ) -> ModelRefinementResult:
     """Optimize a refinement model against the supplied engine/static context and problem terms.
 
@@ -942,6 +950,11 @@ def run_refinement_model(
     overhead, so it is a diagnosis tool for one run, not something to leave on. ``engine.profile``
     must also be set (:func:`~diffBloch.preprocess.scoring.build_engine` threads it through) for the
     structure-factor/solve breakdown; this flag alone only times backward/optimizer-step.
+
+    ``selection_engine`` is an optional held-out objective used only to choose ``best_model`` /
+    ``best_step``. It does not contribute gradients or alter the optimizer trajectory. The app uses
+    it for ``refinement.split.train_test`` validation selection; without it, best selection remains
+    the training objective.
     """
     if steps < 1:
         raise ValueError("steps must be >= 1")
@@ -983,6 +996,7 @@ def run_refinement_model(
         return float(loss.detach())
 
     losses: list[float] = []
+    selection_losses: list[float] = []
     history: list[RefinementStep] = []
     best_loss = float("inf")
     best_step = 0
@@ -1024,8 +1038,16 @@ def run_refinement_model(
                         diff_loss=entry["diff_loss"],
                     )
                 )
-        if loss_value < best_loss:
-            best_loss, best_step, best_model = loss_value, step, snapshot
+        selection_loss = loss_value
+        if selection_engine is not None:
+            with torch.no_grad():
+                selection_objective = selection_engine.objective_value_model(
+                    snapshot, penalties=problem.penalties
+                )
+            selection_loss = _scalar_float(selection_objective.total)
+            selection_losses.append(selection_loss)
+        if selection_loss < best_loss:
+            best_loss, best_step, best_model = selection_loss, step, snapshot
     logger.report(RefinementCompleted(n_steps=steps, best_step=best_step, best_loss=best_loss))
     _, n_matched, n_strong, n_weak, n_unmatched = engine.refinement_metrics(best_model)
     return ModelRefinementResult(
@@ -1033,6 +1055,11 @@ def run_refinement_model(
         losses=torch.tensor(losses, dtype=torch.float64),
         best_model=best_model,
         best_step=best_step,
+        selection_losses=(
+            torch.tensor(selection_losses, dtype=torch.float64)
+            if selection_engine is not None
+            else None
+        ),
         history=tuple(history),
         reflection_counts=MappingProxyType(
             {

--- a/src/diffBloch/engine/forward.py
+++ b/src/diffBloch/engine/forward.py
@@ -954,7 +954,10 @@ def run_refinement_model(
     ``selection_engine`` is an optional held-out objective used only to choose ``best_model`` /
     ``best_step``. It does not contribute gradients or alter the optimizer trajectory. The app uses
     it for ``refinement.split.train_test`` validation selection; without it, best selection remains
-    the training objective.
+    the training objective. It costs one extra no-grad forward pass per step over the held-out
+    rotations -- roughly ``val_frac`` of a training forward, paid every epoch with no opt-out --
+    and it changes which objective :class:`~diffBloch.observability.RefinementCompleted` reports
+    (see that event's ``selection`` field).
     """
     if steps < 1:
         raise ValueError("steps must be >= 1")
@@ -1048,7 +1051,14 @@ def run_refinement_model(
             selection_losses.append(selection_loss)
         if selection_loss < best_loss:
             best_loss, best_step, best_model = selection_loss, step, snapshot
-    logger.report(RefinementCompleted(n_steps=steps, best_step=best_step, best_loss=best_loss))
+    logger.report(
+        RefinementCompleted(
+            n_steps=steps,
+            best_step=best_step,
+            best_loss=best_loss,
+            selection="validation" if selection_engine is not None else "training",
+        )
+    )
     _, n_matched, n_strong, n_weak, n_unmatched = engine.refinement_metrics(best_model)
     return ModelRefinementResult(
         model=_detach_model(current_model()),

--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import ClassVar, Protocol, runtime_checkable
+from typing import ClassVar, Literal, Protocol, runtime_checkable
 
 __all__ = [
     "NULL_LOGGER",
@@ -544,16 +544,24 @@ class RefinementOrientationStep:
 class RefinementCompleted:
     """The refinement-run aggregate, emitted once when ``run_refinement`` finishes.
 
-    Shares the ``"refinement"`` channel with :class:`RefinementStep`: unlike inference (where a
-    per-rotation score and the run mean are distinct entities on distinct channels), a run's
-    per-step loss and its best-loss summary are the same quantity at different granularities, so
-    ``step`` -- the iteration index vs ``None`` -- is what separates the stream from the summary.
+    Shares the ``"refinement"`` channel with :class:`RefinementStep`, separated from the stream by
+    ``step`` (the iteration index vs ``None``). The two are *not* the same quantity at different
+    granularities: :class:`RefinementStep` always reports the training objective, whereas
+    ``best_loss`` is whichever objective actually selected the epoch. ``selection`` names that
+    objective -- ``"training"`` by default, or ``"validation"`` when ``run_refinement_model`` was
+    given a held-out selection engine.
+
+    Because those two populations are not comparable, ``measurements`` emits ``best_loss`` under a
+    *different key* per mode (``best_training_loss`` / ``best_validation_loss``) rather than one
+    shared key plus a flag. A generic backend cannot then plot a train-selected and a val-selected
+    run as one series: the key is absent instead of silently wrong.
     """
 
     channel: ClassVar[str] = "refinement"
     n_steps: int
     best_step: int
     best_loss: float
+    selection: Literal["training", "validation"] = "training"
 
     @property
     def step(self) -> int | None:
@@ -561,10 +569,13 @@ class RefinementCompleted:
 
     @property
     def measurements(self) -> Mapping[str, float]:
+        best_key = (
+            "best_validation_loss" if self.selection == "validation" else "best_training_loss"
+        )
         return {
             "n_steps": float(self.n_steps),
             "best_step": float(self.best_step),
-            "best_loss": self.best_loss,
+            best_key: self.best_loss,
         }
 
 

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -476,10 +476,38 @@ def test_refine_best_params_track_the_lowest_recorded_loss() -> None:
         lr=0.2,
     )
 
+    assert result.selection_losses is None
     assert 0 <= result.best_step < 12
     assert result.best_loss == float(result.losses.min())
     assert result.best_params.occupancy_raw.shape == (1,)
     assert not result.best_params.occupancy_raw.requires_grad
+
+
+def test_refine_best_params_can_track_a_selection_engine() -> None:
+    train_engine = _engine(loss=mse_loss, pattern=_observed_pattern(_params(occupancy_logit=2.2)))
+    selection_engine = _engine(
+        loss=mse_loss,
+        pattern=_observed_pattern(_params(occupancy_logit=0.0)),
+    )
+    initial = _params(occupancy_logit=0.0)
+
+    result = run_refinement_model(
+        train_engine,
+        build_refinement_model(initial=initial),
+        RefinementProblem(),
+        trainable=TrainableSpec(occupancy=AtomSelection.all()),
+        steps=8,
+        optimizer="adam",
+        lr=0.2,
+        selection_engine=selection_engine,
+    )
+
+    assert result.selection_losses is not None
+    assert result.losses[-1] < result.losses[0]  # the training objective still improves
+    assert result.best_step == int(torch.argmin(result.selection_losses))
+    assert result.best_loss == float(result.selection_losses[result.best_step])
+    assert result.best_step != int(torch.argmin(result.losses))
+    assert torch.allclose(result.best_params.occupancy_raw, initial.occupancy_raw)
 
 
 def test_refine_emits_a_step_stream_and_a_completion_event() -> None:

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -490,6 +490,7 @@ def test_refine_best_params_can_track_a_selection_engine() -> None:
         pattern=_observed_pattern(_params(occupancy_logit=0.0)),
     )
     initial = _params(occupancy_logit=0.0)
+    recorder = RecordingLogger()
 
     result = run_refinement_model(
         train_engine,
@@ -500,6 +501,7 @@ def test_refine_best_params_can_track_a_selection_engine() -> None:
         optimizer="adam",
         lr=0.2,
         selection_engine=selection_engine,
+        logger=recorder,
     )
 
     assert result.selection_losses is not None
@@ -508,6 +510,15 @@ def test_refine_best_params_can_track_a_selection_engine() -> None:
     assert result.best_loss == float(result.selection_losses[result.best_step])
     assert result.best_step != int(torch.argmin(result.losses))
     assert torch.allclose(result.best_params.occupancy_raw, initial.occupancy_raw)
+
+    # The completion event must name the objective that selected the epoch, and must not report a
+    # held-out number under the training key -- the per-step stream stays the training objective.
+    (completed,) = [e for e in recorder.events if isinstance(e, RefinementCompleted)]
+    assert completed.selection == "validation"
+    assert completed.measurements["best_validation_loss"] == result.best_loss
+    assert "best_training_loss" not in completed.measurements
+    steps_reported = [e.loss for e in recorder.events if isinstance(e, RefinementStep)]
+    assert steps_reported == [float(x) for x in result.losses]
 
 
 def test_refine_emits_a_step_stream_and_a_completion_event() -> None:
@@ -539,6 +550,9 @@ def test_refine_emits_a_step_stream_and_a_completion_event() -> None:
     assert completed.n_steps == 6
     assert completed.best_step == result.best_step
     assert completed.best_loss == result.best_loss
+    # No selection engine: the summary's best is the training objective, and says so.
+    assert completed.selection == "training"
+    assert "best_training_loss" in completed.measurements
 
 
 def test_refine_lbfgs_step_diagnostics_match_reported_pre_update_loss() -> None:

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -198,7 +198,24 @@ def test_events_expose_a_uniform_channel_and_measurements_surface() -> None:
     refinement_done = RefinementCompleted(n_steps=20, best_step=17, best_loss=0.3)
     assert refinement_done.channel == "refinement"  # shares the stream's channel
     assert refinement_done.step is None  # separated from the stream by step, not channel
-    assert refinement_done.measurements == {"n_steps": 20.0, "best_step": 17.0, "best_loss": 0.3}
+    assert refinement_done.selection == "training"  # the default selection objective
+    assert refinement_done.measurements == {
+        "n_steps": 20.0,
+        "best_step": 17.0,
+        "best_training_loss": 0.3,
+    }
+
+    # A validation-selected run reports the same number under a *different* key, so a generic
+    # backend cannot plot the two populations as one series -- the key is absent, not wrong.
+    validation_done = RefinementCompleted(
+        n_steps=20, best_step=17, best_loss=0.3, selection="validation"
+    )
+    assert validation_done.measurements == {
+        "n_steps": 20.0,
+        "best_step": 17.0,
+        "best_validation_loss": 0.3,
+    }
+    assert "best_training_loss" not in validation_done.measurements
 
 
 def test_events_and_loggers_satisfy_the_protocols_structurally() -> None:


### PR DESCRIPTION
## Summary

Refinement previously selected its best epoch — the one written out as `refined_structure.cif` — on the **training** objective, even when `refinement.split.train_test` was enabled and a held-out validation set existed. The validation split was computed, reported, and then ignored for model selection. This PR wires the held-out objective into best-epoch selection, and makes the resulting completion event say which objective did the selecting rather than reporting two incomparable quantities under one name.

## What changed

### `engine/forward.py` — optional selection engine

`run_refinement_model` gains `selection_engine: RefinementEngine | None = None`. When supplied, after each optimizer step the pre-update parameter snapshot is scored against that engine under `torch.no_grad()`, and *that* value — not the training loss — decides `best_step` / `best_model`.

```python
selection_loss = loss_value
if selection_engine is not None:
    with torch.no_grad():
        selection_objective = selection_engine.objective_value_model(
            snapshot, penalties=problem.penalties
        )
    selection_loss = _scalar_float(selection_objective.total)
    selection_losses.append(selection_loss)
if selection_loss < best_loss:
    best_loss, best_step, best_model = selection_loss, step, snapshot
```

The evaluated state is `snapshot`, taken at the top of the loop before `opt.step`. This matters: `opt.step(closure)` returns the closure's *first* evaluation, which is also at pre-update parameters (the LBFGS line-search case was already handled by the existing `reported_objective` guard). So `losses[i]` and `selection_losses[i]` describe the same model, and `best_step` indexes both consistently.

`ModelRefinementResult` gains `selection_losses: Tensor | None`, and `best_loss` now returns the value that actually drove selection. With no selection engine the field is `None` and every code path is byte-for-byte the previous behaviour.

### `app/program.py` — build the validation engine

`refine_experiment` already built a train-only engine when `validation_rotation_indices` was non-empty; it now builds the complementary validation-only engine from the same partition and passes it as `selection_engine`. Both are constructed with identical loss / method / absorption / batching settings, so the only difference between them is which rotations they cover.

The report gains two rows: `Best epoch selection` (`held-out validation objective` | `training objective`) and `Best selection objective`.

### `observability.py` — name the objective (second commit)

Wiring validation selection into `best_loss` made `RefinementCompleted.best_loss` mean two different things depending on a flag the event did not carry. Every logger backend consumes `.measurements` generically, so W&B and Comet would have plotted `refinement/best_loss` across runs while silently mixing a train-only population with a held-out one.

It also falsified that event's own docstring, which asserted that the per-step loss and the best-loss summary were "the same quantity at different granularities" separated only by `step`.

The fix adds a typed discriminator and keys the measurement off it:

```python
selection: Literal["training", "validation"] = "training"

@property
def measurements(self) -> Mapping[str, float]:
    best_key = (
        "best_validation_loss" if self.selection == "validation" else "best_training_loss"
    )
    return {"n_steps": ..., "best_step": ..., best_key: self.best_loss}
```

`measurements` is `Mapping[str, float]`, so a string discriminator cannot ride inside it — the key itself has to carry the meaning.

## Architecture & data flow

```mermaid
flowchart TD
    P[settled Plan] --> S{split.train_test?}
    S -->|false| E[engine: all rotations]
    S -->|true| T[train_engine: train-only]
    S -->|true| V[selection_engine: held-out]
    E -->|gradients + selection| L[run_refinement_model]
    T -->|gradients| L
    V -.->|no_grad, selection only| L
    L --> B[best_model / best_step]
    B --> C[refined_structure.cif]
    L --> EV[RefinementCompleted]
    EV -->|selection=training| KT[best_training_loss]
    EV -->|selection=validation| KV[best_validation_loss]
```

Per-step interaction inside the loop:

```mermaid
sequenceDiagram
    participant L as refinement loop
    participant O as torch.optim
    participant T as train_engine
    participant V as selection_engine

    L->>L: snapshot = detach(current_model)
    L->>O: step(closure)
    O->>T: objective(params) [grad]
    T-->>O: loss
    O-->>L: loss_value (first eval == snapshot state)
    L->>L: emit RefinementStep(loss=training)
    alt selection_engine present
        L->>V: objective(snapshot) [no_grad]
        V-->>L: selection_loss
    end
    L->>L: if selection_loss < best: best = (step, snapshot)
    L->>L: emit RefinementCompleted(selection=...)
```

Note that the per-step stream stays the training objective in both modes; only the run-level summary changes population.

## Design decisions & tradeoffs

**Decision: select on validation, but do not early-stop.**
*Alternatives:* add patience-based early stopping at the same time.
*Tradeoff:* gains an honest held-out selection signal without changing run duration or introducing a new hyperparameter; sacrifices the compute saving early stopping would give.
*Rationale:* selection and stopping are separable, and stopping adds a tolerance/patience surface that belongs in config with its own validation. The docs now state plainly that the loop always runs `refinement.steps`.

**Decision: distinct measurement keys rather than one key plus a flag.**
*Alternatives:* keep `best_loss` and add `selected_on_validation: 0.0/1.0`.
*Tradeoff:* a dashboard panel tracking `best_loss` goes empty rather than silently mixing populations — a loud break instead of a quiet conflation. Costs one dashboard edit.
*Rationale:* a train-selected and a val-selected run genuinely are not the same series. Distinct keys make conflation structurally impossible instead of relying on every consumer to read a second field. `AGENTS.md` requires event-measurement renames to be deliberate and updated with docs and tests together, which this does.

**Decision: `selection_engine` is a typed API parameter, not a config field.**
*Alternatives:* a `refinement.select_on: training|validation` config key.
*Tradeoff:* less discoverable from YAML; avoids a knob whose only valid value is determined by whether a split exists.
*Rationale:* `AGENTS.md` — scientific composition is typed-Python-first, promoted to config only once the default recipe commits to it. The app derives the engine from `split.train_test`, so there is nothing meaningful for a user to set independently.

**Decision: evaluate the selection objective on `snapshot`, not on post-step parameters.**
*Alternatives:* score after `opt.step`.
*Tradeoff:* selection and the reported training loss describe the same state, so `losses[i]` and `selection_losses[i]` are directly comparable; costs nothing.
*Rationale:* `best_model` must be the parameter set actually written out, and `snapshot` is what gets stored.

## Honest assessment

**1. Penalties leak into the "held-out" objective.**
*Where:* `engine/forward.py`, the `selection_engine.objective_value_model(snapshot, penalties=problem.penalties)` call.
*Why it's wrong:* a `PenaltyTerm` reads only `PhysicalState`, not the engine's orientations, so a restraint contributes an *identical* term to both the training and the selection objective. The selection criterion is therefore not purely held out — it carries a structure-only component that cannot distinguish overfitting.
*What "right" looks like:* decide deliberately whether selection scores the diffraction term alone or the full objective, and document it. Arguably selection should use `components["diffraction"]` only.
*Severity:* tech debt to track — currently **moot**, because `refine_experiment` always passes `build_refinement_problem()` with no penalties. It becomes real the moment a restraint is composed, and it will be silent when it does.

**2. The selection forward has no opt-out and no cost reporting.**
*Where:* `engine/forward.py`, per-step no-grad forward.
*Why it's wrong:* it adds roughly `val_frac` of a training forward to every epoch. The Bloch solve is `O(N²)` assembly plus a dense solve, so this is not free, and there is no flag to skip it or profile counter isolating it. It is documented in the docstring but not measured.
*What "right" looks like:* fold it into the existing `_Timer` profile breakdown so `--profile` attributes it.
*Severity:* fix soon after.

**3. Validation still does not gate anything except which epoch is kept.**
*Where:* `engine/forward.py` loop.
*Why it's wrong:* there is no early stopping and no divergence detection. A run that overfits from epoch 3 onward still burns all 40 epochs, and nothing warns that the selected epoch is far from the last.
*What "right" looks like:* patience-based stopping, or at minimum a report line when `best_step << steps`.
*Severity:* tech debt to track — deliberate scope choice, documented.

**4. `_validation_mask` does not realise the requested fraction.**
*Where:* `preprocess/experiment.py:305-316` (pre-existing, not touched here, but this PR is what makes it consequential).
*Why it's wrong:* `step = round(1.0 / split.val_frac)` means `val_frac=0.3` yields 33%, and any `val_frac` above ~0.667 gives `step == 1`, making *every* rotation validation and leaving `train_only` empty. That fails as an `IndexError` deep inside `build_engine` rather than as a config validation error.
*What "right" looks like:* validate at the config boundary that the realised split leaves a non-empty training set, and either document the rounding or implement the exact fraction.
*Severity:* fix soon after — now that validation actually selects the model, an empty training set is a worse failure than before.

**5. `best_loss` semantics are mode-dependent on the Python API too.**
*Where:* `ModelRefinementResult.best_loss`.
*Why it's wrong:* the event was fixed with an explicit discriminator, but an API consumer reading `result.best_loss` still has to check `result.selection_losses is not None` to know what they are holding. The docstring says so; the type does not.
*What "right" looks like:* a `selection` field on the result mirroring the event, so the two surfaces agree.
*Severity:* nit / tech debt.

**6. No end-to-end test that validation selection changes the written CIF.**
*Where:* `tests/unit/`.
*Why it's wrong:* the unit tests pin the mechanism (`best_step == argmin(selection_losses)`) and the event, but nothing asserts that `refine_experiment` with `train_test: true` actually threads a selection engine through to `_write_refinement_outputs`. The `program.py` wiring is untested.
*What "right" looks like:* a `test_program_refine.py` case with `train_test: true` asserting `result.selection_losses is not None` and that the report contains the `Best epoch selection` row.
*Severity:* fix before merge, arguably — this is the layer most likely to silently regress.

**7. Two engines are built where one filtered evaluation would do.**
*Where:* `app/program.py`, `build_engine` called three times (full, train-only, validation-only).
*Why it's wrong:* each `build_engine` constructs gathers and beam plans; the full engine already covers every rotation, so the validation engine is largely redundant geometry.
*What "right" looks like:* evaluate the full engine and reduce over a validation index mask.
*Severity:* tech debt — memory/setup cost only, and the current form is clearer.

## File-by-file changes

| File | Change |
|---|---|
| `src/diffBloch/engine/forward.py` | `selection_engine` parameter; per-step no-grad selection objective; `selection_losses` on the result; `best_loss` reads the selecting objective; `selection=` threaded into the completion event; docstring notes the per-step cost. |
| `src/diffBloch/app/program.py` | Builds the validation-only engine from the existing split and passes it through; report gains `Best epoch selection` and `Best selection objective` rows. |
| `src/diffBloch/observability.py` | `RefinementCompleted.selection` discriminator; `measurements` keys on it (`best_training_loss` / `best_validation_loss`); docstring corrected — the stream and the summary are no longer the same quantity. |
| `tests/unit/test_engine.py` | New selection-engine test (asserts selection diverges from training argmin, and pins the emitted event); existing tests assert `selection_losses is None` and `selection == "training"` for the default path. |
| `tests/unit/test_observability.py` | Pins both measurement-key variants and asserts the training key is *absent* from a validation-selected event. |
| `docs/refinement.md` | Documents what "best" means per mode and that early stopping still does not happen; rewraps a 490-char line; corrects the outputs table (drops `refinement_summary.json`, superseded by `refinement_report.txt`; adds `refined_components.npz` and `refinement.lock`). |

## Testing

Full suite green: **627 passed, 5 skipped**. `ruff check`, `mypy` (66 files), and a strict `sphinx-build -W` all pass.

The selection test is constructed to be discriminating rather than tautological: the selection engine is pointed at a pattern generated from the *initial* parameters while training pulls toward `occupancy_logit=2.2`, so validation is minimised at step 0 and training at the last step. It asserts `best_step != argmin(losses)` — which fails if selection ever silently falls back to the training objective.

The event discriminator was **mutation-tested**: forcing `selection="training"` unconditionally makes `test_refine_best_params_can_track_a_selection_engine` fail with `assert 'training' == 'validation'`. The test catches the regression it exists for.

Not covered, per honest assessment item 6: the `program.py` wiring has no end-to-end test.

## Migration & compatibility

**Breaking for log consumers.** The `RefinementCompleted` measurement key `best_loss` no longer exists; it is now `best_training_loss` or `best_validation_loss`. Any W&B/Comet panel or CSV consumer keyed on `best_loss` needs updating. This is deliberate — see design decisions — and the break is loud (missing series) rather than quiet (mixed populations).

No config, schema, lock, or plan-format changes. `plan.lock` and `refinement.lock` identity are unaffected: `refinement.split` was already inside `config_digest`, and nothing about the preprocessing recipe changed. Existing checkpoints remain valid.

The Python API is additive — `selection_engine` defaults to `None` and `selection_losses` to `None`, so existing callers are unchanged in behaviour.
