### PR TITLE
TUI: a view for the convergence sweep, and four fixes to --tui

### DIFF
--- a/src/diffBloch/app/cli.py
+++ b/src/diffBloch/app/cli.py
@@ -447,11 +447,16 @@ def _release_sinks(logger: Logger) -> None:
     end any run early -- so the boundary that built the sinks releases them in a ``finally``, rather
     than every stream having to end in exactly the right event.
     """
-    sinks = logger.loggers if isinstance(logger, MultiLogger) else (logger,)
-    for sink in sinks:
-        release = getattr(sink, "close", None)
-        if callable(release):
-            release()
+    if isinstance(logger, MultiLogger):
+        # Recurse: fan-outs nest. `run refine --tui` composes _build_logger's own MultiLogger
+        # (console + csv) inside a second one alongside the summary sink, so walking a single level
+        # would miss the display on exactly the path most likely to be using it.
+        for sink in logger.loggers:
+            _release_sinks(sink)
+        return
+    release = getattr(logger, "close", None)
+    if callable(release):
+        release()
 
 
 def _build_logger(

--- a/src/diffBloch/app/cli.py
+++ b/src/diffBloch/app/cli.py
@@ -237,8 +237,11 @@ def main(argv: list[str] | None = None) -> int:
             logging.basicConfig(
                 level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S"
             )
-        logger = _build_logger(console=not args.quiet, csv=args.csv, tui=args.tui)
+        # Built inside the try so a bad sink choice (e.g. --tui without the extra) is reported as a
+        # concise error like any other user mistake; NULL_LOGGER keeps the finally safe if it fails.
+        logger: Logger = NULL_LOGGER
         try:
+            logger = _build_logger(console=not args.quiet, csv=args.csv, tui=args.tui)
             result = run_experiment(
                 args.experiment_directory,
                 logger=logger,
@@ -266,14 +269,15 @@ def main(argv: list[str] | None = None) -> int:
             logging.basicConfig(
                 level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S"
             )
-        progress_logger = _build_logger(console=not args.quiet, csv=args.csv, tui=args.tui)
         summary_logger = RecordingLogger()
-        logger = (
-            summary_logger
-            if progress_logger is NULL_LOGGER
-            else MultiLogger((progress_logger, summary_logger))
-        )
+        logger = summary_logger
         try:
+            progress_logger = _build_logger(console=not args.quiet, csv=args.csv, tui=args.tui)
+            logger = (
+                summary_logger
+                if progress_logger is NULL_LOGGER
+                else MultiLogger((progress_logger, summary_logger))
+            )
             plan = preprocess_experiment(
                 args.experiment_directory,
                 logger=logger,
@@ -337,13 +341,14 @@ def main(argv: list[str] | None = None) -> int:
         # console/CSV ones rather than by refine_experiment: an API caller composes it (or not) for
         # themselves instead of having a file appear as a side effect of refining.
         report_path = (Path(args.experiment_directory) / "refinement_report.txt").resolve()
-        refine_logger = MultiLogger(
-            (
-                _build_logger(console=not args.quiet, csv=args.csv, tui=args.tui),
-                SummaryLogger(report_path),
-            )
-        )
+        refine_logger: Logger = NULL_LOGGER
         try:
+            refine_logger = MultiLogger(
+                (
+                    _build_logger(console=not args.quiet, csv=args.csv, tui=args.tui),
+                    SummaryLogger(report_path),
+                )
+            )
             refined = refine_experiment(
                 args.experiment_directory,
                 logger=refine_logger,
@@ -397,8 +402,9 @@ def main(argv: list[str] | None = None) -> int:
         logging.basicConfig(
             level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S"
         )
-        logger = _build_logger(console=not args.quiet, csv=args.csv, tui=args.tui)
+        logger = NULL_LOGGER
         try:
+            logger = _build_logger(console=not args.quiet, csv=args.csv, tui=args.tui)
             settled = converge_experiment(
                 args.experiment_directory,
                 logger=logger,

--- a/src/diffBloch/app/cli.py
+++ b/src/diffBloch/app/cli.py
@@ -194,6 +194,20 @@ def main(argv: list[str] | None = None) -> int:
         default=1,
         help="use the first N orientations for convergence testing (default: 1)",
     )
+    p_converge.add_argument(
+        "--quiet",
+        action="store_true",
+        help="silence the per-trial observation stream (the settled result still prints)",
+    )
+    p_converge.add_argument(
+        "--csv", metavar="PATH", help="append per-trial observations to a long-format CSV log"
+    )
+    p_converge.add_argument(
+        "--tui",
+        action="store_true",
+        help="render the sweep as a live terminal dashboard instead of the scrolling console log "
+        "(requires the 'diffBloch[tui]' extra)",
+    )
     p_pack = run_sub.add_parser("pack", help="Export a run directory for transfer/archive")
     p_pack.add_argument("run_directory", help="Path to canonical run artifact directory")
     p_pack.add_argument(
@@ -223,10 +237,11 @@ def main(argv: list[str] | None = None) -> int:
             logging.basicConfig(
                 level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S"
             )
+        logger = _build_logger(console=not args.quiet, csv=args.csv, tui=args.tui)
         try:
             result = run_experiment(
                 args.experiment_directory,
-                logger=_build_logger(console=not args.quiet, csv=args.csv, tui=args.tui),
+                logger=logger,
                 checkpoint=not args.no_checkpoint,
                 refresh=args.refresh,
                 device=args.device,
@@ -241,6 +256,8 @@ def main(argv: list[str] | None = None) -> int:
                 raise
             print(f"error: {exc}", file=sys.stderr)
             return 1
+        finally:
+            _release_sinks(logger)
         print(f"evaluated {result.n_evaluated} rotations; mean R_obs = {result.mean_r_obs:.4f}")
         return 0
 
@@ -249,14 +266,14 @@ def main(argv: list[str] | None = None) -> int:
             logging.basicConfig(
                 level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S"
             )
+        progress_logger = _build_logger(console=not args.quiet, csv=args.csv, tui=args.tui)
+        summary_logger = RecordingLogger()
+        logger = (
+            summary_logger
+            if progress_logger is NULL_LOGGER
+            else MultiLogger((progress_logger, summary_logger))
+        )
         try:
-            progress_logger = _build_logger(console=not args.quiet, csv=args.csv, tui=args.tui)
-            summary_logger = RecordingLogger()
-            logger: Logger = (
-                summary_logger
-                if progress_logger is NULL_LOGGER
-                else MultiLogger((progress_logger, summary_logger))
-            )
             plan = preprocess_experiment(
                 args.experiment_directory,
                 logger=logger,
@@ -274,6 +291,8 @@ def main(argv: list[str] | None = None) -> int:
                 raise
             print(f"error: {exc}", file=sys.stderr)
             return 1
+        finally:
+            _release_sinks(logger)
         print()
         built = cast(tuple[OrientationPlanLike, ...], plan.orientations)
         total_hkl = sum(int(op.pattern.hkl.shape[0]) for op in built)
@@ -314,18 +333,20 @@ def main(argv: list[str] | None = None) -> int:
             logging.basicConfig(
                 level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S"
             )
-        try:
-            # The written summary is one more sink on the run's event stream, chosen here beside
-            # the console/CSV ones rather than by refine_experiment: an API caller composes it (or
-            # not) for themselves instead of having a file appear as a side effect of refining.
-            report_path = (Path(args.experiment_directory) / "refinement_report.txt").resolve()
-            refine_sinks: tuple[Logger, ...] = (
+        # The written summary is one more sink on the run's event stream, chosen here beside the
+        # console/CSV ones rather than by refine_experiment: an API caller composes it (or not) for
+        # themselves instead of having a file appear as a side effect of refining.
+        report_path = (Path(args.experiment_directory) / "refinement_report.txt").resolve()
+        refine_logger = MultiLogger(
+            (
                 _build_logger(console=not args.quiet, csv=args.csv, tui=args.tui),
                 SummaryLogger(report_path),
             )
+        )
+        try:
             refined = refine_experiment(
                 args.experiment_directory,
-                logger=MultiLogger(refine_sinks),
+                logger=refine_logger,
                 checkpoint=not args.no_checkpoint,
                 refresh=args.refresh,
                 device=args.device,
@@ -343,6 +364,8 @@ def main(argv: list[str] | None = None) -> int:
                 raise
             print(f"error: {exc}", file=sys.stderr)
             return 1
+        finally:
+            _release_sinks(refine_logger)
         best = refined.history[refined.best_step]
         wr2 = "n/a" if best.wr2 is None else f"{best.wr2:.6g}"
         r_obs = "n/a" if best.r_obs is None else f"{best.r_obs:.6g}"
@@ -374,10 +397,11 @@ def main(argv: list[str] | None = None) -> int:
         logging.basicConfig(
             level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S"
         )
+        logger = _build_logger(console=not args.quiet, csv=args.csv, tui=args.tui)
         try:
             settled = converge_experiment(
                 args.experiment_directory,
-                logger=ConsoleLogger(),
+                logger=logger,
                 device=args.device,
                 n_orientations=args.orientations,
             )
@@ -386,6 +410,8 @@ def main(argv: list[str] | None = None) -> int:
                 raise
             print(f"error: {exc}", file=sys.stderr)
             return 1
+        finally:
+            _release_sinks(logger)
         print("========================================")
         print("HYPERPARAMETER OPTIMIZATION RESULT")
         print(f"gmax: {settled.g_max:g}")
@@ -411,6 +437,21 @@ def main(argv: list[str] | None = None) -> int:
 
     parser.print_help()
     return 0
+
+
+def _release_sinks(logger: Logger) -> None:
+    """Let any sink holding a resource give it back, whatever the run did.
+
+    The live display owns the terminal until it is stopped. It stops itself on the refinement run's
+    terminal event, but ``preprocess``/``infer``/``converge`` have no such event and an exception can
+    end any run early -- so the boundary that built the sinks releases them in a ``finally``, rather
+    than every stream having to end in exactly the right event.
+    """
+    sinks = logger.loggers if isinstance(logger, MultiLogger) else (logger,)
+    for sink in sinks:
+        release = getattr(sink, "close", None)
+        if callable(release):
+            release()
 
 
 def _build_logger(

--- a/src/diffBloch/app/loggers/tui.py
+++ b/src/diffBloch/app/loggers/tui.py
@@ -22,6 +22,9 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from diffBloch.observability import (
+    ConvergencePassStarted,
+    ConvergenceSweepStarted,
+    ConvergenceTrial,
     Event,
     ExperimentDeclared,
     ObjectiveManifest,
@@ -83,6 +86,9 @@ class TuiLogger:
     _epochs: list[RefinementStep] = field(default_factory=list, init=False, repr=False)
     _rotations: list[RefinedRotationMetrics] = field(default_factory=list, init=False, repr=False)
     _completed: RefinementCompleted | None = field(default=None, init=False, repr=False)
+    _pass: ConvergencePassStarted | None = field(default=None, init=False, repr=False)
+    _sweep: str = field(default="", init=False, repr=False)
+    _trials: list[ConvergenceTrial] = field(default_factory=list, init=False, repr=False)
     _other: list[tuple[str, int | None, str]] = field(default_factory=list, init=False, repr=False)
 
     def report(self, event: Event) -> None:
@@ -119,6 +125,12 @@ class TuiLogger:
                 self._experiment = event
             case ObjectiveManifest():
                 self._manifest = event
+            case ConvergencePassStarted():
+                self._pass = event
+            case ConvergenceSweepStarted():
+                self._sweep = event.control
+            case ConvergenceTrial():
+                self._trials.append(event)
             case PlanSeeded():
                 self._stages.append(("seed (incoming plan)", event.measurements))
             case PlanStepCompleted():
@@ -172,7 +184,7 @@ class TuiLogger:
         terminal each shrink rather than the last one being pushed off the bottom.
         """
         height = self._console.size.height if self._console is not None else 24
-        on_screen = (self._stages, self._epochs, self._rotations, self._other)
+        on_screen = (self._trials, self._stages, self._epochs, self._rotations, self._other)
         tables = sum(bool(x) for x in on_screen) or 1
         return max(_MIN_WINDOW, (height - _CHROME_ROWS) // tables)
 
@@ -182,6 +194,8 @@ class TuiLogger:
 
         rows = self._window() if window == -1 else window
         blocks: list[Any] = [block for block in (self._header(), self._objective()) if block]
+        if self._trials or self._pass:
+            blocks.append(self._convergence_table(rows))
         if self._stages:
             blocks.append(self._stage_table(rows))
         if self._phase.total:
@@ -221,6 +235,42 @@ class TuiLogger:
         # "none" is rendered, never omitted: an objective composing no restraints is a fact.
         body = f"penalties   {penalties}\nconstraints {constraints}\ncomponents  {components}"
         return Panel(body, title="objective", border_style="magenta")
+
+    def _convergence_table(self, window: int | None) -> Any:
+        """The numerical-convergence sweep: each trial's setting change and what it cost in R.
+
+        A trial is starred once its R-factor falls under the pass threshold -- that is the
+        comparison ``converge_scalar`` actually settles on, so showing the threshold without
+        showing which trial cleared it would leave the reader to do the arithmetic.
+        """
+        from rich.table import Table
+
+        started = self._pass
+        label = "convergence"
+        if started is not None:
+            label += (
+                f"  (pass {started.pass_index}, threshold {started.r_factor_threshold:g}, "
+                f"{started.n_orientations} rotation(s))"
+            )
+        if self._sweep:
+            label += f"  sweeping {self._sweep}"
+        table = Table(title=_titled(label, self._trials, window), title_justify="left")
+        table.add_column("control")
+        for column in ("trial", "from", "to", "R", "compared hkl"):
+            table.add_column(column, justify="right")
+        table.add_column("")
+        for trial in _tail(self._trials, window):
+            settled = started is not None and trial.r_factor < started.r_factor_threshold
+            table.add_row(
+                trial.control,
+                str(trial.trial_index),
+                f"{trial.previous:g}",
+                f"{trial.candidate:g}",
+                f"{trial.r_factor:.6f}",
+                str(trial.n_compared_hkl),
+                "settled" if settled else "",
+            )
+        return table
 
     def _stage_table(self, window: int | None) -> Any:
         from rich.table import Table

--- a/src/diffBloch/app/loggers/tui.py
+++ b/src/diffBloch/app/loggers/tui.py
@@ -16,6 +16,7 @@ are dropped, because an in-place display has no meaning there. Use ``ConsoleLogg
 
 from __future__ import annotations
 
+import importlib.util
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -75,6 +76,22 @@ class TuiLogger:
     """
 
     refresh_per_second: float = 8.0
+
+    def __post_init__(self) -> None:
+        """Refuse at construction if rich is absent, rather than at the first event.
+
+        rich is imported lazily inside the rendering methods, so this class imports fine without it
+        and would otherwise fail on the first event reported -- which for a refinement run is after
+        the preprocess has already been paid for. ``find_spec`` detects absence without importing,
+        keeping the rendering path lazy. ``ValueError`` is what the CLI turns into a concise stderr
+        message rather than a traceback.
+        """
+        if importlib.util.find_spec("rich") is None:
+            raise ValueError(
+                "the live dashboard (--tui) needs 'rich', an optional dependency. Install it with "
+                "`uv sync --extra tui`, or omit --tui for the scrolling console log."
+            )
+
     _live: Any = field(default=None, init=False, repr=False)
     _console: Any = field(default=None, init=False, repr=False)
     _experiment: ExperimentDeclared | None = field(default=None, init=False, repr=False)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 from pydantic import ValidationError
 
-from diffBloch.app.cli import main
+from diffBloch.app.cli import _release_sinks, main
 from diffBloch.app.loggers import ConsoleLogger
 from diffBloch.observability import MultiLogger, NullLogger, OrientationOptimized
 from diffBloch.preprocess.inference import InferenceResult, RotationInference
@@ -502,3 +502,34 @@ def test_run_refine_missing_experiment_reports_concise_error(
     err = capsys.readouterr().err
     assert err.startswith("error:")
     assert "Traceback" not in err
+
+
+def test_run_converge_accepts_the_sink_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """converge emits the sweep stream, so it takes the same sinks as every other subcommand."""
+    seen: dict[str, object] = {}
+
+    def fake_converge_experiment(
+        experiment_dir: str, *, logger: object, device: object, n_orientations: int
+    ) -> SimpleNamespace:
+        seen["logger"] = logger
+        return SimpleNamespace(g_max=2.5, sg_max=0.02, tilt_steps=46)
+
+    monkeypatch.setattr("diffBloch.app.cli.converge_experiment", fake_converge_experiment)
+    assert main(["run", "converge", "/some/experiment", "--quiet"]) == 0
+    assert isinstance(seen["logger"], NullLogger)  # --quiet reaches it
+
+
+def test_released_sinks_give_back_their_resources(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A live display owns the terminal; a run with no terminal event must still release it."""
+    closed: list[str] = []
+
+    class _Holder:
+        def report(self, event: object) -> None:
+            return None
+
+        def close(self) -> None:
+            closed.append("released")
+
+    _release_sinks(MultiLogger((_Holder(), NullLogger())))  # type: ignore[arg-type]
+    assert closed == ["released"]
+    _release_sinks(NullLogger())  # a sink with no close() is simply skipped

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -533,3 +533,10 @@ def test_released_sinks_give_back_their_resources(monkeypatch: pytest.MonkeyPatc
     _release_sinks(MultiLogger((_Holder(), NullLogger())))  # type: ignore[arg-type]
     assert closed == ["released"]
     _release_sinks(NullLogger())  # a sink with no close() is simply skipped
+
+    # Fan-outs nest: `run refine --tui --csv` puts _build_logger's own MultiLogger inside a second
+    # one alongside the summary sink, so a single-level walk would miss the display entirely.
+    closed.clear()
+    nested = MultiLogger((MultiLogger((_Holder(), NullLogger())), NullLogger()))  # type: ignore[arg-type]
+    _release_sinks(nested)
+    assert closed == ["released"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -540,3 +540,23 @@ def test_released_sinks_give_back_their_resources(monkeypatch: pytest.MonkeyPatc
     nested = MultiLogger((MultiLogger((_Holder(), NullLogger())), NullLogger()))  # type: ignore[arg-type]
     _release_sinks(nested)
     assert closed == ["released"]
+
+
+@pytest.mark.parametrize("command", ["infer", "preprocess", "refine", "converge"])
+def test_tui_without_the_extra_reports_concisely(
+    command: str, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A missing optional extra is a user mistake: a message and exit 1, never a traceback."""
+    import importlib.util
+
+    real = importlib.util.find_spec
+    monkeypatch.setattr(
+        importlib.util,
+        "find_spec",
+        lambda name, *a, **k: None if name == "rich" else real(name, *a, **k),
+    )
+
+    assert main(["run", command, "/some/experiment", "--tui"]) == 1
+    captured = capsys.readouterr()
+    assert "uv sync --extra tui" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/unit/test_tui_logger.py
+++ b/tests/unit/test_tui_logger.py
@@ -252,3 +252,16 @@ def test_close_is_safe_without_a_started_display() -> None:
     logger.close()
     logger.close()  # idempotent
     assert logger._live is None
+
+
+def test_missing_rich_fails_at_construction_with_an_install_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--tui is a CLI flag, so the failure must arrive before the run, not on the first event."""
+    import importlib.util
+
+    monkeypatch.setattr(
+        importlib.util, "find_spec", lambda name: None if name == "rich" else object()
+    )
+    with pytest.raises(ValueError, match=r"uv sync --extra tui"):
+        TuiLogger()

--- a/tests/unit/test_tui_logger.py
+++ b/tests/unit/test_tui_logger.py
@@ -244,3 +244,11 @@ def test_terminal_event_closes_the_display() -> None:
     logger.report(_experiment())
     logger.report(RefinementOutputsWritten(structure="/tmp/refined_structure.cif"))
     assert logger._live is None
+
+
+def test_close_is_safe_without_a_started_display() -> None:
+    """The CLI releases sinks in a finally, so close() runs even on runs that drew nothing."""
+    logger = TuiLogger()
+    logger.close()
+    logger.close()  # idempotent
+    assert logger._live is None

--- a/tests/unit/test_tui_logger.py
+++ b/tests/unit/test_tui_logger.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import pytest
 
 from diffBloch.observability import (
+    ConvergencePassStarted,
+    ConvergenceSweepStarted,
     ConvergenceTrial,
     ExperimentDeclared,
     ObjectiveManifest,
@@ -94,32 +96,50 @@ def test_off_a_terminal_the_display_never_starts(monkeypatch: pytest.MonkeyPatch
 
 
 def test_unmodelled_events_surface_generically_instead_of_vanishing() -> None:
-    """No event is dropped by omission -- an unstyled row beats an unseen observation.
-
-    The convergence sweep is the case that matters: for a `run converge` the terminal is often the
-    only sink attached, so an event the dashboard has no dedicated view for still has to appear.
-    """
+    """No event is dropped by omission -- an unstyled row beats an unseen observation."""
     logger = TuiLogger()
     assert logger._absorb(RotationScored(index=0, r_obs=0.1, n_observed=5, n_beams=9)) is True
-    assert (
-        logger._absorb(
-            ConvergenceTrial(
-                control="g_max",
-                trial_index=0,
-                pass_index=0,
-                previous=2.25,
-                candidate=2.45,
-                r_factor=0.031,
-                n_compared_hkl=612,
-            )
-        )
-        is True
-    )
 
     text = _rendered(logger)
     assert "other events" in text
-    assert "convergence g_max" in text
-    assert "r_factor=0.031" in text and "n_compared_hkl=612" in text
+    assert "rotation" in text and "n_beams=9" in text
+
+
+def test_convergence_sweep_has_its_own_view_not_the_generic_fallback() -> None:
+    """A trial's setting change, its cost in R, and whether it cleared the pass threshold."""
+    logger = TuiLogger()
+    logger._absorb(
+        ConvergencePassStarted(
+            pass_index=0,
+            g_max=2.25,
+            sg_max=0.01,
+            tilt_steps=42,
+            r_factor_threshold=0.01,
+            n_orientations=1,
+        )
+    )
+    logger._absorb(ConvergenceSweepStarted(control="g_max", pass_index=0))
+    for index, (previous, candidate, r_factor) in enumerate(
+        ((2.25, 2.45, 0.0312), (2.45, 2.65, 0.0071))
+    ):
+        logger._absorb(
+            ConvergenceTrial(
+                control="g_max",
+                trial_index=index,
+                pass_index=0,
+                previous=previous,
+                candidate=candidate,
+                r_factor=r_factor,
+                n_compared_hkl=612 + index,
+            )
+        )
+
+    text = _rendered(logger)
+    assert "other events" not in text  # it has a dedicated view now
+    assert "threshold 0.01" in text and "sweeping g_max" in text
+    settled = [line for line in text.splitlines() if "settled" in line]
+    # Only the trial that actually fell under the threshold is marked.
+    assert len(settled) == 1 and "0.007100" in settled[0]
 
 
 def test_tables_say_when_they_are_showing_a_window() -> None:


### PR DESCRIPTION
Follow-up to #74. The sweep table is the new view; the other four commits are fixes to `--tui` as merged, all found by running it rather than by testing it.

## Trying it: converge through to refine

Every command takes `--tui`. Drop `--device cpu` if you have CUDA. `uv sync --extra tui` first.

```bash
EXP=examples/Colmey_et_al_2026_Acta_Cryst_A/data/quartz-no-abs

# 1. Converge the numerics. This is what the new table shows.
uv run diffbloch run converge $EXP --tui

# 2. Settle the Plan. Survival counts per stage, then the orientation and thickness fits.
#    Writes plan.npz + plan.lock into the experiment's reproducibility/.
uv run diffbloch run preprocess $EXP --tui

# 3. Refine. Reuses the checkpoint step 2 just wrote, so this starts at the first epoch.
uv run diffbloch run refine $EXP --tui
```

Step 1 prints its settled `gmax`/`sgmax`/`tilt_steps` at the end. **They are not chained automatically** — `converge_experiment` returns the settled state and discards the converged `Plan`. Paste them into `$EXP/experiment.yaml` before step 2 if you want the run to use them, which also keeps the recorded config an honest description of what ran.

Steps 2 and 3 are the expensive ones: no example ships a preprocess checkpoint, so step 2 pays the full orientation and thickness fits, and `refinement.steps` defaults to 40. Run step 2 before step 3 and the refine starts immediately; run step 3 alone and it does step 2's work first.

`--csv PATH` writes the same event stream to a long-format log and composes with either console mode. `--quiet` silences the display but still prints the run summary.

## What each phase shows

**Converge** — the new table. Each trial's setting change, what it cost in R, the reflections it was compared over, and a `settled` marker on the trial whose R-factor fell under the pass threshold:

```
convergence  (pass 0, threshold 0.01, 1 rotation(s))  sweeping g_max  (3)
┏━━━━━━━━━┳━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ control ┃ trial ┃ from ┃   to ┃        R ┃ compared hkl ┃         ┃
┡━━━━━━━━━╇━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ g_max   │     0 │ 2.25 │ 2.45 │ 0.031200 │          612 │         │
│ g_max   │     1 │ 2.45 │ 2.65 │ 0.018000 │          655 │         │
│ g_max   │     2 │ 2.65 │ 2.85 │ 0.007100 │          689 │ settled │
└─────────┴───────┴──────┴──────┴──────────┴──────────────┴─────────┘
```

Showing the threshold in the title without showing which trial cleared it would leave the reader doing the arithmetic. #74 rendered these as a flat measurements dump in the generic "other events" table — visible, but not legible.

**Preprocess** — the per-stage survival counts, seed row first, so the prune reads directly (538263 candidate solve beams down to 9988).

**Refine** — the declared objective, the epoch table with each mean's denominator and a column per composed penalty, then the settled per-rotation table with held-out rotations marked.

## The four fixes

**`run converge` took none of the sink flags.** It hardcoded `ConsoleLogger()` and accepted neither `--tui`, `--csv`, nor `--quiet` — it does not use `_add_run_flags`. So the one command that emits convergence events was the one command that could not render them. It now builds its sinks like every other subcommand.

**The live display was never released on three of four commands.** `TuiLogger` stops on the refinement run's terminal event, but `converge`/`preprocess`/`infer` have no such event and an exception can end any run early, so the display kept the terminal while the process moved on to printing its summary. The boundary that builds the sinks now releases them in a `finally`, for all four, rather than every event stream having to end in exactly the right event.

**That release missed nested fan-outs.** `run refine --tui --csv` puts `_build_logger`'s own `MultiLogger` inside a second one alongside the summary sink, so a single-level walk skipped the display on the combination most likely to be using it. It recurses now, and the test pins the nested shape — covering only the flat case is why the gap survived the first fix.

**`--tui` without the extra raised `ModuleNotFoundError`.** rich is imported lazily inside the rendering methods, so `TuiLogger` constructed fine without it and failed on the *first event* — for a refine run, after the entire preprocess had been paid for. It now refuses at construction via `find_spec` (which detects absence without importing, keeping the rendering path lazy) and raises `ValueError`, which the CLI already turns into a concise message. Fixing that exposed a regression from the release commit: hoisting `_build_logger` out of the `try` had also moved sink construction outside the concise-error handler, so the new message escaped as a traceback. Sinks are built inside the `try` again, initialised to `NULL_LOGGER` so the `finally` stays safe when construction is what failed.

## Verification

`ruff check`, `mypy` (68 files), `pytest -q` — 668 passed, 3 skipped. The TUI tests render to an off-screen `Console` and assert on the text, so layout is covered without a terminal, and the module is `importorskip`-guarded so the suite passes without the extra. The missing-extra path is asserted end-to-end across all four subcommands: concise message, exit 1, no traceback.

## Still not addressed

Convergence records its search bounds in provenance but never its settled values, and the `integrate_rocking_curve`/`couple_beams` steps it applies internally are called directly rather than through `pipeline`, so their `StepRecord`s never reach the plan's recipe.
