### PR TITLE
Make the run summary a logger backend fed by the event stream

### DIFF
--- a/src/diffBloch/app/cli.py
+++ b/src/diffBloch/app/cli.py
@@ -406,11 +406,15 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-def _build_logger(*, console: bool, csv: str | None) -> Logger:
-    """Combine the requested observation sinks (none => the null logger that discards events)."""
+def _build_logger(*, console: bool, csv: str | None, per_rotation: bool = False) -> Logger:
+    """Combine the requested observation sinks (none => the null logger that discards events).
+
+    ``per_rotation`` opts the console into the settled per-rotation stream; it is off by default
+    because one line per rotation is n_orientations x louder than the run summary.
+    """
     sinks: list[Logger] = []
     if console:
-        sinks.append(ConsoleLogger())
+        sinks.append(ConsoleLogger(per_rotation=per_rotation))
     if csv is not None:
         sinks.append(CSVLogger(Path(csv)))
     if not sinks:

--- a/src/diffBloch/app/cli.py
+++ b/src/diffBloch/app/cli.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 
 from diffBloch import __version__
 from diffBloch.app.loggers import ConsoleLogger, CSVLogger, residual_label
+from diffBloch.app.loggers.summary import SummaryLogger
 from diffBloch.app.program import (
     converge_experiment,
     preprocess_experiment,
@@ -307,9 +308,17 @@ def main(argv: list[str] | None = None) -> int:
                 level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S"
             )
         try:
+            # The written summary is one more sink on the run's event stream, chosen here beside
+            # the console/CSV ones rather than by refine_experiment: an API caller composes it (or
+            # not) for themselves instead of having a file appear as a side effect of refining.
+            report_path = (Path(args.experiment_directory) / "refinement_report.txt").resolve()
+            refine_sinks: tuple[Logger, ...] = (
+                _build_logger(console=not args.quiet, csv=args.csv),
+                SummaryLogger(report_path),
+            )
             refined = refine_experiment(
                 args.experiment_directory,
-                logger=_build_logger(console=not args.quiet, csv=args.csv),
+                logger=MultiLogger(refine_sinks),
                 checkpoint=not args.no_checkpoint,
                 refresh=args.refresh,
                 device=args.device,
@@ -351,6 +360,7 @@ def main(argv: list[str] | None = None) -> int:
         print("Output files")
         for name, path in refined.artifacts.items():
             print(f"  • {name.replace('_', ' ').title():<20} {path}")
+        print(f"  • {'Refinement Report':<20} {report_path}")
         return 0
 
     if args.command == "run" and args.run_command == "converge":

--- a/src/diffBloch/app/loggers/__init__.py
+++ b/src/diffBloch/app/loggers/__init__.py
@@ -33,12 +33,14 @@ from diffBloch.observability import (
     ConvergenceTrial,
     DeviceSelected,
     Event,
+    ExperimentDeclared,
     Logger,
     ObjectiveManifest,
     OrientationOptimizationStarted,
     OrientationOptimized,
     PlanSeeded,
     PlanStepCompleted,
+    RefinedRotationMetrics,
     RefinementOrientationStep,
     RefinementStarted,
     RefinementStep,
@@ -149,7 +151,10 @@ def _render_progress_bar(current: int, total: int, elapsed: float, suffix: str) 
     if current > 0 and current < total:
         remaining = (elapsed / current) * (total - current)
         eta = f" eta {_format_eta(remaining)}"
-    sys.stdout.write(f"\r[{bar}] {current}/{total} ({100.0 * fraction:.0f}%){eta} {suffix}")
+    # `\r` returns the cursor but does not erase, so a shorter line leaves the tail of a longer one
+    # behind ("wR2 0.057427" over "wR2 0.0398710.039671"). `\033[K` clears to end of line; it is the
+    # one escape used here, and only on the tty path this function is already gated behind.
+    sys.stdout.write(f"\r[{bar}] {current}/{total} ({100.0 * fraction:.0f}%){eta} {suffix}\033[K")
     sys.stdout.flush()
     if current >= total:
         sys.stdout.write("\n")
@@ -173,6 +178,10 @@ class ConsoleLogger:
     """
 
     level: int = logging.INFO
+    # The settled per-rotation stream: one line per rotation, once, after the run. On by default
+    # -- unlike the per-epoch verbose stream (n_orientations x n_steps lines) this fires once, and
+    # the final score of every rotation is a result worth reading, not a diagnostic.
+    per_rotation: bool = True
     _refinement_total: int = field(default=0, init=False, repr=False)
     _refinement_started_at: float = field(default=0.0, init=False, repr=False)
     _orientation_total: int = field(default=0, init=False, repr=False)
@@ -185,6 +194,40 @@ class ConsoleLogger:
     def report(self, event: Event) -> None:
         if isinstance(event, DeviceSelected):
             _log.log(self.level, _format_device_selection(event))
+            return
+        if isinstance(event, ExperimentDeclared):
+            _log.log(
+                self.level,
+                "Experiment │ %s │ %s + %s",
+                event.name,
+                event.structure,
+                event.experimental_data,
+            )
+            _log.log(
+                self.level,
+                "Experiment │ %s lr=%g │ %d epoch(s) │ g_max(solve)=%g sg_max=%g │ absorption %s",
+                event.optimizer,
+                event.learning_rate,
+                event.steps,
+                event.solve_g_max,
+                event.sg_max,
+                "on" if event.absorption else "off",
+            )
+            return
+        if isinstance(event, RefinedRotationMetrics):
+            # Gated at the sink, not the emitter: the event must always be emitted -- the
+            # SummaryLogger builds its per-rotation table from it and W&B/Comet want the settled
+            # scores -- so a console that wants less says so here.
+            if self.per_rotation:
+                _log.log(
+                    self.level,
+                    "  rotation %3d │ wR2 %.6f │ R_obs %.6f │ %d matched%s",
+                    event.rotation_index,
+                    event.wr2,
+                    event.r_obs,
+                    event.n_matched,
+                    " │ validation" if event.is_validation else "",
+                )
             return
         if isinstance(event, ObjectiveManifest):
             # "none" is printed rather than the line being dropped: an objective composing no

--- a/src/diffBloch/app/loggers/summary.py
+++ b/src/diffBloch/app/loggers/summary.py
@@ -1,0 +1,387 @@
+"""The human-readable run summary (``refinement_report.txt``) as an ordinary logger backend.
+
+Named for what it produces, not for how it is fed: ``report`` is already the :class:`Logger`
+protocol's own method, so a ``ReportLogger.report(...)`` would read as a tautology.
+
+The summary is built from the event stream and nothing else: the run's
+knobs arrive as :class:`~diffBloch.observability.ExperimentDeclared`, its objective as
+:class:`~diffBloch.observability.ObjectiveManifest`, the epoch curve as
+:class:`~diffBloch.observability.RefinementStep`, the settled per-rotation scores as
+:class:`~diffBloch.observability.RefinedRotationMetrics`, and the trained thickness curve as
+:class:`~diffBloch.observability.ThicknessProfile`. So it composes through
+:class:`~diffBloch.observability.MultiLogger` beside the console/CSV/W&B sinks, and a caller who
+does not want the file simply does not attach it.
+
+Writing happens once, on :class:`~diffBloch.observability.RefinementOutputsWritten` -- the run's
+terminal event. That is what lets a write-at-the-end artifact be a plain one-method ``Logger``
+rather than forcing a ``close``/``finalize`` hook into the protocol. That event also carries the
+path of the committed ``refined_structure.cif``, which this reads back rather than being handed
+parsed values, so the reported cell / space group / atom-site tables are byte-consistent with the
+file on disk by construction.
+
+Unlike the vendor backends this needs no optional dependency: gemmi is already a core dependency
+and the tables are rendered as plain text.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+import gemmi
+
+from diffBloch.core.crystal import cell_volume
+from diffBloch.io import read_structure
+from diffBloch.observability import (
+    Event,
+    ExperimentDeclared,
+    ObjectiveManifest,
+    RefinedRotationMetrics,
+    RefinementCompleted,
+    RefinementOutputsWritten,
+    RefinementStep,
+    ThicknessProfile,
+)
+
+__all__ = ["SummaryLogger", "ascii_table"]
+
+
+def ascii_table(headers: list[str], rows: list[list[str]]) -> str:
+    """Column-aligned plain-text table: a header row, a rule, then the data rows.
+
+    Widths are measured from the content, so a long cell widens its column rather than overflowing
+    it.
+    """
+    widths = [
+        max(len(headers[i]), max((len(r[i]) for r in rows), default=0)) for i in range(len(headers))
+    ]
+
+    def fmt(cells: list[str]) -> str:
+        return "  ".join(cell.ljust(width) for cell, width in zip(cells, widths, strict=True))
+
+    lines = [fmt(headers), "  ".join("-" * width for width in widths)]
+    lines.extend(fmt(row) for row in rows)
+    return "\n".join(lines)
+
+
+def _cif_loop_as_table(block: gemmi.cif.Block, first_tag: str) -> str | None:
+    """Render a CIF loop (identified by its first column tag) as a plain aligned ASCII table.
+
+    ``None`` if the loop is absent (e.g. no ``_atom_site_aniso_*`` loop when every ADP is Uiso).
+    """
+    column = block.find_loop(first_tag)
+    if not column:
+        return None
+    loop = column.get_loop()
+    tags = list(loop.tags)
+    width = loop.width()
+    rows = [
+        [loop.values[row * width + col] for col in range(width)] for row in range(loop.length())
+    ]
+    return ascii_table(tags, rows)
+
+
+@dataclass
+class SummaryLogger:
+    """Accumulate a refinement run's events and write ``refinement_report.txt`` when it ends.
+
+    ``path`` is the report file. Every event is buffered until
+    :class:`~diffBloch.observability.RefinementOutputsWritten` arrives, at which point the report is
+    rendered and written; a run that never emits that event writes nothing, which is the correct
+    behaviour for an aborted run (there is no committed structure to describe).
+
+    ``plot`` (default ``True``) additionally writes the thickness-NN shape PNG beside the report when
+    a :class:`~diffBloch.observability.ThicknessProfile` was seen and matplotlib is installed; the
+    report notes the omission otherwise, exactly as before.
+    """
+
+    path: Path
+    plot: bool = True
+    _experiment: ExperimentDeclared | None = field(default=None, init=False, repr=False)
+    _manifest: ObjectiveManifest | None = field(default=None, init=False, repr=False)
+    _steps: list[RefinementStep] = field(default_factory=list, init=False, repr=False)
+    _completed: RefinementCompleted | None = field(default=None, init=False, repr=False)
+    _rotations: list[RefinedRotationMetrics] = field(default_factory=list, init=False, repr=False)
+    _profile: ThicknessProfile | None = field(default=None, init=False, repr=False)
+    _started_at: float = field(default=0.0, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.path = Path(self.path)
+        # The sink times the run itself rather than being told how long it took: it sees the first
+        # event and the last, which is the same span the caller would have measured.
+        self._started_at = time.perf_counter()
+
+    def report(self, event: Event) -> None:
+        if isinstance(event, ExperimentDeclared):
+            self._experiment = event
+        elif isinstance(event, ObjectiveManifest):
+            self._manifest = event
+        elif isinstance(event, RefinementStep):
+            self._steps.append(event)
+        elif isinstance(event, RefinementCompleted):
+            self._completed = event
+        elif isinstance(event, RefinedRotationMetrics):
+            self._rotations.append(event)
+        elif isinstance(event, ThicknessProfile):
+            self._profile = event
+        elif isinstance(event, RefinementOutputsWritten):
+            self._write(event)
+
+    def _write(self, outputs: RefinementOutputsWritten) -> None:
+        elapsed = time.perf_counter() - self._started_at
+        lines: list[str] = []
+
+        def banner(title: str) -> None:
+            lines.append("=" * 78)
+            lines.append(f" {title}")
+            lines.append("=" * 78)
+
+        def rule(title: str) -> None:
+            lines.append("")
+            lines.append(f"--- {title} " + "-" * max(0, 74 - len(title)))
+
+        experiment = self._experiment
+        banner(f"diffBloch refinement report -- {experiment.name if experiment else 'run'}")
+        lines.append(f" structure   : {experiment.structure if experiment else 'n/a'}")
+        lines.append(f" exp_data    : {experiment.experimental_data if experiment else 'n/a'}")
+        lines.append(f" generated   : {datetime.now(UTC).isoformat(timespec='seconds')}")
+        lines.append(f" elapsed     : {elapsed:.1f} s ({elapsed / 60.0:.2f} min)")
+
+        self._simulation_parameters(lines, rule)
+        self._crystallographic_parameters(lines, rule, Path(outputs.structure))
+        self._objective_terms(lines, rule)
+        self._objective_components(lines, rule)
+        self._rotation_metrics(lines, rule)
+        self._thickness_profile(lines, rule)
+        self._refined_structure(lines, rule, Path(outputs.structure))
+
+        self.path.write_text("\n".join(lines) + "\n")
+
+    @property
+    def _best(self) -> RefinementStep | None:
+        """The epoch the run selected, or ``None`` if no step stream was seen."""
+        if not self._steps:
+            return None
+        if self._completed is not None:
+            for step in self._steps:
+                if step.iteration == self._completed.best_step:
+                    return step
+        return self._steps[-1]
+
+    def _simulation_parameters(self, lines: list[str], rule: Callable[[str], None]) -> None:
+        rule("Simulation / refinement parameters")
+        experiment, best, completed = self._experiment, self._best, self._completed
+        if experiment is None:
+            lines.append(" n/a (no recorded experiment declaration)")
+            return
+
+        def epoch_mean_pct(value: float | None, evaluated: int | None) -> str:
+            """A best-epoch mean as a percentage, with the rotation count it was averaged over.
+
+            A non-finite mean renders ``n/a``, the same spelling the per-rotation means below this
+            table use: the objective averages only finite scores, so non-finite means nothing was
+            evaluated -- already stated by the count beside it.
+            """
+            if best is None or value is None:
+                return "n/a"
+            rendered = f"{100.0 * value:.2f}" if math.isfinite(value) else "n/a"
+            if evaluated is None or best.n_rotations is None:
+                return rendered
+            return f"{rendered} [{evaluated}/{best.n_rotations}]"
+
+        counts = completed.reflection_counts if completed else {}
+        hkls_matched = (
+            f"{counts['matched_i_gt_3sigma']} / {counts['matched']}"
+            if "matched" in counts and "matched_i_gt_3sigma" in counts
+            else "n/a"
+        )
+        best_epoch = f"{completed.best_step + 1:g}" if completed else "n/a"
+        rows = [
+            ["Integration semiangle (deg)", f"{experiment.integration_semiangle:g}"],
+            ["Rocking-curve sampling", f"{experiment.rocking_curve_sampling:g}"],
+            ["D_sg", f"{experiment.dsg:g}"],
+            ["R_sg", f"{experiment.rsg:g}"],
+            ["g_max (solve cutoff, A^-1)", f"{experiment.solve_g_max:g}"],
+            [
+                "structure-factor support (2 x g_max, A^-1)",
+                f"{2.0 * experiment.solve_g_max:g}",
+            ],
+            ["sg_max (A^-1)", f"{experiment.sg_max:g}"],
+            ["Absorption (T/F)", "T" if experiment.absorption else "F"],
+            ["Seed thickness (A)", ", ".join(f"{t:g}" for t in experiment.seed_thicknesses)],
+            ["Epochs (configured)", f"{experiment.steps:g}"],
+            ["Best epoch", best_epoch],
+            ["Optimizer", experiment.optimizer],
+            ["Learning rate", f"{experiment.learning_rate:g}"],
+            [
+                "R_obs (%)",
+                epoch_mean_pct(
+                    best.r_obs if best else None, best.n_r_obs_evaluated if best else None
+                ),
+            ],
+            [
+                "wR2 (%)",
+                epoch_mean_pct(best.wr2 if best else None, best.n_wr2_evaluated if best else None),
+            ],
+            ["HKLs (Observed/total)", hkls_matched],
+        ]
+        lines.append(ascii_table(["Parameter", "Value"], rows))
+
+    def _crystallographic_parameters(
+        self, lines: list[str], rule: Callable[[str], None], structure_path: Path
+    ) -> None:
+        rule("Crystallographic parameters")
+        structure = read_structure(structure_path)
+        a, b, c, alpha, beta, gamma = (float(v) for v in structure.cell_parameters)
+        lines.append(
+            ascii_table(
+                ["Parameter", "Value"],
+                [
+                    ["Space group", f"{structure.spacegroup_hm} (#{structure.spacegroup_number})"],
+                    ["a, b, c (A)", f"{a:.4f}, {b:.4f}, {c:.4f}"],
+                    ["alpha, beta, gamma (deg)", f"{alpha:.2f}, {beta:.2f}, {gamma:.2f}"],
+                    ["Volume (A^3)", f"{cell_volume(structure.unit_cell):.1f}"],
+                    ["N atoms (ASU)", f"{len(structure.labels)}"],
+                ],
+            )
+        )
+
+    def _objective_terms(self, lines: list[str], rule: Callable[[str], None]) -> None:
+        rule("Objective terms (declared)")
+        manifest = self._manifest
+        if manifest is None:
+            lines.append(" n/a (no recorded objective manifest)")
+            return
+        # "none" rather than an omitted line: the default CLI path composes no penalties, and that
+        # is a scientific fact a reader should not have to infer from a missing section.
+        penalties = ", ".join(f"{t.name} (weight {t.weight:g})" for t in manifest.penalties)
+        lines.append(f" penalties  : {penalties or 'none'}")
+        lines.append(f" constraints: {', '.join(manifest.constraints) or 'none'}")
+        lines.append(f" components : {', '.join(manifest.components) or 'none'}")
+
+    def _objective_components(self, lines: list[str], rule: Callable[[str], None]) -> None:
+        rule("Objective components (best epoch)")
+        best = self._best
+        if best is None or not best.components:
+            lines.append(" n/a (no recorded objective components)")
+            return
+        lines.append(
+            ascii_table(
+                ["Component", "Raw", "Weight", "Contribution"],
+                [
+                    [
+                        term,
+                        f"{values['raw']:.6g}",
+                        f"{values['weight']:g}",
+                        f"{values['contribution']:.6g}",
+                    ]
+                    for term, values in best.components.items()
+                ],
+            )
+        )
+        lines.append("")
+        total = "n/a" if best.objective_total is None else f"{best.objective_total:.6g}"
+        lines.append(f" objective total = {total}")
+        # Every row is a term the objective actually composed. A restraint that was not composed
+        # has no row, so this table never reports an inactive term as a satisfied zero.
+        lines.append(" (terms not composed into the objective have no row)")
+
+    def _rotation_metrics(self, lines: list[str], rule: Callable[[str], None]) -> None:
+        def block(rows: Sequence[RefinedRotationMetrics]) -> None:
+            lines.append(
+                ascii_table(
+                    ["Rotation", "wR2", "R_obs", "N matched"],
+                    [
+                        [
+                            str(row.rotation_index),
+                            f"{row.wr2:.6f}",
+                            f"{row.r_obs:.6f}",
+                            str(row.n_matched),
+                        ]
+                        for row in rows
+                    ],
+                )
+            )
+            finite_wr2 = [row.wr2 for row in rows if math.isfinite(row.wr2)]
+            finite_r_obs = [row.r_obs for row in rows if math.isfinite(row.r_obs)]
+            lines.append("")
+
+            def mean_line(label: str, finite: list[float]) -> str:
+                # Each mean states the denominator it was taken over: a mean that covers fewer
+                # rotations is a different quantity, not a better one.
+                if not finite:
+                    return f" mean {label} = n/a [0/{len(rows)}]"
+                return (
+                    f" mean {label} = {sum(finite) / len(finite):.6f} [{len(finite)}/{len(rows)}]"
+                )
+
+            lines.append(mean_line("wR2  ", finite_wr2))
+            lines.append(mean_line("R_obs", finite_r_obs))
+
+        rule("Per-rotation wR2 / R_obs (final refined model)")
+        block(self._rotations)
+        validation = [row for row in self._rotations if row.is_validation]
+        if validation:
+            rule("Validation set (held out from the refinement objective)")
+            lines.append(f" n_rotations = {len(validation)}")
+            lines.append("")
+            block(validation)
+
+    def _thickness_profile(self, lines: list[str], rule: Callable[[str], None]) -> None:
+        rule("Thickness NN")
+        profile = self._profile
+        if profile is None:
+            lines.append(" enabled: no (preprocess-baked per-rotation thickness only)")
+            return
+        lines.append(
+            f" enabled: yes ({profile.form}, bounds "
+            f"[{profile.min_thickness:g}, {profile.max_thickness:g}] A)"
+        )
+        lines.append("")
+        lines.append(
+            ascii_table(
+                ["Rotation", "alpha (degrees)", "Thickness (A)"],
+                [
+                    [str(index), f"{alpha:.4f}", f"{thickness:.2f}"]
+                    for index, alpha, thickness in zip(
+                        profile.rotation_indices,
+                        profile.alphas,
+                        profile.thicknesses,
+                        strict=True,
+                    )
+                ],
+            )
+        )
+        if not self.plot:
+            return
+        plot_path = self.path.parent / "thickness_nn_shape.png"
+        try:
+            from diffBloch.app.loggers.plotting import plot_thickness_nn_shape
+
+            plot_thickness_nn_shape(
+                list(zip(profile.alphas, profile.thicknesses, strict=True)), plot_path
+            )
+            lines.append("")
+            lines.append(f" plot: {plot_path.name}")
+        except ModuleNotFoundError:
+            lines.append("")
+            lines.append(
+                " plot: skipped (matplotlib not installed -- see the diffBloch[plot] extra)"
+            )
+
+    def _refined_structure(
+        self, lines: list[str], rule: Callable[[str], None], structure_path: Path
+    ) -> None:
+        rule("Refined structure -- atom_site")
+        block = gemmi.cif.read_file(str(structure_path)).sole_block()
+        atom_table = _cif_loop_as_table(block, "_atom_site_label")
+        if atom_table is not None:
+            lines.append(atom_table)
+        aniso_table = _cif_loop_as_table(block, "_atom_site_aniso_label")
+        if aniso_table is not None:
+            lines.append("")
+            lines.append(aniso_table)

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -24,11 +24,7 @@ load/resume go through stdlib ``logging`` (not the domain-observation ``logger``
 from __future__ import annotations
 
 import logging
-import math
-import time
-from collections.abc import Sequence
 from dataclasses import replace
-from datetime import UTC, datetime
 from pathlib import Path
 
 import gemmi
@@ -51,19 +47,24 @@ from diffBloch.config import (
     write_preprocess_lock,
     write_refinement_lock,
 )
-from diffBloch.core.crystal import cell_volume
 from diffBloch.engine import (
     ApparentThicknessNN,
     ModelRefinementResult,
     RefinementEngine,
-    RotationMetrics,
     ThicknessBounds,
     build_refinement_model,
     build_refinement_problem,
     run_refinement_model,
 )
 from diffBloch.io import read_experimental_data, read_structure
-from diffBloch.observability import NULL_LOGGER, DeviceSelected, Logger, MultiLogger
+from diffBloch.observability import (
+    NULL_LOGGER,
+    DeviceSelected,
+    Logger,
+    MultiLogger,
+    RefinedRotationMetrics,
+    RefinementOutputsWritten,
+)
 from diffBloch.params import Device, constrain
 from diffBloch.preprocess import (
     OPAQUE,
@@ -420,7 +421,6 @@ def refine_experiment(
     solve intermediates until backward. Execution-only -- gradients are unaffected. See
     :class:`~diffBloch.engine.RefinementEngine`.
     """
-    started = time.perf_counter()
     root = Path(experiment_dir)
     device = _select_device(device, logger=logger)
     cfg, _lock = load_experiment(root)
@@ -484,6 +484,7 @@ def refine_experiment(
             profile=profile,
             checkpoint_activations=checkpoint_activations,
         )
+    logger.report(cfg.to_declaration(integration))
     initial = refinement.params if device is None else refinement.params.to(device)
     thickness_spec = cfg.refinement.thickness_nn.to_spec()
     thickness_nn: ApparentThicknessNN | None = None
@@ -528,21 +529,59 @@ def refine_experiment(
         profile=profile,
         selection_engine=selection_engine,
     )
-    elapsed_seconds = time.perf_counter() - started
     result = _write_refinement_outputs(root, cfg, refinement, result)
-    report_path = _write_refinement_report(
-        root,
-        cfg,
-        integration,
+    # The settled-result events, then the terminal one: SummaryLogger writes the file on the latter.
+    _report_refinement_outcome(
+        logger,
         engine,
         result,
-        elapsed_seconds=elapsed_seconds,
         validation_rotation_indices=validation_rotation_indices,
         thickness_nn=thickness_nn,
         raw_alphas=raw_alphas,
     )
-    result = replace(result, artifacts={**result.artifacts, "refinement_report": str(report_path)})
     return result
+
+
+def _report_refinement_outcome(
+    logger: Logger,
+    engine: RefinementEngine,
+    result: ModelRefinementResult,
+    *,
+    validation_rotation_indices: frozenset[int],
+    thickness_nn: ApparentThicknessNN | None,
+    raw_alphas: np.ndarray | None,
+) -> None:
+    """Emit the settled-result events the refinement loop itself cannot produce.
+
+    ``run_refinement_model`` only ever sees the *training* engine, so the final per-rotation scores
+    (which cover held-out rotations too) and the trained thickness curve have to be emitted here,
+    where the reporting engine and the split are both in scope. :class:`RefinementOutputsWritten`
+    goes last and is the run's terminal event -- a sink that must write exactly once, after
+    everything else, acts on it.
+    """
+    for row in engine.per_rotation_metrics(result.best_model):
+        logger.report(
+            RefinedRotationMetrics(
+                rotation_index=row.rotation_index,
+                wr2=row.wr2,
+                r_obs=row.r_obs,
+                n_matched=row.n_matched,
+                is_validation=row.rotation_index in validation_rotation_indices,
+            )
+        )
+    if thickness_nn is not None and raw_alphas is not None:
+        logger.report(
+            thickness_nn.profile(
+                result.best_model.component_params[thickness_nn.key],
+                engine.orientations,
+                raw_alphas,
+            )
+        )
+    logger.report(
+        RefinementOutputsWritten(
+            structure=result.artifacts["refined_structure"], artifacts=result.artifacts
+        )
+    )
 
 
 def _normalized_pets_alphas(alphas: np.ndarray) -> tuple[float, ...]:
@@ -568,9 +607,9 @@ def _write_refinement_outputs(
 
     ``refined_structure.cif`` lands at ``root`` (the human-facing output); the raw ``.npz``
     snapshots and the checkpoint/refinement locks go under :func:`_reproducibility_dir` --
-    bookkeeping nobody reads directly. See :func:`_write_refinement_report` for the actual
-    human-readable summary (``refinement_report.txt``), which supersedes the machine-readable
-    ``refinement_summary.json`` this function used to also write.
+    bookkeeping nobody reads directly. See :class:`~diffBloch.app.loggers.summary.SummaryLogger`
+    for the actual human-readable summary (``refinement_report.txt``), which supersedes the
+    machine-readable ``refinement_summary.json`` this function used to also write.
     """
     reproducibility_dir = _reproducibility_dir(root)
     structure_path = (root / "refined_structure.cif").resolve()
@@ -684,272 +723,6 @@ def _write_refinement_outputs(
         )
         artifacts["refinement_lock"] = str(lock_path)
     return replace(result, artifacts=artifacts)
-
-
-def _ascii_table(headers: list[str], rows: list[list[str]]) -> str:
-    """Column-aligned plain-text table: a header row, a rule, then the data rows."""
-    widths = [
-        max(len(headers[i]), max((len(r[i]) for r in rows), default=0)) for i in range(len(headers))
-    ]
-
-    def fmt(cells: list[str]) -> str:
-        return "  ".join(cell.ljust(width) for cell, width in zip(cells, widths, strict=True))
-
-    lines = [fmt(headers), "  ".join("-" * width for width in widths)]
-    lines.extend(fmt(row) for row in rows)
-    return "\n".join(lines)
-
-
-def _format_cif_loop_as_table(block: gemmi.cif.Block, first_tag: str) -> str | None:
-    """Render a CIF loop (identified by its first column tag) as a plain aligned ASCII table.
-
-    ``None`` if the loop is absent (e.g. no ``_atom_site_aniso_*`` loop when every ADP is Uiso).
-    """
-    column = block.find_loop(first_tag)
-    if not column:
-        return None
-    loop = column.get_loop()
-    tags = list(loop.tags)
-    width = loop.width()
-    rows = [
-        [loop.values[row * width + col] for col in range(width)] for row in range(loop.length())
-    ]
-    return _ascii_table(tags, rows)
-
-
-def _write_refinement_report(
-    root: Path,
-    cfg: ExperimentConfig,
-    integration: IntegrationGeometry,
-    engine: RefinementEngine,
-    result: ModelRefinementResult,
-    *,
-    elapsed_seconds: float,
-    validation_rotation_indices: frozenset[int] = frozenset(),
-    thickness_nn: ApparentThicknessNN | None = None,
-    raw_alphas: np.ndarray | None = None,
-) -> Path:
-    """Write ``refinement_report.txt``: paper-table-ready stats, no prose, tables/loops only.
-
-    Reads the just-written ``refined_structure.cif`` back (rather than recomputing its atom-site
-    values a second time) so the reported unit cell / space group / atom-site tables are guaranteed
-    byte-for-byte consistent with the committed CIF -- this function runs after
-    :func:`_write_refinement_outputs`. ``engine`` covers every rotation (the per-rotation table is
-    never restricted to train); ``validation_rotation_indices`` non-empty (``train_test`` on) adds a
-    held-out-only section after it.
-    """
-    blochwave = cfg.blochwave
-    best = result.history[result.best_step] if result.history else None
-    structure_path = root / "refined_structure.cif"
-    document = gemmi.cif.read_file(str(structure_path))
-    block = document.sole_block()
-    structure = read_structure(structure_path)
-    volume = cell_volume(structure.unit_cell)
-
-    lines: list[str] = []
-
-    def banner(title: str) -> None:
-        lines.append("=" * 78)
-        lines.append(f" {title}")
-        lines.append("=" * 78)
-
-    def rule(title: str) -> None:
-        lines.append("")
-        lines.append(f"--- {title} " + "-" * max(0, 74 - len(title)))
-
-    banner(f"diffBloch refinement report -- {root.name}")
-    lines.append(f" structure   : {cfg.inputs.structure}")
-    lines.append(f" exp_data    : {cfg.inputs.exp_data}")
-    lines.append(f" generated   : {datetime.now(UTC).isoformat(timespec='seconds')}")
-    lines.append(f" elapsed     : {elapsed_seconds:.1f} s ({elapsed_seconds / 60.0:.2f} min)")
-
-    rule("Simulation / refinement parameters")
-
-    def epoch_mean_pct(value: float | None, evaluated: int | None) -> str:
-        """A best-epoch mean as a percentage, with the rotation count it was averaged over.
-
-        A non-finite mean renders ``n/a``, the same spelling the per-rotation means below this table
-        use: the objective averages only finite scores, so non-finite means nothing was evaluated --
-        already stated by the count beside it.
-        """
-        if best is None or value is None:
-            return "n/a"
-        rendered = f"{100.0 * value:.2f}" if math.isfinite(value) else "n/a"
-        if evaluated is None or best.n_rotations is None:
-            return rendered
-        return f"{rendered} [{evaluated}/{best.n_rotations}]"
-
-    r_obs_pct = epoch_mean_pct(
-        best.r_obs if best else None, best.n_r_obs_evaluated if best else None
-    )
-    wr2_pct = epoch_mean_pct(best.wr2 if best else None, best.n_wr2_evaluated if best else None)
-    counts = result.reflection_counts
-    hkls_matched = f"{counts['matched_i_gt_3sigma']} / {counts['matched']}"
-    param_rows = [
-        ["Integration semiangle (deg)", f"{integration.semiangle:g}"],
-        ["Rocking-curve sampling", f"{blochwave.rocking_curve_sampling:g}"],
-        ["D_sg", f"{blochwave.dsg:g}"],
-        ["R_sg", f"{blochwave.rsg:g}"],
-        ["g_max (solve cutoff, A^-1)", f"{blochwave.g_max:g}"],
-        ["structure-factor support (2 x g_max, A^-1)", f"{2.0 * blochwave.g_max:g}"],
-        ["sg_max (A^-1)", f"{blochwave.sg_max:g}"],
-        ["Absorption (T/F)", "T" if blochwave.absorption else "F"],
-        ["Seed thickness (A)", ", ".join(f"{t:g}" for t in cfg.sample.thicknesses)],
-        ["Epochs (configured)", f"{cfg.refinement.steps:g}"],
-        ["Best epoch", f"{result.best_step + 1:g}"],
-        [
-            "Best epoch selection",
-            "held-out validation objective"
-            if result.selection_losses is not None
-            else "training objective",
-        ],
-        ["Best selection objective", f"{result.best_loss:.6g}"],
-        ["Optimizer", cfg.refinement.optimizer.name],
-        ["Learning rate", f"{cfg.refinement.optimizer.lr:g}"],
-        ["R_obs (%)", r_obs_pct],
-        ["wR2 (%)", wr2_pct],
-        ["HKLs (Observed/total)", hkls_matched],
-    ]
-    lines.append(_ascii_table(["Parameter", "Value"], param_rows))
-
-    rule("Crystallographic parameters")
-    a, b, c, alpha, beta, gamma = (float(v) for v in structure.cell_parameters)
-    cell_rows = [
-        ["Space group", f"{structure.spacegroup_hm} (#{structure.spacegroup_number})"],
-        ["a, b, c (A)", f"{a:.4f}, {b:.4f}, {c:.4f}"],
-        ["alpha, beta, gamma (deg)", f"{alpha:.2f}, {beta:.2f}, {gamma:.2f}"],
-        ["Volume (A^3)", f"{volume:.1f}"],
-        ["N atoms (ASU)", f"{len(structure.labels)}"],
-    ]
-    lines.append(_ascii_table(["Parameter", "Value"], cell_rows))
-
-    rule("Objective terms (declared)")
-    manifest = result.objective_manifest
-    if manifest is None:
-        lines.append(" n/a (no recorded objective manifest)")
-    else:
-        # "none" rather than an omitted line: the default CLI path composes no penalties, and that
-        # is a scientific fact a reader should not have to infer from a missing section.
-        penalties = ", ".join(f"{t.name} (weight {t.weight:g})" for t in manifest.penalties)
-        lines.append(f" penalties  : {penalties or 'none'}")
-        lines.append(f" constraints: {', '.join(manifest.constraints) or 'none'}")
-        lines.append(f" components : {', '.join(manifest.components) or 'none'}")
-
-    rule("Objective components (best epoch)")
-    if best is not None and best.components:
-        lines.append(
-            _ascii_table(
-                ["Component", "Raw", "Weight", "Contribution"],
-                [
-                    [
-                        term,
-                        f"{values['raw']:.6g}",
-                        f"{values['weight']:g}",
-                        f"{values['contribution']:.6g}",
-                    ]
-                    for term, values in best.components.items()
-                ],
-            )
-        )
-        lines.append("")
-        total = "n/a" if best.objective_total is None else f"{best.objective_total:.6g}"
-        lines.append(f" objective total = {total}")
-        # Every row is a term the objective actually composed. A restraint that was not composed
-        # has no row, so this table never reports an inactive term as a satisfied zero.
-        lines.append(" (terms not composed into the objective have no row)")
-    else:
-        lines.append(" n/a (no recorded objective components)")
-
-    def rotation_metrics_block(rows: Sequence[RotationMetrics]) -> None:
-        lines.append(
-            _ascii_table(
-                ["Rotation", "wR2", "R_obs", "N matched"],
-                [
-                    [
-                        str(row.rotation_index),
-                        f"{row.wr2:.6f}",
-                        f"{row.r_obs:.6f}",
-                        str(row.n_matched),
-                    ]
-                    for row in rows
-                ],
-            )
-        )
-        finite_wr2 = [row.wr2 for row in rows if row.wr2 == row.wr2]
-        finite_r_obs = [row.r_obs for row in rows if row.r_obs == row.r_obs]
-        lines.append("")
-
-        def mean_line(label: str, finite: list[float]) -> str:
-            # Each mean states the denominator it was taken over: a mean that covers fewer
-            # rotations is a different quantity, not a better one.
-            if not finite:
-                return f" mean {label} = n/a [0/{len(rows)}]"
-            return f" mean {label} = {sum(finite) / len(finite):.6f} [{len(finite)}/{len(rows)}]"
-
-        lines.append(mean_line("wR2  ", finite_wr2))
-        lines.append(mean_line("R_obs", finite_r_obs))
-
-    rule("Per-rotation wR2 / R_obs (final refined model)")
-    per_rotation = engine.per_rotation_metrics(result.best_model)
-    rotation_metrics_block(per_rotation)
-
-    if validation_rotation_indices:
-        rule("Validation set (held out from the refinement objective)")
-        validation_rows = tuple(
-            row for row in per_rotation if row.rotation_index in validation_rotation_indices
-        )
-        lines.append(f" n_rotations = {len(validation_rows)}")
-        lines.append("")
-        rotation_metrics_block(validation_rows)
-
-    rule("Thickness NN")
-    if thickness_nn is not None and raw_alphas is not None:
-        component_params = result.best_model.component_params[thickness_nn.key]
-        shape_rows: list[list[str]] = []
-        plot_rows: list[tuple[float, float]] = []
-        for orientation in engine.orientations:
-            index = orientation.pattern.rotation_index
-            context = thickness_nn.forward_context(
-                component_params, rotation_index=index, orientation=orientation
-            )
-            assert context.thickness is not None
-            thickness = float(context.thickness.reshape(-1)[0])
-            angle = float(raw_alphas[index])
-            shape_rows.append([str(index), f"{angle:.4f}", f"{thickness:.2f}"])
-            plot_rows.append((angle, thickness))
-        lines.append(
-            f" enabled: yes ({thickness_nn.form}, bounds "
-            f"[{thickness_nn.bounds.min_angstrom:g}, {thickness_nn.bounds.max_angstrom:g}] A)"
-        )
-        lines.append("")
-        lines.append(_ascii_table(["Rotation", "alpha (degrees)", "Thickness (A)"], shape_rows))
-        plot_path = root / "thickness_nn_shape.png"
-        try:
-            from diffBloch.app.loggers.plotting import plot_thickness_nn_shape
-
-            plot_thickness_nn_shape(plot_rows, plot_path)
-            lines.append("")
-            lines.append(f" plot: {plot_path.name}")
-        except ModuleNotFoundError:
-            lines.append("")
-            lines.append(
-                " plot: skipped (matplotlib not installed -- see the diffBloch[plot] extra)"
-            )
-    else:
-        lines.append(" enabled: no (preprocess-baked per-rotation thickness only)")
-
-    rule("Refined structure -- atom_site")
-    atom_table = _format_cif_loop_as_table(block, "_atom_site_label")
-    if atom_table is not None:
-        lines.append(atom_table)
-    aniso_table = _format_cif_loop_as_table(block, "_atom_site_aniso_label")
-    if aniso_table is not None:
-        lines.append("")
-        lines.append(aniso_table)
-
-    report_path = (root / "refinement_report.txt").resolve()
-    report_path.write_text("\n".join(lines) + "\n")
-    return report_path
 
 
 def _preprocess(

--- a/src/diffBloch/config/schema.py
+++ b/src/diffBloch/config/schema.py
@@ -26,6 +26,7 @@ from diffBloch.engine.refine import AtomSelection, TrainableSpec
 
 if TYPE_CHECKING:
     from diffBloch.engine.forward import LossFn, ScoresFn
+from diffBloch.observability import ExperimentDeclared
 from diffBloch.specs import (
     Absorption,
     ApparentThicknessNetwork,
@@ -447,6 +448,32 @@ class ExperimentConfig(_StrictConfig):
     # scoped to either stage.
     loss_metrics: LossMetricsConfig = Field(default_factory=LossMetricsConfig)
     refinement: RefinementConfig = Field(default_factory=RefinementConfig)
+
+    def to_declaration(self, integration: IntegrationGeometry) -> ExperimentDeclared:
+        """Project the result-determining knobs onto the run's declaration event.
+
+        One more ``to_*`` edge alongside :meth:`BlochwaveConfig.to_policy` /
+        :meth:`~BlochwaveConfig.to_absorption`: the config already owns every value here, so mapping
+        them lives with it rather than in whichever caller happens to emit the event. Any backend
+        (W&B/Comet hyperparameters, the written summary) reads the run's settings from this one
+        event instead of being handed the config object.
+        """
+        return ExperimentDeclared(
+            name=self.name,
+            structure=self.inputs.structure,
+            experimental_data=self.inputs.exp_data,
+            optimizer=self.refinement.optimizer.name,
+            seed_thicknesses=tuple(self.sample.thicknesses),
+            integration_semiangle=integration.semiangle,
+            rocking_curve_sampling=self.blochwave.rocking_curve_sampling,
+            dsg=self.blochwave.dsg,
+            rsg=self.blochwave.rsg,
+            solve_g_max=self.blochwave.g_max,
+            sg_max=self.blochwave.sg_max,
+            absorption=self.blochwave.absorption,
+            steps=self.refinement.steps,
+            learning_rate=self.refinement.optimizer.lr,
+        )
 
 
 def load_config(path: str | Path) -> ExperimentConfig:

--- a/src/diffBloch/engine/components.py
+++ b/src/diffBloch/engine/components.py
@@ -7,13 +7,16 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Literal
 
+import numpy as np
 import torch
 import torch.nn.functional as F
+from numpy.typing import NDArray
 from torch import Tensor
 
 from diffBloch.core.constraints import positive
 from diffBloch.engine.forward import ForwardContext
 from diffBloch.engine.plan import OrientationPlanLike
+from diffBloch.observability import ThicknessProfile
 
 __all__ = [
     "ApparentThicknessNN",
@@ -226,6 +229,34 @@ class ApparentThicknessNN:
             "layer2.weight": w2,
             "layer2.bias": b2,
         }
+
+    def profile(
+        self,
+        params: Mapping[str, Tensor],
+        orientations: Sequence[OrientationPlanLike],
+        raw_alphas: Sequence[float] | NDArray[np.float64],
+    ) -> ThicknessProfile:
+        """Evaluate the trained curve at every orientation's tilt angle, as a reportable value.
+
+        The component owns this because it owns the behaviour: sampling its own output is not
+        something an orchestrator or a logger should reimplement, and a sink must never run the
+        forward model itself. ``raw_alphas`` is indexed by source PETS rotation index.
+        """
+        indices = [orientation.pattern.rotation_index for orientation in orientations]
+        thicknesses: list[float] = []
+        for index, orientation in zip(indices, orientations, strict=True):
+            context = self.forward_context(params, rotation_index=index, orientation=orientation)
+            if context.thickness is None:
+                raise ValueError("thickness component produced no thickness")
+            thicknesses.append(float(context.thickness.reshape(-1)[0]))
+        return ThicknessProfile(
+            form=self.form,
+            min_thickness=self.bounds.min_angstrom,
+            max_thickness=self.bounds.max_angstrom,
+            rotation_indices=tuple(indices),
+            alphas=tuple(float(raw_alphas[index]) for index in indices),
+            thicknesses=tuple(thicknesses),
+        )
 
     def forward_context(
         self,

--- a/src/diffBloch/engine/forward.py
+++ b/src/diffBloch/engine/forward.py
@@ -1083,15 +1083,24 @@ def run_refinement_model(
             selection_losses.append(selection_loss)
         if selection_loss < best_loss:
             best_loss, best_step, best_model = selection_loss, step, snapshot
+    _, n_matched, n_strong, n_weak, n_unmatched = engine.refinement_metrics(best_model)
+    reflection_counts = MappingProxyType(
+        {
+            "matched": n_matched,
+            "matched_i_gt_3sigma": n_strong,
+            "matched_i_le_3sigma": n_weak,
+            "unmatched_observed": n_unmatched,
+        }
+    )
     logger.report(
         RefinementCompleted(
             n_steps=steps,
             best_step=best_step,
             best_loss=best_loss,
             selection="validation" if selection_engine is not None else "training",
+            reflection_counts=reflection_counts,
         )
     )
-    _, n_matched, n_strong, n_weak, n_unmatched = engine.refinement_metrics(best_model)
     return ModelRefinementResult(
         model=_detach_model(current_model()),
         losses=torch.tensor(losses, dtype=torch.float64),
@@ -1103,13 +1112,6 @@ def run_refinement_model(
             else None
         ),
         history=tuple(history),
-        reflection_counts=MappingProxyType(
-            {
-                "matched": n_matched,
-                "matched_i_gt_3sigma": n_strong,
-                "matched_i_le_3sigma": n_weak,
-                "unmatched_observed": n_unmatched,
-            }
-        ),
+        reflection_counts=reflection_counts,
         objective_manifest=manifest,
     )

--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -34,6 +34,7 @@ __all__ = [
     "ConvergenceSweepStarted",
     "DeviceSelected",
     "Event",
+    "ExperimentDeclared",
     "InferenceCompleted",
     "Logger",
     "MultiLogger",
@@ -46,14 +47,17 @@ __all__ = [
     "PlanSeeded",
     "PlanStepCompleted",
     "RecordingLogger",
+    "RefinedRotationMetrics",
     "RefinementCompleted",
     "RefinementOrientationStep",
+    "RefinementOutputsWritten",
     "RefinementStarted",
     "RefinementStep",
     "RotationCoupling",
     "RotationScored",
     "ThicknessOptimized",
     "ThicknessOptimizationStarted",
+    "ThicknessProfile",
 ]
 
 
@@ -495,6 +499,155 @@ class InferenceCompleted:
 
 
 @dataclass(frozen=True)
+class ExperimentDeclared:
+    """The run's identity and its result-determining knobs, declared once before any compute.
+
+    The counterpart to :class:`ObjectiveManifest` for everything the objective does *not* cover: which
+    inputs are being refined and under which simulation/optimizer settings. A sink that writes a
+    standalone artifact (the refinement report) needs this to describe the run without being handed
+    the :class:`~diffBloch.config.schema.ExperimentConfig` directly -- which is what keeps such a sink
+    an ordinary :class:`Logger` rather than a component wired into the app's orchestration.
+
+    Paths, the optimizer name, and the seed-thickness list ride on the dataclass rather than in
+    ``measurements``, which stays flat-scalar for the generic backends -- the same split
+    :class:`ThicknessOptimized` makes for its candidate grid.
+    """
+
+    channel: ClassVar[str] = "experiment"
+    name: str
+    structure: str
+    experimental_data: str
+    optimizer: str
+    seed_thicknesses: tuple[float, ...]
+    integration_semiangle: float
+    rocking_curve_sampling: int
+    dsg: float
+    rsg: float
+    solve_g_max: float
+    sg_max: float
+    absorption: bool
+    steps: int
+    learning_rate: float
+
+    @property
+    def step(self) -> int | None:
+        return None
+
+    @property
+    def measurements(self) -> Mapping[str, float]:
+        return {
+            "integration_semiangle": self.integration_semiangle,
+            "rocking_curve_sampling": float(self.rocking_curve_sampling),
+            "dsg": self.dsg,
+            "rsg": self.rsg,
+            # Scoped per the SOLVE/SCORED/support rule: a bare g_max has no owning object here.
+            "solve_g_max": self.solve_g_max,
+            "sg_max": self.sg_max,
+            "absorption": float(self.absorption),
+            "steps": float(self.steps),
+            "learning_rate": self.learning_rate,
+        }
+
+
+@dataclass(frozen=True)
+class RefinedRotationMetrics:
+    """One rotation's wR2/R_obs under the *final refined* model, emitted after the loop.
+
+    Distinct from :class:`RefinementOrientationStep`, which is a per-epoch training diagnostic: this
+    is the settled result, scored once on the best model by the *reporting* engine, so it covers
+    every rotation including the held-out ones (``is_validation`` marks those). The refinement loop
+    cannot emit it -- the loop only ever sees the training engine -- so the app boundary emits it
+    once the run has finished.
+    """
+
+    channel: ClassVar[str] = "refined rotation"
+    rotation_index: int
+    wr2: float
+    r_obs: float
+    n_matched: int
+    is_validation: bool
+
+    @property
+    def step(self) -> int | None:
+        return self.rotation_index
+
+    @property
+    def measurements(self) -> Mapping[str, float]:
+        return {
+            "wr2": self.wr2,
+            "r_obs": self.r_obs,
+            "n_matched": float(self.n_matched),
+            "is_validation": float(self.is_validation),
+        }
+
+
+@dataclass(frozen=True)
+class ThicknessProfile:
+    """The trained apparent-thickness curve, sampled at every rotation's tilt angle.
+
+    Emitted once after refinement when a thickness component was composed. The whole curve rides on
+    the dataclass as parallel tuples (one entry per rotation, in plan order) rather than as ~100
+    separate events or ~300 flat measurement keys -- the shape :class:`ThicknessOptimized` already
+    uses for its candidate grid. ``measurements`` carries only the scalar summary.
+    """
+
+    channel: ClassVar[str] = "thickness_profile"
+    form: str
+    min_thickness: float
+    max_thickness: float
+    rotation_indices: tuple[int, ...]
+    alphas: tuple[float, ...]
+    thicknesses: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        lengths = {len(self.rotation_indices), len(self.alphas), len(self.thicknesses)}
+        if len(lengths) != 1:
+            raise ValueError("thickness profile columns must have equal length")
+
+    @property
+    def step(self) -> int | None:
+        return None
+
+    @property
+    def measurements(self) -> Mapping[str, float]:
+        return {
+            "n_rotations": float(len(self.rotation_indices)),
+            "min_thickness": self.min_thickness,
+            "max_thickness": self.max_thickness,
+        }
+
+
+@dataclass(frozen=True)
+class RefinementOutputsWritten:
+    """The refined artifacts are on disk -- the run's terminal event.
+
+    This is what lets a report be a plain :class:`Logger` despite having to be written exactly once,
+    after everything else, without adding a ``close``/``finalize`` method to the protocol: a sink that
+    must finish at the end simply acts on this event. Putting the lifecycle in the stream keeps it
+    observable (a :class:`RecordingLogger` shows it) instead of implicit in a call order.
+
+    ``structure`` is the path to the written ``refined_structure.cif``. A sink reads it back rather
+    than being handed parsed values, so anything it reports about the structure is byte-consistent
+    with the committed file by construction.
+    """
+
+    channel: ClassVar[str] = "outputs"
+    structure: str
+    artifacts: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "artifacts", MappingProxyType(dict(self.artifacts)))
+
+    @property
+    def step(self) -> int | None:
+        return None
+
+    @property
+    def measurements(self) -> Mapping[str, float]:
+        return {"n_artifacts": float(len(self.artifacts))}
+
+
+@dataclass(frozen=True)
 class ObjectiveTerm:
     """One declared soft-penalty term: the objective name it reports under and its weight."""
 
@@ -695,6 +848,15 @@ class RefinementCompleted:
     best_step: int
     best_loss: float
     selection: Literal["training", "validation"] = "training"
+    # The reflection counts the best model was scored over, on the *training* engine -- the same set
+    # the per-step means range over. Carried here rather than as a separate event because they are
+    # facts about this completed run, and the summary is the one place they belong.
+    reflection_counts: Mapping[str, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "reflection_counts", MappingProxyType(dict(self.reflection_counts))
+        )
 
     @property
     def step(self) -> int | None:
@@ -705,11 +867,13 @@ class RefinementCompleted:
         best_key = (
             "best_validation_loss" if self.selection == "validation" else "best_training_loss"
         )
-        return {
+        values = {
             "n_steps": float(self.n_steps),
             "best_step": float(self.best_step),
             best_key: self.best_loss,
         }
+        values.update({name: float(count) for name, count in self.reflection_counts.items()})
+        return values
 
 
 class NullLogger:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -434,7 +434,11 @@ def test_run_refine_delegates_and_reports(
 
     assert rc == 0
     assert captured["dir"] == "/some/experiment"
-    assert isinstance(captured["logger"], ConsoleLogger)  # console on by default (no --quiet)
+    # The refine path fans out to the console and to the summary sink that writes
+    # refinement_report.txt -- composed here, not inside refine_experiment.
+    logger = captured["logger"]
+    assert isinstance(logger, MultiLogger)
+    assert [type(s).__name__ for s in logger.loggers] == ["ConsoleLogger", "SummaryLogger"]
     out = capsys.readouterr().out
     assert "REFINEMENT COMPLETE" in out
     assert _summary_row(out, "Best epoch", "2")

--- a/tests/unit/test_program_refine.py
+++ b/tests/unit/test_program_refine.py
@@ -4,26 +4,21 @@ from dataclasses import replace
 from pathlib import Path
 
 import numpy as np
-import pytest
 import torch
 
-from diffBloch.app.program import _write_refinement_outputs, _write_refinement_report
+from diffBloch.app.program import _write_refinement_outputs
 from diffBloch.config.manifest import read_refinement_lock
 from diffBloch.config.schema import ExperimentConfig
 from diffBloch.core.products import PatternBatch
 from diffBloch.engine import (
-    ApparentThicknessNN,
     ModelRefinementResult,
     StructureFactorGrid,
-    ThicknessBounds,
     build_refinement_model,
 )
 from diffBloch.io import read_structure
 from diffBloch.observability import ObjectiveManifest, ObjectiveTerm, RefinementStep
 from diffBloch.preprocess import RefinementSetup, build_orientation_plans
 from diffBloch.preprocess.plan import CandidatePlan, Plan
-from diffBloch.preprocess.scoring import build_engine
-from diffBloch.specs import IntegrationGeometry
 
 _MINIMAL_CIF = """data_q
 _cell_length_a 5
@@ -190,179 +185,3 @@ def _built_plan_with_two_rotations(cell: np.ndarray) -> Plan:
     )
     seed = Plan(structure_factor_grid=grid, orientations=candidates)
     return build_orientation_plans()(seed)
-
-
-def test_write_refinement_report_without_a_thickness_nn(tmp_path: Path) -> None:
-    cfg, refinement, result = _refinement_result_for(tmp_path)
-    _write_refinement_outputs(tmp_path, cfg, refinement, result)
-    plan = _built_plan_matching(np.eye(3, dtype=np.float64) * 5.0)
-    engine = build_engine(plan, refinement)
-
-    report_path = _write_refinement_report(
-        tmp_path,
-        cfg,
-        IntegrationGeometry(semiangle=1.0),
-        engine,
-        result,
-        elapsed_seconds=12.5,
-    )
-
-    assert report_path == tmp_path / "refinement_report.txt"
-    text = report_path.read_text()
-    assert "Simulation / refinement parameters" in text
-    assert "Crystallographic parameters" in text
-    assert "Per-rotation wR2 / R_obs" in text
-    assert "Thickness NN" in text
-    assert "enabled: no" in text
-    assert "atom_site" in text
-    assert "C1" in text and "O1" in text  # the CIF's own atom labels came through
-    assert "12.5" in text  # elapsed time was reported
-    # Every composed objective term reports raw, weight, and contribution separately, so a
-    # zero-weighted term still shows a live scientific raw value.
-    # The declared composition is stated up front, including the terms that are absent.
-    assert "Objective terms (declared)" in text
-    assert "penalties  : bond_length (weight 3)" in text
-    assert "constraints: none" in text
-    assert "Objective components (best epoch)" in text
-    assert "bond_length" in text
-    assert "0.05" in text and "0.15" in text
-    assert "objective total = 0.35" in text
-    # Every reported mean states the rotation count it was averaged over -- a mean over fewer
-    # rotations is a different quantity, not a better one.
-    assert "10.00 [3/4]" in text  # best-epoch wR2 (%), 3 of 4 rotations finite
-    assert "5.00 [2/4]" in text  # best-epoch R_obs (%), 2 of 4
-    assert "mean wR2   = " in text and "[1/1]" in text  # per-rotation table mean + denominator
-
-
-def test_write_refinement_report_renders_an_unevaluated_mean_as_na(tmp_path: Path) -> None:
-    """One spelling for "nothing was evaluated" across every mean the report prints."""
-    cfg, refinement, result = _refinement_result_for(tmp_path)
-    (event,) = result.history
-    result = replace(
-        result,
-        history=(
-            replace(
-                event,
-                wr2=float("nan"),
-                r_obs=float("nan"),
-                n_wr2_evaluated=0,
-                n_r_obs_evaluated=0,
-            ),
-        ),
-    )
-    _write_refinement_outputs(tmp_path, cfg, refinement, result)
-    engine = build_engine(_built_plan_matching(np.eye(3, dtype=np.float64) * 5.0), refinement)
-
-    text = _write_refinement_report(
-        tmp_path,
-        cfg,
-        IntegrationGeometry(semiangle=1.0),
-        engine,
-        result,
-        elapsed_seconds=1.0,
-    ).read_text()
-
-    assert "n/a [0/4]" in text  # the best-epoch wR2 and R_obs rows
-    assert "nan [" not in text  # ...spelled the same way the per-rotation means already were
-
-
-def test_write_refinement_report_with_a_thickness_nn(tmp_path: Path) -> None:
-    cfg, refinement, result = _refinement_result_for(tmp_path)
-    _write_refinement_outputs(tmp_path, cfg, refinement, result)
-    plan = _built_plan_matching(np.eye(3, dtype=np.float64) * 5.0)
-    engine = build_engine(plan, refinement)
-
-    thickness_nn = ApparentThicknessNN(
-        bounds=ThicknessBounds(min_angstrom=100.0, max_angstrom=1000.0),
-        normalized_alphas=(0.0,),
-    )
-    dtype = refinement.params.asu_positions.dtype
-    device = refinement.params.asu_positions.device
-    model = build_refinement_model(
-        initial=refinement.params,
-        components=(thickness_nn,),
-        component_params={
-            thickness_nn.key: thickness_nn.initial_params(dtype=dtype, device=device)
-        },
-    )
-    result_with_nn = replace(result, model=model, best_model=model)
-
-    report_path = _write_refinement_report(
-        tmp_path,
-        cfg,
-        IntegrationGeometry(semiangle=1.0),
-        engine,
-        result_with_nn,
-        elapsed_seconds=1.0,
-        thickness_nn=thickness_nn,
-        raw_alphas=np.array([12.5], dtype=np.float64),
-    )
-
-    text = report_path.read_text()
-    assert "enabled: yes" in text
-    assert "alpha (degrees)" in text
-
-    pytest.importorskip("matplotlib", reason="optional diffBloch[plot] extra")
-    assert (tmp_path / "thickness_nn_shape.png").is_file()
-    assert "plot: thickness_nn_shape.png" in text
-
-
-def test_write_refinement_report_adds_a_validation_section_when_split_is_on(
-    tmp_path: Path,
-) -> None:
-    cfg, refinement, result = _refinement_result_for(tmp_path)
-    _write_refinement_outputs(tmp_path, cfg, refinement, result)
-    plan = _built_plan_with_two_rotations(np.eye(3, dtype=np.float64) * 5.0)
-    engine = build_engine(plan, refinement)
-
-    report_path = _write_refinement_report(
-        tmp_path,
-        cfg,
-        IntegrationGeometry(semiangle=1.0),
-        engine,
-        result,
-        elapsed_seconds=1.0,
-        validation_rotation_indices=frozenset({1}),
-    )
-
-    text = report_path.read_text()
-    assert "Validation set (held out from the refinement objective)" in text
-    assert "n_rotations = 1" in text
-
-
-def test_write_refinement_report_omits_the_validation_section_when_split_is_off(
-    tmp_path: Path,
-) -> None:
-    cfg, refinement, result = _refinement_result_for(tmp_path)
-    _write_refinement_outputs(tmp_path, cfg, refinement, result)
-    plan = _built_plan_matching(np.eye(3, dtype=np.float64) * 5.0)
-    engine = build_engine(plan, refinement)
-
-    report_path = _write_refinement_report(
-        tmp_path, cfg, IntegrationGeometry(semiangle=1.0), engine, result, elapsed_seconds=1.0
-    )
-
-    assert "Validation set" not in report_path.read_text()
-
-
-def test_write_refinement_outputs_writes_a_refinement_lock_from_a_relative_root(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Regression: ``root`` is whatever the CLI's ``experiment_dir`` arg was -- often relative.
-
-    ``structure_path``/``params_path`` are ``.resolve()``d (absolute); passing the unresolved
-    (possibly relative) ``root`` straight to ``artifact_hash_for`` mismatched an absolute path
-    against a relative base and raised ``ValueError: ... is not in the subpath of ...`` the moment
-    a real run used a relative experiment directory (every CLI invocation does).
-    """
-    monkeypatch.chdir(tmp_path)
-    relative_root = Path(".")
-    cfg, refinement, result = _refinement_result_for(relative_root)
-    (relative_root / "reproducibility").mkdir()
-    (relative_root / "reproducibility" / "plan.lock").write_text("fake-plan-lock-bytes")
-
-    written = _write_refinement_outputs(relative_root, cfg, refinement, result)
-
-    assert "refinement_lock" in written.artifacts
-    lock_path = relative_root / "reproducibility" / "refinement.lock"
-    assert read_refinement_lock(lock_path).refined_structure.path == "refined_structure.cif"

--- a/tests/unit/test_summary_logger.py
+++ b/tests/unit/test_summary_logger.py
@@ -1,0 +1,269 @@
+"""``SummaryLogger``: the run summary built from the event stream, not from orchestration state.
+
+Every test here drives the sink the way a real run does -- by reporting events at it -- so these
+also pin the contract that the events carry everything the summary needs. Reading the refined CIF
+back off disk is the one deliberate exception, and ``RefinementOutputsWritten`` is what points at it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from diffBloch.app.loggers.summary import SummaryLogger, ascii_table
+from diffBloch.observability import (
+    ExperimentDeclared,
+    ObjectiveManifest,
+    ObjectiveTerm,
+    RefinedRotationMetrics,
+    RefinementCompleted,
+    RefinementOutputsWritten,
+    RefinementStep,
+    RotationScored,
+    ThicknessProfile,
+)
+
+_CIF = """data_q
+_cell_length_a 5.0
+_cell_length_b 5.0
+_cell_length_c 5.0
+_cell_angle_alpha 90.0
+_cell_angle_beta 90.0
+_cell_angle_gamma 90.0
+_space_group_name_H-M_alt 'P 1'
+_space_group_IT_number 1
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_atom_site_U_iso_or_equiv
+C1 C 0.10 0.20 0.30 0.5 0.01
+O1 O 0.40 0.50 0.60 0.5 0.02
+"""
+
+
+def _structure(tmp_path: Path) -> Path:
+    path = tmp_path / "refined_structure.cif"
+    path.write_text(_CIF)
+    return path
+
+
+def _experiment() -> ExperimentDeclared:
+    return ExperimentDeclared(
+        name="q",
+        structure="q.cif",
+        experimental_data="q.cif_pets",
+        optimizer="lbfgs",
+        seed_thicknesses=(820.0,),
+        integration_semiangle=1.0,
+        rocking_curve_sampling=42,
+        dsg=0.0015,
+        rsg=0.9,
+        solve_g_max=2.25,
+        sg_max=0.01,
+        absorption=False,
+        steps=3,
+        learning_rate=0.001,
+    )
+
+
+def _step(**overrides: object) -> RefinementStep:
+    fields: dict[str, object] = {
+        "iteration": 0,
+        "loss": 0.2,
+        "wr2": 0.1,
+        "r_obs": 0.05,
+        "diff_loss": 0.2,
+        "objective_total": 0.35,
+        "n_rotations": 4,
+        "n_wr2_evaluated": 3,
+        "n_r_obs_evaluated": 2,
+        "components": {
+            "diffraction": {"raw": 0.2, "weight": 1.0, "contribution": 0.2},
+            "bond_length": {"raw": 0.05, "weight": 3.0, "contribution": 0.15},
+        },
+    }
+    fields.update(overrides)
+    return RefinementStep(**fields)  # type: ignore[arg-type]
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    steps: tuple[RefinementStep, ...] = (),
+    rotations: tuple[RefinedRotationMetrics, ...] = (),
+    profile: ThicknessProfile | None = None,
+    manifest: ObjectiveManifest | None = None,
+    completed: RefinementCompleted | None = None,
+) -> str:
+    """Drive a SummaryLogger through one run's worth of events and return the written text."""
+    structure = _structure(tmp_path)
+    logger = SummaryLogger(tmp_path / "refinement_report.txt")
+    logger.report(_experiment())
+    logger.report(
+        manifest
+        if manifest is not None
+        else ObjectiveManifest(penalties=(ObjectiveTerm(name="bond_length", weight=3.0),))
+    )
+    for step in steps or (_step(),):
+        logger.report(step)
+    logger.report(
+        completed
+        if completed is not None
+        else RefinementCompleted(
+            n_steps=1,
+            best_step=0,
+            best_loss=0.2,
+            reflection_counts={"matched": 12, "matched_i_gt_3sigma": 8},
+        )
+    )
+    for rotation in rotations:
+        logger.report(rotation)
+    if profile is not None:
+        logger.report(profile)
+    logger.report(RefinementOutputsWritten(structure=str(structure)))
+    return (tmp_path / "refinement_report.txt").read_text()
+
+
+def _rotation(
+    index: int, *, wr2: float = 0.2, is_validation: bool = False
+) -> RefinedRotationMetrics:
+    return RefinedRotationMetrics(
+        rotation_index=index, wr2=wr2, r_obs=0.15, n_matched=5, is_validation=is_validation
+    )
+
+
+def test_summary_is_written_only_on_the_terminal_event(tmp_path: Path) -> None:
+    """No committed structure means no summary -- the sink does not write a half-finished run."""
+    logger = SummaryLogger(tmp_path / "refinement_report.txt")
+    logger.report(_experiment())
+    logger.report(_step())
+    assert not (tmp_path / "refinement_report.txt").exists()
+
+    logger.report(RefinementOutputsWritten(structure=str(_structure(tmp_path))))
+    assert (tmp_path / "refinement_report.txt").is_file()
+
+
+def test_summary_renders_every_section_from_events_alone(tmp_path: Path) -> None:
+    text = _run(tmp_path, rotations=(_rotation(0),))
+
+    assert "Simulation / refinement parameters" in text
+    assert "Crystallographic parameters" in text
+    assert "Per-rotation wR2 / R_obs" in text
+    assert "Thickness NN" in text
+    assert "enabled: no" in text
+    assert "C1" in text and "O1" in text  # atom labels read back out of the committed CIF
+    # The declared composition is stated up front, including the categories that are empty.
+    assert "penalties  : bond_length (weight 3)" in text
+    assert "constraints: none" in text
+    # Every composed term reports raw, weight and contribution separately.
+    assert "objective total = 0.35" in text
+    # Every mean states the rotation count it was averaged over.
+    assert "10.00 [3/4]" in text  # best-epoch wR2 (%), 3 of 4 rotations finite
+    assert "5.00 [2/4]" in text  # best-epoch R_obs (%), 2 of 4
+    assert "mean wR2   = 0.200000 [1/1]" in text
+    assert "HKLs (Observed/total)" in text and "8 / 12" in text
+
+
+def test_summary_selects_the_best_epoch_not_the_last(tmp_path: Path) -> None:
+    """The reported epoch is the one RefinementCompleted names, wherever it sits in the stream."""
+    text = _run(
+        tmp_path,
+        steps=(
+            _step(iteration=0, wr2=0.9, objective_total=9.0),
+            _step(iteration=1, wr2=0.1, objective_total=1.0),
+            _step(iteration=2, wr2=0.5, objective_total=5.0),
+        ),
+        completed=RefinementCompleted(n_steps=3, best_step=1, best_loss=1.0),
+        rotations=(_rotation(0),),
+    )
+
+    assert "objective total = 1" in text
+    assert "10.00 [3/4]" in text  # the best epoch's wR2, not epoch 2's
+
+
+def test_summary_renders_an_unevaluated_mean_as_na(tmp_path: Path) -> None:
+    """One spelling for "nothing was evaluated" across every mean the summary prints."""
+    text = _run(
+        tmp_path,
+        steps=(
+            _step(wr2=float("nan"), r_obs=float("nan"), n_wr2_evaluated=0, n_r_obs_evaluated=0),
+        ),
+        rotations=(_rotation(0, wr2=float("nan")),),
+    )
+
+    assert "n/a [0/4]" in text
+    assert "nan [" not in text
+
+
+def test_summary_adds_a_validation_section_only_when_rotations_are_held_out(
+    tmp_path: Path,
+) -> None:
+    held_out = _run(
+        tmp_path,
+        rotations=(_rotation(0), _rotation(1, is_validation=True)),
+    )
+    assert "Validation set (held out from the refinement objective)" in held_out
+    assert "n_rotations = 1" in held_out
+    assert "mean wR2   = 0.200000 [2/2]" in held_out  # the full table still covers both
+
+    none_held_out = _run(tmp_path, rotations=(_rotation(0), _rotation(1)))
+    assert "Validation set" not in none_held_out
+
+
+def test_summary_reports_the_thickness_profile_when_one_was_trained(tmp_path: Path) -> None:
+    text = _run(
+        tmp_path,
+        rotations=(_rotation(0),),
+        profile=ThicknessProfile(
+            form="quadratic",
+            min_thickness=100.0,
+            max_thickness=1000.0,
+            rotation_indices=(0,),
+            alphas=(12.5,),
+            thicknesses=(430.25,),
+        ),
+    )
+
+    assert "enabled: yes (quadratic, bounds [100, 1000] A)" in text
+    assert "alpha (degrees)" in text
+    assert "12.5000" in text and "430.25" in text
+
+    pytest.importorskip("matplotlib", reason="optional diffBloch[plot] extra")
+    assert (tmp_path / "thickness_nn_shape.png").is_file()
+    assert "plot: thickness_nn_shape.png" in text
+
+
+def test_summary_degrades_without_the_declaration_events(tmp_path: Path) -> None:
+    """A sink attached mid-run says so rather than inventing values or raising."""
+    logger = SummaryLogger(tmp_path / "refinement_report.txt")
+    logger.report(RotationScored(index=0, r_obs=0.1, n_observed=5, n_beams=9))
+    logger.report(RefinementOutputsWritten(structure=str(_structure(tmp_path))))
+
+    text = (tmp_path / "refinement_report.txt").read_text()
+    assert "n/a (no recorded experiment declaration)" in text
+    assert "n/a (no recorded objective manifest)" in text
+    assert "n/a (no recorded objective components)" in text
+
+
+def test_thickness_profile_rejects_ragged_columns() -> None:
+    with pytest.raises(ValueError, match="equal length"):
+        ThicknessProfile(
+            form="quadratic",
+            min_thickness=100.0,
+            max_thickness=1000.0,
+            rotation_indices=(0, 1),
+            alphas=(12.5,),
+            thicknesses=(430.25,),
+        )
+
+
+def test_ascii_table_widens_a_column_to_its_content() -> None:
+    """Widths are measured, so a long cell never overflows into the next column."""
+    table = ascii_table(["A", "B"], [["a-very-long-cell", "1"]])
+    header, rule, row = table.splitlines()
+    assert len(header) == len(rule) == len(row)


### PR DESCRIPTION
Stacked on #72 (`iainland/logging-extended`) — review that one first; this branch only adds the two commits below.

`refinement_report.txt` was written by `app/program.py` out of orchestration state: the config, the reporting engine, the result object, and four keyword arguments. Nothing else could produce it, nobody could opt out of it, and half of what it showed reached no other backend — W&B and Comet had never seen the run's hyperparameters or its settled per-rotation scores.

It is now `SummaryLogger` (`app/loggers/summary.py`): an ordinary one-method sink composed in the CLI beside the console and CSV ones. Named for what it produces rather than how it is fed — `ReportLogger.report()` would have read as a tautology against the `Logger` protocol's own method.

## The events that were missing

Five events carry what the summary needs and previously had no emitter:

| Event | Carries |
|---|---|
| `ExperimentDeclared` | the run's identity and result-determining knobs |
| `RefinedRotationMetrics` | per-rotation scores under the final model, including held-out rotations the training engine never sees |
| `ThicknessProfile` | the trained apparent-thickness curve |
| `RefinementOutputsWritten` | the terminal event, carrying the committed CIF path |
| `RefinementCompleted` | extended with the reflection counts it already computed |

The test each had to pass was whether *every* backend wants it, not just the summary — otherwise it should have been a constructor argument rather than an event. All five pass. What could be derived was: the sink times itself off the stream rather than being told an elapsed time.

## The protocol did not change

Three pressure points, all absorbed by the existing design:

- **Non-numeric payloads.** `measurements` stays `Mapping[str, float]`; strings and tuples ride on the concrete dataclass, exactly as `ThicknessOptimized.candidate_thicknesses` already does for its candidate grid.
- **Write-once-at-the-end.** Rather than adding `close()`/`finalize()` to `Logger`, the run emits a terminal `RefinementOutputsWritten` and the sink acts on it. That keeps `Logger` a single method and puts the lifecycle in the stream where a `RecordingLogger` can see it, instead of implicit in a call order.
- **Buffering.** A sink that accumulates is what `RecordingLogger` already is.

## Where construction lives

Not in the orchestrator. `cfg.to_declaration()` joins `to_policy()`/`to_absorption()` on the config, and sampling the trained curve is `ApparentThicknessNN.profile()` — the component owns its own behaviour, and a sink must never run the forward model. What remains in `program.py` is ~15 lines of emission, which is irreducible: something has to compute the settled results and announce them, and only the orchestrator holds the reporting engine and the split.

One trade-off worth flagging for review: every other `to_*` on the config projects onto a frozen `specs` value-type, whereas `to_declaration` projects onto an event, and it introduces a `config -> observability` import that did not exist. The import is strictly downward (`observability` imports only stdlib) and the alternatives are worse — `ExperimentDeclared.from_config` would invert the dependency, and burying construction in `summary.py` would deny the event to every other backend. If the blurring of `to_*` is unwelcome, a module-level `declaration_for(cfg, integration)` keeps the same home off the model's method surface.

Reading the refined CIF back off disk stays, deliberately: `RefinementOutputsWritten` points at the file, so the reported cell and atom-site tables are byte-consistent with what was committed rather than a second rendering of the same numbers.

## Console fixes the refactor exposed

Running it surfaced three defects, fixed in the second commit:

- `ExperimentDeclared` and `RefinedRotationMetrics` had no `ConsoleLogger` branch and fell through to the generic measurements formatter — an unreadable `experiment integration_semiangle=1 rocking_curve_sampling=42 ...` dump, and one `refined rotation[0] wr2=0.184523 ... is_validation=0` line per rotation. Both now render as prose:

```
Experiment │ quartz-checkpoint │ quartz.cif + quartz_exp_data.cif_pets
Experiment │ lbfgs lr=0.001 │ 40 epoch(s) │ g_max(solve)=2.25 sg_max=0.01 │ absorption off
  rotation   0 │ wR2 0.184523 │ R_obs 0.199981 │ 23 matched
  rotation   2 │ wR2 0.152995 │ R_obs 0.096914 │ 24 matched │ validation
```

The per-rotation stream is on by default. Unlike the per-epoch verbose stream it fires once, and every rotation's settled score is a result worth reading rather than a diagnostic. It is gated at the sink rather than the emitter, because the event must always be emitted.

- **Pre-existing:** the progress bar returned the cursor with `\r` but never erased, so a shorter line left the tail of a longer one behind and the orientation fit rendered `wR2 0.0574270.039671` — two numbers with no separator, one of them stale. Now clears to end of line.

## Verification

`ruff check`, `mypy` (67 files), `pytest -q` (640 passed, 5 skipped). Verified end to end with `uv run diffbloch run refine` on the quartz example: every section, every denominator, and the thickness table render as before, and the per-rotation console stream matches the summary's table.

The old `_write_refinement_report` tests are replaced by `tests/unit/test_summary_logger.py`, which drives the sink with events only — so they also pin the contract that the events carry everything the summary needs.

## Not in this branch

The `rich`/`TuiLogger` step. With the summary rendered from events, one renderer can drive both a live terminal display and the written file (`Console(record=True).export_text()`), which would retire three hand-rolled renderers — the progress bar, the summary box, and `ascii_table`. The bug above is a fair argument for it. The decision to make first is that `ConsoleLogger` writes through stdlib `logging`, which fights with a Rich `Live` display.

## Found while testing: the shipped `quartz-checkpoint` example no longer reuses its checkpoint

Pre-existing on `main`, not introduced here, but worth recording because it is user-visible and the example's own README asserts the opposite ("REUSES the checkpoint and scores in seconds — no ~6–16 min fit").

Running `uv run diffbloch run refine examples/experiments/quartz-checkpoint` recomputes the whole preprocess and then **overwrites the committed `plan.npz` / `plan.lock` in place**. Diffing the regenerated lock against the committed one shows all three reuse-gate axes disagree:

- `experiment_lock_sha256` — the committed `plan.lock` records a different input hash than the sibling `experiment.lock` file currently has, so the two committed artifacts are out of sync with each other;
- `config_digest` — differs;
- `recipe` — the committed lock's recipe is `select_beams` → `build_orientation_plans` (no params) → `integrate_rocking_curve` → …, whereas the current `_recipe_steps` produces `build_orientation_plans(rocking=…, coupling=…)` → …. The checkpoint was frozen against a recipe the code no longer composes.

This branch changes none of those inputs: `git diff main -- src/diffBloch/config/manifest.py` is empty, and `_recipe_steps` is untouched, so the staleness predates it.

Two consequences worth separating. The reuse *gate* behaved correctly — it refused a checkpoint that genuinely no longer matches, which is the conservative behaviour the design intends. What is wrong is that a committed example ships a checkpoint that can never be reused, and that a run silently rewrites a committed artifact rather than writing beside it or refusing. Neither belongs in this PR; both want their own fix (regenerate and re-freeze the example, and decide whether a non-`--refresh` run should ever overwrite a committed checkpoint).
