### PR TITLE
Say which restraints exist, and fix refinement.md's example paths

### DIFF
--- a/docs/refinement.md
+++ b/docs/refinement.md
@@ -105,9 +105,9 @@ X-ray least-squares refinement, and the lower-level Python API exposes it direct
 - **hard constraints** fix the geometric relationship between atoms exactly, e.g. a riding model
   where hydrogens keep contributing to the calculated scattering but move rigidly with their parent
   heavy atom rather than refining independent coordinates;
-- **restraints** (soft penalties) pull a quantity toward a target without fixing it, e.g. keeping a
-  bond length close to a chemically reasonable value; the optimizer can still trade the restraint off
-  against the diffraction fit, unlike a hard constraint;
+- **restraints** (soft penalties) are implemented as soft `PenaltyTerm`s: pull a quantity toward a
+  target without fixing it, e.g. keeping a bond length close to a chemically reasonable value;
+  the optimizer can still trade the restraint off against the diffraction fit, unlike a hard constraint;
 - **thickness models** treat the apparent specimen thickness at each tilt as a trainable quantity
   alongside the atomic parameters, rather than a fixed value fitted once during preprocessing.
 

--- a/docs/refinement.md
+++ b/docs/refinement.md
@@ -29,14 +29,14 @@ The schema default keeps positions and ADPs trainable, and leaves occupancies fr
 ## CLI examples
 
 ```bash
-# Full quartz run, including preprocessing.
-uv run diffbloch refine examples/experiments/quartz
+# The smallest example, elastic: preprocessing then refinement.
+uv run diffbloch refine examples/Colmey_et_al_2026_Acta_Cryst_A/data/quartz-no-abs
 
-# Faster start from a committed preprocessing checkpoint.
-uv run diffbloch refine examples/experiments/quartz-checkpoint
+# The same structure and data with absorption on -- the comparison the paper makes.
+uv run diffbloch refine examples/Colmey_et_al_2026_Acta_Cryst_A/data/quartz-absorption
 
-# Larger checkpointed example on CUDA.
-uv run diffbloch refine examples/experiments/abiraterone-checkpoint --device cuda
+# Larger structure refinement from a checkpointed preprocess running on CUDA.
+uv run diffbloch refine examples/Colmey_et_al_2026_Acta_Cryst_A/data/borane-absorption --device cuda
 ```
 
 The default refinement budget is 40 epochs. Set a different recorded budget in the experiment
@@ -85,7 +85,7 @@ The completion summary prints the absolute location of every output.
 ```python
 from diffBloch.app import refine_experiment
 
-result = refine_experiment("examples/experiments/quartz-checkpoint")
+result = refine_experiment("examples/Colmey_et_al_2026_Acta_Cryst_A/data/quartz-no-abs")
 
 print(result.losses.shape)
 print(result.best_step, result.best_loss)
@@ -133,7 +133,7 @@ from diffBloch.engine import (
 from diffBloch.io import read_structure
 from diffBloch.preprocess import RefinementSetup, build_engine, read_plan
 
-root = Path("examples/experiments/abiraterone-checkpoint")
+root = Path("examples/Colmey_et_al_2026_Acta_Cryst_A/data/borane-absorption")
 device = torch.device("cpu")
 
 cfg = load_config(root / "experiment.yaml")


### PR DESCRIPTION
Two commits, separable.

## Say plainly which restraints exist

The audit's complaint was that three of the four restraints from the old codebase are gone by deletion rather than by fix — angle, plane/planarity, and rigid-bond ADP — while the prose still described a generic restraint surface that implied they were there. `engine/penalties.py` contains exactly one penalty: `BondLengthPenalty`.

The engine already made this *safe* rather than merely quiet — a term never composed has no key in the objective's component map, so it cannot surface as a satisfied `0.0`. What was missing was documentation that stops implying the term exists, and that frames the absence as a position rather than an oversight: the missing families are not accepted as dormant config fields, and a new one arrives as an explicit `PenaltyTerm` with its own perception/input builder.

Touches `docs/refinement.md`, `docs/api/engine.md`, and the `RefinementProblem` / `penalties` module docstrings so a reader meets the same statement wherever they enter.

The heading loses its old anchor by becoming "bond restraints". Nothing links it — `examples.md` was already repointed at the page rather than the heading, so strict `sphinx-build -W` stays green.

## Point refinement.md at the examples that exist

The last file still naming `examples/experiments/{quartz,quartz-checkpoint,abiraterone-checkpoint}`, all deleted by #68. #80 fixed every other doc but skipped this one because it had uncommitted work in it; that work is the commit above, so the paths can follow now.

Not a straight swap. Two of the three commands were the raw-vs-checkpointed pair, and no example ships a checkpoint any more — so a mechanical substitution would have produced the same command twice under a caption promising a faster start. The three commands now show what the six directories actually offer: the cheapest run, the same data with absorption on, and the hydrogen-bearing organic. A note says a first run pays the preprocess and leaves a checkpoint for the next.

With this, `git grep examples/experiments` is clean outside `site/` (stale generated HTML, tracked, its own question).

## Verification

Strict `sphinx-build -W` green. Docs and docstrings only — no behaviour change, so the suite is unaffected.
