### PR TITLE
Docsite expansion extracted from #87 (pruned to main's behavior)

### DIFF
--- a/docs/api/preprocess.md
+++ b/docs/api/preprocess.md
@@ -1,7 +1,7 @@
 # Preprocess
 
 The composable `Plan → Plan` preprocess pipeline: build the initial plan from an experiment, sharpen
-it with swappable steps (beam selection, orientation/thickness fits, rocking-curve integration,
+it with swappable steps (beam selection, orientation/thickness determination, rocking-curve integration,
 mosaicity, convergence/coverage sweeps), then hand the final plan to a terminal (`run_inference` or
 `engine.refine`).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,322 +1,155 @@
 # Architecture
 
-## Building the potential
+diffBloch converts a starting crystal structure and 3D electron-diffraction data into a
+refined structure through the following calculation:
 
-Everything below starts after the `io` boundary: `positions`, `numbers`, `occupancies`, `uij_star`
-are already validated tensors on the ASU.
-
-**Symmetry expansion.** The refined parameters live only on the asymmetric unit. Before any
-scattering physics, every symmetry operation {math}`(R_m, \mathbf{t}_m)` of the space group is
-applied to each ASU atom {math}`i`:
-
-```{math}
-\mathbf{r}'_m = R_m \mathbf{r}_i + \mathbf{t}_m ,
+```text
+.cif structure + .cif_pets experiment
+  -> crystal potential
+  -> Bloch-wave simulation
+  -> calculated/observed intensity comparison
+  -> preprocessing
+  -> structural refinement
 ```
 
-producing the full-cell atom list (positions, atomic numbers, occupancies, ADPs all carried through
-the same expansion). This is `core.symmetry.expand_asu` — purely geometric, no scattering physics
-yet, differentiable in `positions` because {math}`R_m`/{math}`\mathbf{t}_m` are fixed constants and
-only {math}`\mathbf{r}_i` carries gradient.
+## Structural and experimental data
 
-**Elastic structure factor.** For each reflection {math}`\mathbf{h}`, sum a scattering contribution
-over every expanded atom:
+The structure `.cif` supplies asymmetric-unit atoms, fractional coordinates, elemental identities,
+occupancies, atomic displacement parameters (ADPs), space-group symmetry operations, and the unit
+cell.
 
-```{math}
-F_{\mathbf{g}}(\mathbf{h}) = \frac{1}{V}\sum_{j} f_j(s)\, T_j(\mathbf{h})\, O_j\,
-\exp(2\pi i\, \mathbf{h}\cdot\mathbf{r}_j) ,
-```
+The `.cif_pets` file supplies the measured experimental data: observed reflection intensities and
+uncertainties for each rotation, the UB orientation matrix, electron wavelength, the goniometer
+angles, and its own unit cell.
 
-with {math}`s = |\mathbf{g}|/2` and {math}`V` the cell volume. {math}`f_j(s)` is the electron
-scattering factor: diffBloch hardcodes the Lobato & Van Dyck (2014) parametrization — a
-five-Gaussian-rational fit, {math}`f_e(s) = \sum_i a_i(2+b_i s^2)/(1+b_i s^2)^2`, coefficients
-vendored per element from the published table (`core/data/lobato.json`). There is no runtime
-switch: Kirkland and Peng *et al.* parametrizations were evaluated during design (see
-`REFERENCES.md`) but neither is wired in as a swappable option.
+Both files are parsed into validated numerical records before simulation begins. Malformed values
+and unsupported representations fail at this boundary. See [Inputs](inputs.md) for the file
+requirements and experiment-directory layout.
 
-{math}`T_j(\mathbf{h})` is the Debye–Waller factor. Every atom's ADP is carried in the reciprocal
-`U*` frame regardless of whether the CIF gave `Uiso` or `Uani` (Trueblood *et al.*, 1996
-convention: `Uani` maps directly, {math}`U^*_{ij} = d^*_i d^*_j\, U^{\mathrm{cif}}_{ij}`; `Uiso`
-maps via {math}`U^* = U_{\mathrm{iso}} G^*`, {math}`G^* = BB^\top`). One formula consumes both:
+## Constructing the crystal potential
+
+The asymmetric unit is expanded using the symmetry operations from the `.cif`. For symmetry
+operation {math}`(R_m, \mathbf{t}_m)` and atomic position {math}`\mathbf{r}_i`, the expanded
+position is
 
 ```{math}
-T_j(\mathbf{h}) = \exp(-2\pi^2\, \mathbf{h}^\top U^*_j\, \mathbf{h}) .
+\mathbf{r}'_{mi} = R_m\mathbf{r}_i + \mathbf{t}_m.
 ```
 
-**Absorption.** With `absorption.enabled`, {math}`f_j(s)` picks up an imaginary part:
-{math}`f_j \to f_j + i f'_j(s, B_j)`, where {math}`f'_j` is a fitted absorptive form factor
-(Gaussian-sum interpolation over the atom's isotropic-equivalent {math}`B_j`, converted from its
-`U*`), following Bird & King (1990). {math}`F_{\mathbf{g}}` is then complex for every reflection —
-which is what later makes the structure matrix {math}`A` non-Hermitian.
-
-{math}`F_{\mathbf{g}}` is a setup constant with respect to orientation — computed once per
-parameter state (`core.scattering.structure_factors`) and reused across every rotation, since it
-depends only on the structure, not on the beam geometry.
-
-## The Bloch-wave forward model
-
-The forward model maps a beam set, an orientation, an energy, and the structure factors built above
-to an exit-wave intensity vector.
-
-**Structure matrix.** For a beam set {math}`\{\mathbf{g}_i\}_{i=1}^{N}` at a given orientation,
-`core.dynamical.assembly` assembles the Hermitian (or, with absorption, non-Hermitian) {math}`N
-\times N` structure matrix {math}`A`:
+The elastic electron structure factor is
 
 ```{math}
-A_{ii} = 2 K_n \, S_{g_i} \, M_{ii}, \qquad
-A_{ij} = \sigma \, M_{ii} M_{jj} \, F(\mathbf{g}_j - \mathbf{g}_i) \;\; (i \neq j),
+F_{\mathbf{g}}(\mathbf{h}) = \frac{1}{V}\sum_j f_j(s)T_j(\mathbf{h})O_j
+\exp(2\pi i\,\mathbf{h}\cdot\mathbf{r}_j).
 ```
 
-with Lorentz/obliquity factor {math}`M_{ii} = (1 - g_{i,z}/K_n)^{-1/2}` (equal to 1 at
-{math}`\mathbf{g}=0`), interaction constant {math}`\sigma`, and in-crystal wavevector magnitude
-{math}`K_n = \sqrt{1/\lambda^2 + U_0}`, where {math}`U_0` is the mean inner potential correction,
-{math}`U_0 = |F_{000}| \cdot \sigma / (\kappa \lambda \pi)`, computed once from the starting
-structure and held fixed through refinement. The off-diagonal is a differentiable gather of
-{math}`F_{\mathbf{g}}` onto every beam-pair difference; only {math}`F` carries gradient — the
-gather indices are precomputed geometry.
+where {math}`f_j(s)` is the electron scattering factor, {math}`O_j` is occupancy,
+and {math}`T_j` is the Debye--Waller factor calculated from the ADP. Absorptive scattering can be
+included as an imaginary contribution. The output is the reciprocal-space crystal potential
+{math}`F_g` used by the Bloch-wave calculation.
 
-The excitation error {math}`S_{g_i}` is the signed distance of {math}`\mathbf{g}_i` from the Ewald
-sphere: with beam {math}`\mathbf{K}` fixed along {math}`-z` at magnitude {math}`K_n`,
+## Bloch-wave simulation
+
+For each experimental orientation, diffBloch selects the reciprocal-lattice vectors included in the
+calculation, calculates their excitation errors, and constructs the Bloch structure matrix
 
 ```{math}
-S_{g} = \frac{|\mathbf{K}|^2 - |\mathbf{K}+\mathbf{g}|^2}{2|\mathbf{K}|}
+A_{ii} = 2K_nS_{g_i}M_{ii}, \qquad
+A_{ij} = \sigma M_{ii}M_{jj}F(\mathbf{g}_j-\mathbf{g}_i) \quad (i\ne j),
 ```
 
-(Spence & Zuo, 1992 convention); {math}`S_{g}=0` exactly at {math}`\mathbf{g}=0`, so the
-transmitted beam always sits on the diagonal at zero.
+where {math}`S_{g_i}` is excitation error, {math}`M_{ii}` is the obliquity correction,
+{math}`\sigma` is the interaction constant, and {math}`K_n` is the in-crystal wavevector magnitude.
+The off-diagonal terms describe dynamical scattering between beams.
 
-{math}`N` is not fixed by the structure matrix code — it is whatever beam set preprocessing handed
-it, and that is entirely config-controlled: `blochwave.g_max` bounds the candidate pool radius
-(and sets the {math}`F_{\mathbf{g}}` support at {math}`2\times g_{\max}`); `select_beams` prunes
-candidates to the active set with the Klar cutoffs `rsg`/`dsg` against
-{math}`sg_{\max}=|g_\perp|\cdot\text{semiangle}`. On the default coupled path, {math}`N` is the
-*union* of active beams across a whole tilt segment, not one orientation's active set alone —
-governed by `coupling_mode`, `fixed_n_segments`, `rocking_curve_sampling` (sub-tilts per segment),
-and `union_adaptive`/`union_max_new_beams_pct` (adaptive segment splitting). Since matrix assembly
-is {math}`O(N^2)` and the dense solve worse, these are the knobs that set simulation cost.
-
-**Propagation.** `psi0` is the boundary condition: amplitude 1 on the {math}`\mathbf{g}=000` beam,
-0 on every other beam in the set — all incident amplitude in the transmitted beam at {math}`t=0`.
-`core.solver.propagate` integrates the exit wavefunction through specimen thickness {math}`t`:
+The incident wave begins entirely in the transmitted beam. Propagation through specimen thickness
+{math}`t` gives
 
 ```{math}
-\psi(t) = \exp\!\left(\frac{i \pi t}{K_n} A\right) \psi_0 .
+\psi(t) = \exp\left(\frac{i\pi t}{K_n}A\right)\psi(0),
 ```
 
-`thicknesses` is a scalar or `(T,)` array of trial values (Å); `propagate` returns `psi` of shape
-`(T, N)` — one full {math}`N`-beam amplitude vector per requested thickness, in a single batched
-call. Two propagators evaluate this, both over the same `BlochSystem` and swappable without
-touching geometry code:
+and the calculated intensity is {math}`|\psi_g(t)|^2`.
 
-- `matrix_exp` — a dense matrix exponential per thickness (batched over {math}`T`), stable
-  autograd. The refinement default.
-- `bloch_eigen` — diagonalize {math}`A` once (`eigh`), then each of the {math}`T` thicknesses is a
-  cheap phase multiply on the eigenbasis-projected `psi0`: exact and fast for many thicknesses at
-  once, but `eigh`'s backward is ill-conditioned near degenerate eigenvalues — routine in symmetric
-  crystals — so it is eval-only, never on the differentiated path. The two coincide only where
-  {math}`M_{ii}=1` for every beam; otherwise one returns symmetrised amplitudes, the other physical
-  ones — a property of the two formulations, not a bug in either.
-
-`intensities = |psi|**2` gives shape `(T, N)`: the full simulated pattern for every candidate
-thickness in one shot. That single batched call is why the thickness grid search
-(`optimize_thickness`) is cheap — assembling and exponentiating/diagonalizing {math}`A` is paid
-once, not once per candidate {math}`t`.
-
-**Alignment.** `core.products.align` places simulated and observed intensities on a common
-reflection index for loss evaluation. Before that comparison is meaningful, each virtual frame's
-single-orientation exit wave above has to become the actual integrated pattern PETS measured — see
-[Rocking-curve integration and mosaicity](#rocking-curve-integration-and-mosaicity).
-
-**SOLVE and SCORED reflection sets are independent.** The SOLVE set is which beams couple
-dynamically inside the structure matrix; the SCORED set is which reflections enter the residual.
-Every scored reflection must be solved (SCORED {math}`\subseteq` SOLVE), but widening the solve
-basis for numerical convergence must not silently change what is scored, and a scoring-set change
-must not perturb the dynamical coupling. `preprocess.select_beams` selects the SOLVE set from
-excitation error and resolution thresholds (`sg_max`, `g_max`); alignment against the PETS
-experimental data determines the SCORED set independently.
-
-## Rocking-curve integration and mosaicity
-
-Everything in [The Bloch-wave forward model](#the-bloch-wave-forward-model) above solves one static
-orientation. A continuous-rotation 3DED frame is not static — it integrates over the crystal
-sweeping through the Ewald sphere — so a single Bloch solve at the frame's nominal orientation is
-not what was measured. `integrate_rocking_curve` closes that gap.
-
-**Building the tilt set.** `preprocess.orientation.rocking_curve_tilts(semiangle, sampling)`
-generates `sampling` rotation matrices about the goniometer x-axis, at angles
-{math}`\mathrm{linspace}(-\text{semiangle}, +\text{semiangle}, \text{sampling})`. These are pure,
-orientation-independent geometry, built once and reused for every rotation. For a virtual frame
-with nominal (already PETS-derived) orientation {math}`M_i`, the sub-orientations are
+A continuous-rotation frame covers an angular interval rather than one static orientation.
+diffBloch samples that rocking curve, performs a Bloch-wave solve at each sub-orientation, and sums
+the intensities incoherently:
 
 ```{math}
-M_i^{(k)} = R_{\mathrm{tilt}}(k)\, M_i, \qquad k = 1,\dots,\text{sampling} .
+I_{\mathrm{frame}}(t) = \sum_k |\psi^{(k)}(t)|^2.
 ```
 
-`sampling = 1` is special-cased to the identity tilt at angle {math}`0` exactly (not the
-`linspace`-start value), so composing this step with `sampling = 1` leaves the `Plan` unchanged —
-the integration is opt-in, not baked into `from_experiment`. This step is pure geometry: it rebuilds
-each orientation with `N = sampling` sub-orientations sharing the *same* beam set and gather, no
-engine or structure factors involved. It runs last in the default recipe, after
-`optimize_orientation`/`optimize_thickness`, because those fit against the fast single-solve at the
-nominal orientation; only once both are settled is the plan expanded to the full tilt set they will
-actually be evaluated at.
+When mosaicity is enabled (the default configuration is `Mosaicity(window=5)`), a moving average of
+that width is applied over consecutive sampled tilts before the sum, modelling crystal mosaic
+spread as a blur of the sampled rocking curve rather than integrating the sharp unbroadened curve.
+The window is a sampled-tilt count recorded in the plan provenance; it is not derived from PETS
+mosaic-spread metadata. The output is one calculated diffraction pattern for each experimental
+rotation.
 
-**Summing the Bloch waves.** Each of the `N` sub-orientations is solved independently — same beam
-set, same {math}`F_{\mathbf{g}}`, but a different structure matrix {math}`A` per tilt, since
-{math}`S_g` and {math}`M_{ii}` depend on orientation. That gives `N` separate exit waves
-{math}`\psi^{(k)}(t)`, reduced over the tilt axis as an **incoherent** sum of intensities
-(`core.products.BlochSolution.integrate` / `reduce_tilts`):
+## Comparing simulation with experiment
 
-```{math}
-I_{\mathrm{frame}}(t) = \sum_{k=1}^{N} \left|\psi^{(k)}(t)\right|^2 ,
-```
+The calculated intensities are matched to the observed reflections from the corresponding `.cif_pets`
+rotation. diffBloch distinguishes three reflection sets:
 
-not {math}`\bigl|\sum_k \psi^{(k)}(t)\bigr|^2`. This is the physical rotation-frame integration —
-summing counts across the sweep, not interfering amplitudes — so phase is deliberately discarded;
-the integrated solution stores only {math}`\sqrt{I_{\mathrm{frame}}}` as a nominal amplitude with no
-downstream use, and only `intensities` feeds alignment and the loss.
+- **solve beams** participate in the dynamical calculation;
+- **matched reflections** occur in both the calculated and experimental patterns;
+- **scored reflections** are the matched reflections admitted to the objective.
 
-**Mosaicity.** At the low-level step-composition API, omitting mosaicity (`mosaicity=None`)
-keeps `PlainSum`, the bare sum above. The default app/CLI recipe is different: it passes the
-configured `blochwave.mosaicity` into `build_orientation_plans`, and that config currently defaults
-to `Mosaicity(window=5)`. The window is a sampled-tilt moving-average width recorded in the plan
-recipe/provenance; it is not derived from the PETS free-text mosaicity value. The `mosaicity` step
-or configured build reduction swaps the reduction to `MosaicSmoothed(window)`: a `window`-wide moving
-average over consecutive tilts on the tilt axis, applied *before* the sum —
+Refinement minimises a scaling-optimised residual. The default is {math}`wR_2`.
+{math}`R_{\mathrm{obs}}`, restricted to observations satisfying {math}`I>3\sigma`, is also
+reported.
 
-```{math}
-I_{\mathrm{frame}}(t) = \sum_{k} \left(\frac{1}{\text{window}}\sum_{l=0}^{\text{window}-1}
-\left|\psi^{(k+l)}(t)\right|^2\right) ,
-```
+## Preprocessing the experiment
 
-modelling crystal mosaic spread as a blur of the sampled rocking curve before it is integrated,
-rather than integrating the sharp unbroadened curve. `window = 1` is the identity. It can only
-compose after `integrate_rocking_curve` (raises below two tilts — a moving average over one point is
-meaningless) and must precede the fits: whatever reduction is used at evaluation has to be the same
-one the orientation/thickness fits saw, or the fit and the eval would be scoring against two
-different forward models — the fit/eval consistency invariant.
+The PETS orientations provide the starting geometry. diffBloch searches a small angular region
+around each orientation and retains the orientation with the best agreement to the observed
+intensities.
 
-## Scoring
+Specimen thickness strongly affects dynamical intensities. When both fitting stages are enabled,
+preprocessing fits orientation against the seed thickness first and thickness against the fitted
+orientation second by default (`preprocess.stage_order` reverses this). The fitted values give the
+thickness model a better starting value during refinement.
 
-**The reflection-comparison set.** Not a union of anything — an intersection.
-`build_alignment_plan(solution_hkl, pattern_hkl, restrict_to=scored_hkl)` computes
-{math}`\text{pattern} \cap \text{solution} \cap \text{restrict\_to}`: `pattern` is what PETS
-observed for that rotation, `solution` is what beams the Bloch solve actually computed (the SOLVE
-set), `restrict_to` is the SCORED set. A reflection not solved cannot be scored even if PETS
-measured it (SCORED {math}`\subseteq` SOLVE); a reflection PETS did not record cannot be scored even
-if it was solved.
+Convergence tests determine the reciprocal-space cutoffs and rocking-curve sampling used during
+refinement.
 
-**What decides the SCORED set — the fully-integrated filter.** `klar_beam_mask`, applied via
-`scoring_selection` on the candidate pool before that intersection. Per reflection {math}`\mathbf{g}`:
-
-```{math}
-sg_{\max} = |\mathbf{g}_{\mathrm{lever}}| \cdot \mathrm{deg2rad}(\text{semiangle})
-```
-
-is how far {math}`S_g` *sweeps* for that reflection as the crystal rocks through the measured
-semiangle, with {math}`\mathbf{g}_{\mathrm{lever}}` the component of {math}`\mathbf{g}`
-perpendicular to the rock axis (`(g_y, g_z)` for continuous rotation about the goniometer x-axis) —
-reflections far from the rock axis sweep a bigger {math}`S_g` range for the same tilt than
-reflections near it. A reflection is kept — judged fully integrated — when both
-
-```{math}
-\frac{|S_g|}{sg_{\max}} < rsg, \qquad sg_{\max} - |S_g| > dsg .
-```
-
-The first is relative: {math}`S_g` small against the sweep range means the rocking curve's peak
-({math}`S_g \approx 0`, exact Bragg) falls inside the measured window, not at or beyond its edge.
-The second is an absolute safety margin on top, so a reflection sitting right at the edge — which
-might narrowly pass the relative test alone — is still excluded. Fail either and the reflection is
-dropped from the SCORED candidate pool before the intersection runs: only part of its rocking curve
-was actually measured, so comparing it would compare a partial integration to an implicitly-full
-one.
-
-**Getting R.** Once the intersection is fixed, `align(solution, pattern, plan)` gathers
-`calculated`/`observed`/`sigmas` onto that shared axis (index-gather, no further filtering). The
-conventional Bragg residual:
-
-```{math}
-R_{\mathrm{obs}} = \frac{\sum |\sqrt{I_{\mathrm{obs}}} - \sqrt{I_{\mathrm{calc}}}|}
-{\sum \sqrt{I_{\mathrm{obs}}}}, \quad \text{restricted to } I_{\mathrm{obs}} > 3\sigma
-```
-
-— an extra runtime cut on top of the SCORED-set selection above: even a reflection that passed the
-`rsg`/`dsg` fully-integrated test only enters this particular sum if its measured intensity clears
-the conventional {math}`3\sigma` significance threshold. `R_obs` is reported at every step but is
-not itself minimized; see [Refinement](#refinement) for `w_rbragg`, the quantity actually optimized.
+The output is a `Plan` containing the orientations, thicknesses, beam geometry, experimental
+observations, and calculated/observed reflection alignment. The `Plan` remains fixed during
+structural refinement. See [Preprocessing](preprocessing.md) and
+[Convergence testing](convergence-testing.md).
 
 ## Refinement
 
-Refinement holds a settled `Plan` fixed and differentiates a scalar objective back to the
-structural parameters through the complete forward chain:
+Refinement holds the settled `Plan` fixed and repeatedly evaluates the scientific calculation:
 
 ```text
-RefinableParams
-  -> constrain (crystallographic hard constraints)                  -> PhysicalState
-  -> expand_asu (space-group expansion)                             -> Fgb (structure_factors)
-  -> per rotation: build_bloch_system -> propagate -> intensities   -> AlignedIntensities
-  -> optional molecular constraints, components, penalties
-  -> scalar objective (w_rbragg, Klar et al. 2023) + soft penalty terms
+raw structural parameters
+  -> physical crystallographic structure
+  -> crystal potential
+  -> Bloch-wave intensities
+  -> comparison with experiment
+  -> scalar objective
+  -> gradients and updated parameters
 ```
 
-`w_rbragg` is the directly minimized, scaling-optimized weighted residual; the conventional Bragg
-{math}`R_{\mathrm{obs}} = \sum |{\sqrt{I_{\mathrm{obs}}}} - \sqrt{I_{\mathrm{calc}}}| / \sum
-\sqrt{I_{\mathrm{obs}}}`, restricted to {math}`I_{\mathrm{obs}} > 3\sigma`, is reported at every step
-as the standard crystallographic residual but is not itself optimized; each is independently
-scale-optimized against the same simulated intensities. Changes to the discrete problem — beam
-selection, orientation, thickness, tilt coupling — are `Plan -> Plan` preprocessing steps and are
-held fixed during refinement; refinement only varies the structural parameters and any composed
-model components. Composition follows a fixed taxonomy: a value supplied to the forward model is a
-`ModelComponent`; an invariant enforced exactly is a `ConstraintTransform` (or lives inside
-`constrain`); an additive soft cost is a `PenaltyTerm`; a choice of which parameters vary is a
-`TrainableSpec`. The optimizer loop (`engine/refine.py`) is the only stateful, mutating corner of
-the codebase: it clones selected trainable leaves into fresh optimizer variables and never mutates
-caller-owned parameters in place. See [Refinement](refinement.md) for the config surface and CLI
-behaviour, and [Preprocessing](preprocessing.md) for how the `Plan` refinement holds fixed is
-itself constructed.
+Automatic differentiation calculates the gradient of the objective with respect to the selected
+atomic positions, ADPs, and occupancies. Crystallographic constraints are applied before the
+potential is calculated. Molecular constraints, such as hydrogen riding, and soft structural
+restraints can also be included. See [Refinement](refinement.md).
 
-## Reproducibility and provenance
+## Learned model components
 
-Every stage that consumes a checkpoint verifies it before use rather than trusting it. `experiment.lock`
-pins the raw structure and experimental-data files by content hash. `plan.lock` binds a preprocessing
-checkpoint to that input identity, the preprocessing-determining projection of the resolved
-configuration, the exact ordered recipe that produced it, and the producing code version.
-`refinement.lock` extends the same discipline to the refinement stage: it records the `plan.lock`
-this run refined from, the refinement-determining configuration, the code version, and hashes of the
-refined outputs, so a refined structure is independently verifiable against exactly what produced
-it. None of this is a performance optimization incidentally used for provenance; the reverse is
-true — the mechanism exists to make a result verifiable, and checkpoint reuse is a consequence of
-that verification succeeding. See [Reproducibility](reproducibility.md) for the full guarantee and
-its limits.
+Differentiable models can be refined alongside the atomic structure. The current thickness neural
+network takes the experimental rotation coordinate and supplies a thickness to each Bloch-wave
+calculation. Its parameters are updated using the same diffraction objective as the structure.
 
-## Observability
+The same architecture can support other quantities that vary through an experiment. Planned beam
+damage models will describe changes across an ordered dataset. Future components could describe
+other systematic experimental changes or additional scattering contributions, including inelastic
+scattering.
 
-The pure core communicates progress by returning or emitting typed `Event` values
-(`observability.py`); it runs correctly with no logger attached (`NULL_LOGGER`). Logger backends —
-console, CSV, Weights & Biases, Comet — are attached at the application boundary and import their
-vendor SDKs lazily. Scientific results are never routed through the diagnostic `logging` channel,
-and no step reads back another step's logged output as pipeline state; a log is a write-only report.
-See [Observability](observability-guide.md).
+## Logs, locks, and reproducibility
 
-## Design invariants
-
-The following properties are treated as defects when violated, independent of whether a forward
-value looks numerically correct:
-
-- **Differentiability.** The forward path is autograd-differentiable end to end, from
-  `RefinableParams` to the scalar objective. An in-place operation on a leaf tensor, a stray
-  `.item()`/`.detach()`, or non-differentiable indexing on the differentiated path is a defect even
-  when the forward value is unchanged.
-- **Determinism.** Identical inputs produce identical outputs; the simulation carries no hidden
-  state across calls.
-- **Precision as a boundary condition.** The Bloch solve runs at float32/complex64
-  throughout (`core.solver.propagate`); precision is not threaded ad hoc through individual
-  kernels.
-- **Device/dtype preservation.** Kernels preserve the device and dtype of their inputs; the
-  authoritative device for a forward pass is `RefinableParams`'s own device, and invariants are
-  co-located onto it at the point of use.
-- **Strategy as value, not as class hierarchy.** `SolverMethod` is a literal selecting between
-  interchangeable propagators over one shared `BlochSystem`; geometry logic is not duplicated per
-  solver.
-- **Caching discipline.** Geometry-only lookup structures (`StructureFactorGather`, `BeamPlan`
-  constants) may be cached; differentiable values that can go stale, most importantly
-  {math}`F_{\mathbf{g}}`, are never cached.
+Logs report preprocessing, comparison metrics, and refinement progress. Locks record the input
+files, configuration, code version, and generated results. See
+[Reproducibility](reproducibility.md).

--- a/docs/convergence-testing.md
+++ b/docs/convergence-testing.md
@@ -1,0 +1,113 @@
+# Convergence testing
+
+Bloch-wave calculations use a finite subset of an infinite reciprocal lattice and a finite number
+of tilts across each rocking curve. Too few beams or tilts can change the calculated
+intensities; too many increase the cost without improving the result. The required values depend on
+the material, orientation, and thickness.
+
+## Convergence
+
+A simulation is converged when increasing its size produces little to no change in the
+simulated intensities. This is different from agreement with experiment: convergence compares two
+simulations, while refinement compares simulation with measurement. A converged calculation can
+still disagree with experiment because the structure or experimental metadata is wrong.
+
+The main numerical controls are:
+
+| Control | What it changes |
+|---|---|
+| `g_max` | Maximum reciprocal-vector length of beams included in the Bloch-wave simulation. |
+| `sg_max` | Maximum excitation-error magnitude for a beam to enter the simulation at a sampled tilt. |
+| `rocking_curve_sampling` | Number of tilt samples used to integrate each rocking curve. |
+
+Increasing `g_max` or `sg_max` increases the number of beams {math}`N`, with simulation cost scaling
+approximately as {math}`N^3`. Cost scales approximately linearly with
+`rocking_curve_sampling`.
+
+For `g_max`, a useful starting value is the magnitude of the largest reciprocal vector observed in
+the experimental data. This is only a lower bound. Dynamical scattering can reach an observed
+reflection through coupling to unobserved beams outside the measured range, so the SOLVE basis
+normally extends beyond the largest observed {math}`|\mathbf{g}|`. Start the convergence sweep at
+the experimental limit and increase `g_max` until adding the more distant beams no longer changes
+the calculated intensities. The larger structure-factor support required for beam differences is
+derived automatically from `g_max`.
+
+## Convergence testing in diffBloch
+
+Convergence testing should be performed before thickness optimization, orientation optimization,
+or structural refinement. Its purpose is to determine whether the finite beam basis and tilt grid
+are large enough, not whether the model agrees with experiment. These numerical requirements are
+usually insensitive to small orientation corrections and to the structural changes produced by
+refinement. There is little value in optimizing the model first and then discovering that the
+simulation used to optimize it was not converged.
+
+Thickness requires separate consideration. In the thin-crystal, two-beam limit, the rocking-curve
+profile has the form
+
+```{math}
+I(s_g) \propto \operatorname{sinc}^2(\pi t s_g),
+```
+
+where {math}`t` is thickness and {math}`s_g` is excitation error. Its width is therefore inversely
+proportional to thickness: a thinner crystal produces a broader rocking curve. If the actual experimental crystal
+thickness is much thicker than the value used for convergence testing, preserving the same angular sampling requires
+more tilt samples. The user should therefore consider performing convergence testing again if thickness optimization returns a substantially different value.
+
+For each control, diffBloch increases the value by a chosen step, rebuilds the simulation, and
+compares consecutive calculated intensity sets. The sweep stops when their R-factor falls below
+`r_factor_threshold`; failure to reach the threshold within `max_iterations` raises an error.
+
+Convergence testing sweeps `g_max`, `sg_max`, and `rocking_curve_sampling`. It should include
+representative experimental orientations because reciprocal-space density varies through a tilt
+series.
+## API example
+
+Convergence testing is an optional preprocessing step, so its settings are explicit Python values
+rather than fields in `experiment.yaml`:
+
+```python
+from pathlib import Path
+
+from diffBloch.config import load_experiment
+from diffBloch.io import read_experimental_data, read_structure
+from diffBloch.preprocess import (
+    ConvergenceTest,
+    ConvergenceTolerance,
+    build_orientation_plans,
+    converge_numerics,
+    from_experiment,
+    select_beams,
+)
+
+root = Path("examples/Colmey_et_al_2026_Acta_Cryst_A/data/quartz-no-abs")
+cfg, _lock = load_experiment(root)
+structure = read_structure(root / cfg.inputs.structure)
+experimental_data = read_experimental_data(root / cfg.inputs.exp_data)
+setup = from_experiment(structure, experimental_data, cfg)
+plan = build_orientation_plans()(
+    select_beams(cfg.blochwave.to_beam_selection(setup.integration))(setup.plans.combined)
+)
+
+test = ConvergenceTest(
+    g_max_step=0.1,
+    sg_max_step=0.005,
+    tilt_steps_step=2,
+    num_passes=2,
+)
+tolerance = ConvergenceTolerance(
+    r_factor_threshold=0.005,
+    max_iterations=100,
+)
+
+converged_plan = converge_numerics(
+    test,
+    cfg.blochwave.to_rocking_curve(setup.integration),
+    cfg.blochwave.to_policy(),
+    setup.refinement,
+    tolerance,
+)(plan)
+```
+
+Smaller sweep steps resolve the convergence boundary more precisely but require more simulations.
+The threshold states the numerical accuracy required; it should be chosen before inspecting the
+result and reported with the selected hyperparameters.

--- a/docs/hyperparameter-selection.md
+++ b/docs/hyperparameter-selection.md
@@ -1,87 +1,149 @@
 # Hyperparameter selection
 
-Bloch-wave calculations use a finite subset of an infinite reciprocal lattice and a finite number
-of samples across each rocking curve. Too few beams or samples can change the calculated
-intensities; too many increase the cost without improving the result. The required values depend on
-the material, orientation, and thickness.
+Running an experiment requires the user to select numerical, preprocessing, and refinement settings. Hyperparameters control how diffBloch performs the calculation but are not themselves determined by structural refinement.
 
-## Convergence
+These choices are recorded in `experiment.yaml`. diffBloch keeps this file short by supplying
+defaults for common settings and automatically deriving quantities already defined by the input
+data.
 
-A calculation is converged when increasing its numerical resolution produces little to no change in the
-simulated intensities. This is different from agreement with experiment: convergence compares two
-simulations, while refinement compares simulation with measurement. A converged calculation can
-still disagree with experiment because the structure or experimental metadata is wrong.
+This page lists every config, its default, and what it controls. For guidance in selecting appropriate `g_max`, `sg_max`, and `rocking_curve_sampling` specifically, see [Convergence testing](convergence-testing.md).
 
-The main numerical controls are:
+## What is *not* config: auto-filled from CIF/PETS
 
-| Control | What it changes |
-|---|---|
-| `g_max` | Maximum reciprocal-vector length of beams included in the Bloch-wave simulation. |
-| `sg_max` | Maximum excitation-error magnitude for a beam to enter the simulation at a sampled tilt. |
-| `rocking_curve_sampling` | Number of tilt samples used to integrate each rocking curve. |
+Some values that other refinement packages expose as settings are deliberately **not** config
+fields in diffBloch — they are read from the structure `.cif` or `.cif_pets` file at load time, so
+they cannot silently drift from the data they describe:
 
-Increasing `g_max` or `sg_max` increases the number of beams {math}`N`, with simulation cost scaling
-approximately as {math}`N^3` (the propagator diagonalizes or exponentiates the {math}`N \times N`
-structure matrix once per orientation/thickness). Cost scales approximately linearly with
-`rocking_curve_sampling`.
+| Value | Source | Notes |
+|---|---|---|
+| Electron energy / wavelength | `.cif_pets` wavelength | Converted to electron energy for the simulation. |
+| UB orientation matrix | `.cif_pets`, per rotation | Each rotation's own PETS UB seeds its starting orientation, later refined by `preprocess.orientation` (below) if enabled. |
+| Integration semiangle | `.cif_pets` precession angle | The tilt half-width of the rocking curve. |
+| Atomic positions, ADPs, occupancies, symmetry ops | structure `.cif` | All atomic content comes from the structure CIF. |
+| Structure-factor support radius | derived, `2 * blochwave.g_max` | Not independently configurable: a beam set bounded by `\|g\| <= g_max` produces `F(g - h)` terms reaching `2 * g_max`, so a separate support setting could silently contradict the solve cutoff. |
 
-## Convergence testing in diffBloch
+## `sample`
 
-For each control, diffBloch increases the value by a chosen step, rebuilds the simulation, and
-compares consecutive calculated intensity sets. The sweep stops when their R-factor falls below
-`r_factor_threshold`; failure to reach the threshold within `max_iterations` raises an error.
+Fixed sample properties (`diffBloch.config.schema.SampleConfig`).
 
-Convergence testing sweeps `g_max`, `sg_max`, and `rocking_curve_sampling`. It should include
-representative experimental orientations because reciprocal-space density varies through a tilt
-series.
-## API example
+| Field | Default | What it does |
+|---|---|---|
+| `thicknesses` | `(820.0,)` | Seed specimen thickness in Å, one shared value for every rotation — required whenever the seed actually reaches a solve; harmless if `preprocess.optimize_thickness` runs first and overwrites it anyway. |
 
-Convergence testing is an optional preprocessing step, so its settings are explicit Python values
-rather than fields in `experiment.yaml`:
+## `blochwave`
 
-```python
-from pathlib import Path
+Numerical-accuracy controls frozen into the simulation spec (`BlochwaveConfig`).
 
-from diffBloch.config import load_experiment
-from diffBloch.io import read_experimental_data, read_structure
-from diffBloch.preprocess import (
-    ConvergenceTest,
-    ConvergenceTolerance,
-    build_orientation_plans,
-    converge_numerics,
-    from_experiment,
-    select_beams,
-)
+| Field | Default | What it does |
+|---|---|---|
+| `solver.refine` | `"matrix_exp"` | Dynamical solver used during gradient refinement. Must stay `matrix_exp` if `absorption: true` (the alternative, `bloch_eigen`, isn't safe for the non-Hermitian absorptive structure matrix). |
+| `solver.inference` | `"matrix_exp"` | Dynamical solver used for `infer` / preprocessing forward solves. |
+| `absorption` | `false` | Include anomalous absorption as an imaginary structure-factor contribution. |
+| `rsg` | `0.9` | Klar beam-selection cutoff: relative excitation-error radius. |
+| `dsg` | `0.0015` | Klar beam-selection cutoff: excitation-error offset. |
+| `rocking_curve_sampling` | `42` | Tilt samples integrated per rocking curve. See [Convergence testing](convergence-testing.md). |
+| `mosaicity` | `window: 5` | Moving-average mosaic reduction over the sampled tilts (`Mosaicity`). Not estimated from PETS mosaic-spread metadata; pass `mosaicity=None` at the lower-level API for a bare sum. |
+| `fixed_n_segments` | `12` | Number of tilt-coupling segments when `coupling_mode: "union"` and `union_adaptive: false`. |
+| `coupling_mode` | `"union"` | `"union"`: couple the union of excited beams across each tilt-chunk's boundary tilts. `"per_tilt"`: couple only each tilt's own excited beams (more accurate, more expensive). |
+| `g_max` | `2.25` | Solve cutoff (Å⁻¹): maximum reciprocal-vector length of beams entering the Bloch-wave matrix. See [Convergence testing](convergence-testing.md). |
+| `sg_max` | `0.01` | Maximum excitation-error magnitude (Å⁻¹) for a beam to enter the simulation at a sampled tilt. |
+| `union_adaptive` | `true` | Use recursive-bisection adaptive tilt-chunk boundaries instead of `fixed_n_segments` evenly-sized chunks. |
+| `union_max_new_beams_pct` | `0.01` | Adaptive-chunking split threshold: a chunk splits further while its midpoint tilt would add more than this fraction of new beams beyond its boundary union. |
+| `ignore_orientations` | `()` | Zero-based PETS rotation indices to exclude from the whole experiment (damaged/empty/diagnostic frames). |
 
-root = Path("examples/Colmey_et_al_2026_Acta_Cryst_A/data/quartz-no-abs")
-cfg, _lock = load_experiment(root)
-structure = read_structure(root / cfg.inputs.structure)
-experimental_data = read_experimental_data(root / cfg.inputs.exp_data)
-setup = from_experiment(structure, experimental_data, cfg)
-plan = build_orientation_plans()(
-    select_beams(cfg.blochwave.to_beam_selection(setup.integration))(setup.plans.combined)
-)
+## `preprocess`
 
-test = ConvergenceTest(
-    g_max_step=0.1,
-    sg_max_step=0.005,
-    tilt_steps_step=2,
-    num_passes=2,
-)
-tolerance = ConvergenceTolerance(
-    r_factor_threshold=0.005,
-    max_iterations=100,
-)
+Which preprocessing steps run and their search bounds (`PreprocessConfig`).
 
-converged_plan = converge_numerics(
-    test,
-    cfg.blochwave.to_rocking_curve(setup.integration),
-    cfg.blochwave.to_policy(),
-    setup.refinement,
-    tolerance,
-)(plan)
-```
+| Field | Default | What it does |
+|---|---|---|
+| `optimize_orientation` | `true` | Run the per-rotation Nelder-Mead orientation search. |
+| `optimize_thickness` | `true` | Run the per-rotation thickness grid search. |
+| `stage_order` | `"orientation_first"` | Which fitting stage runs first when both are enabled. `"orientation_first"`: fit orientation against the seed thickness, then thickness against the fitted orientation. `"thickness_first"`: reversed. |
+| `orientations_csv` | `None` | Path (relative to the experiment directory) to a `Rotation Index`/`Orientation Matrix` CSV that overwrites every candidate's orientation before the recipe's fitting steps. `optimize_orientation` still controls whether the search then refines from that imported seed. Overridden by the CLI's `--orientations-csv` flag. |
 
-Smaller sweep steps resolve the convergence boundary more precisely but require more simulations.
-The threshold states the numerical accuracy required; it should be chosen before inspecting the
-result and reported with the selected hyperparameters.
+### `preprocess.orientation.nelder_mead`
+
+Bounds for the local orientation search (`NelderMeadOptimizationConfig`).
+
+| Field | Default | What it does |
+|---|---|---|
+| `step_size` | `0.05` | Initial simplex step size, degrees. |
+| `max_iterations` | `60` | Maximum Nelder-Mead iterations (`maxiter`). |
+| `x_tolerance` | `1e-3` | Simplex convergence tolerance on the orientation parameters (`xatol`). |
+| `f_tolerance` | `1e-3` | Simplex convergence tolerance on the objective (`fatol`). |
+| `penalize_fewer_reflections` | `true` | Penalize trial orientations that match fewer reflections than the seed, discouraging the search from drifting to a trivially-easier beam set. |
+
+### `preprocess.thickness`
+
+Bounds for the per-rotation thickness grid search (`ThicknessOptimizationConfig`).
+
+| Field | Default | What it does |
+|---|---|---|
+| `min_thickness` | `5.0` | Lower bound, Å. |
+| `max_thickness` | `2000.0` | Upper bound, Å. |
+| `n_steps` | `100` | Number of evenly-spaced grid candidates (inclusive endpoints). |
+| `plot` | `false` | Write one wR2-vs-thickness PNG per rotation (`<inputs.structure's directory>/thickness_optim`). Reporting-only — never affects the fitted `Plan` and is excluded from the reproducibility digest. |
+
+## `loss_metrics`
+
+The one residual driving both preprocessing search and gradient refinement (`LossMetricsConfig`).
+Top-level, not nested under `refinement`, because it governs preprocessing too.
+
+| Field | Default | What it does |
+|---|---|---|
+| `residual` | `"wr2"` | `"wr2"`, `"least_squares"`, or `"robs"`. Parses into the matching loss (gradient refinement) and per-thickness scores (preprocessing search) function pair — the two stages always agree on one metric. |
+
+## `refinement`
+
+Execution knobs for the default single-stage `refine` (`RefinementConfig`).
+
+| Field | Default | What it does |
+|---|---|---|
+| `steps` | `40` | Number of gradient-refinement epochs. |
+| `optimizer.name` | `"lbfgs"` | `"lbfgs"`, `"adam"`, or `"adamw"`. |
+| `optimizer.lr` | `1e-3` | Learning rate (Adam/AdamW; L-BFGS uses its own internal line search). |
+
+### `refinement.trainable`
+
+Whole-group trainable selections (`TrainableConfig`). Element-filtered selections (e.g. freeze
+hydrogens) are Python/API composition, not config — see `engine.with_hydrogen_riding`.
+
+| Field | Default | What it does |
+|---|---|---|
+| `positions` | `"all"` | `"all"` or `"none"`: whether atomic positions are refined. |
+| `adp` | `"all"` | `"all"` or `"none"`: whether atomic displacement parameters are refined. |
+| `occupancy` | `"none"` | `"all"` or `"none"`: whether site occupancies are refined. |
+
+### `refinement.split`
+
+Train/validation split (`DataSplitConfig`).
+
+| Field | Default | What it does |
+|---|---|---|
+| `train_test` | `false` | `false`: train on every rotation, no held-out set. `true`: hold out an evenly-spaced `val_frac` of rotations from the refinement objective (preprocessing still fits their orientation/thickness) and report their wR2/R_obs separately. |
+| `val_frac` | `0.2` | Fraction of rotations held out when `train_test: true`. Must be strictly between 0 and 1. |
+
+### `refinement.thickness_nn`
+
+Apparent-thickness neural network used by the default refinement path (`ThicknessNNConfig`).
+
+| Field | Default | What it does |
+|---|---|---|
+| `enabled` | `true` | Whether a learned thickness model replaces the fixed per-rotation seed during refinement. |
+| `num_samples` | `40` | Number of thickness samples the network's input encoding uses. |
+| `sample_thickness` | `false` | Whether thickness itself is sampled as part of the network's forward pass. |
+| `form` | `"min_thickness"` | Functional form of the network's output (currently only one implemented). |
+| `min_thickness` | `100.0` | Lower bound, Å, for the network's thickness output. |
+| `max_thickness` | `2000.0` | Upper bound, Å, for the network's thickness output. |
+| `init_seed` | `0` | Random seed for the network's initial weights. |
+
+## `inputs`
+
+Input file references, relative to the experiment directory only (`Inputs`).
+
+| Field | Default | What it does |
+|---|---|---|
+| `structure` | required | Relative path to the structure `.cif`. |
+| `exp_data` | required | Relative path to a `.cif_pets`. |
+| `load_hydrogens` | `false` | Include hydrogen atom sites from the structure CIF (molecular crystals). |

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,8 @@ diffBloch performs the refinement as two complementary values: a crystal structu
 | [Architecture](architecture.md) | Why dynamical diffraction needs a Bloch-wave simulation, and how the pieces fit together. |
 | [Inputs](inputs.md) | The starting structure and rocking-curve data a refinement needs. |
 | [Preprocessing](preprocessing.md) | Fitting crystal orientation and specimen thickness before the structure is touched. |
-| [Hyperparameter selection](hyperparameter-selection.md) | Choosing beam and rocking-curve settings using convergence tests. |
+| [Convergence testing](convergence-testing.md) | Choosing beam and rocking-curve settings using convergence tests. |
+| [Config reference](hyperparameter-selection.md) | Every `experiment.yaml` switch, its default, and what's auto-filled from CIF/PETS instead. |
 | [Refinement](refinement.md) | The optimization loop: constraints, restraints, and thickness models alongside the structure. |
 | [Reproducibility](reproducibility.md) | How `experiment.lock`, `plan.npz`, and `plan.lock` pin a fitted `Plan` so a result can be reproduced exactly. |
 | [Observability](observability-guide.md) | Tracking wR2, R_obs, and diffraction loss as a run progresses. |
@@ -108,6 +109,7 @@ If you use diffBloch in your research, please cite it:
 architecture.md
 inputs.md
 preprocessing.md
+convergence-testing.md
 hyperparameter-selection.md
 reproducibility.md
 refinement.md

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -1,7 +1,7 @@
 # Preprocessing and `Plan`
 
 Dynamical diffraction is extremely sensitive to crystal orientation and thickness. diffBloch
-therefore fits this experimental metadata before refining the structure and stores it in a `Plan`.
+therefore determines this experimental metadata before refining the structure and stores it in a `Plan`.
 
 PETS2 reduces continuous-rotation data into overlapping **virtual frames**, allowing complete
 rocking curves to be integrated and partial reflections to be rejected
@@ -10,44 +10,158 @@ virtual frame by sampled tilt sub-orientations and sums their simulated intensit
 
 ## Orientation
 
-PETS2 supplies a best-fit **UB matrix**: {math}`B` maps the reciprocal lattice and {math}`U`
-orients that lattice in the laboratory frame. For virtual frame {math}`i`, diffBloch constructs
+PETS2 supplies a **UB matrix**. The reciprocal-basis matrix {math}`B` is calculated from the unit
+cell and maps integer reflection indices {math}`(h,k,l)` to reciprocal-space vectors. The matrix
+{math}`U` places that reciprocal basis in the laboratory coordinate system. Their product {math}`UB`
+therefore maps a reflection index directly into the measured laboratory geometry.
+
+diffBloch separates the two matrices using
+
+```{math}
+U = (UB)B^{-1}.
+```
+
+For virtual frame {math}`i`, the PETS goniometer angles are then applied in their recorded order:
 
 ```{math}
 M_i = R_z(\omega_i)R_x(\alpha_i)R_y(\beta_i)(UB)B^{-1},
 ```
 
-where {math}`\alpha` is the main varying goniometer angle.
+where {math}`\alpha_i`, {math}`\beta_i`, and {math}`\omega_i` are given in degrees and
+{math}`\alpha_i` is the main scan angle. {math}`M_i` is the starting crystal orientation for that
+virtual frame.
 
-Using a fixed trial thickness and the starting structure, orientation optimization searches nearby
-orientations for better agreement with experiment. Two approaches are implemented, selected by
-`preprocess.orientation.method`:
+Using the current thickness and starting unrefined structure, diffBloch searches for a small
+correction to each {math}`M_i`. A trial correction is described by three angles
+{math}`(\Delta\alpha,\Delta\beta,\Delta\omega)` and applied as
 
-| Method | Difference |
-|---|---|
-| `palatinus_modified_simplex` (default) | Searches progressively smaller tilts around the starting orientation; robust when the PETS2 estimate is close. |
-| `nelder_mead` | Local simplex search over all three goniometer-correction angles directly (`scipy.optimize.minimize`); efficient but sensitive to the starting orientation and the fixed `step_size` neighbourhood it explores. |
+```{math}
+M_i' = M_i R_z(\Delta\omega)R_x(\Delta\alpha)R_y(\Delta\beta).
+```
 
-Bayesian optimization is not implemented.
+The Bloch-wave intensities are recalculated for each trial and compared with the observed
+intensities using `loss_metrics.residual`, which defaults to `wr2`.
 
-## Thickness
+### Orientation-search method
 
-Real crystals have irregular shapes. diffBloch offers two
-approaches, both using the starting structure to improve agreement with experiment:
+diffBloch applies the general Nelder--Mead optimization algorithm
+([Nelder and Mead, 1965](https://doi.org/10.1093/comjnl/7.4.308)) to orientation refinement.
 
-| Method | Difference |
-|---|---|
-| Grid search | Selects the best mean thickness independently for each rotation. |
-| Neural network | Learns how apparent thickness varies smoothly with rotation angle. |
+Nelder--Mead minimizes the orientation residual without requiring its derivatives. For the three
+correction angles, the search holds four trial points: zero correction and one point displaced by
+`step_size` along each angle. These four points form a simplex.
 
-The default workflow optimizes orientation first and thickness second when both stages are enabled.
-Either stage can be disabled independently:
+Each point is evaluated by running the Bloch-wave calculation and comparing its intensities with
+experiment. Nelder--Mead ranks the four residuals and replaces the worst point by reflecting it
+through the opposite face of the simplex. Depending on the new residual, it may expand farther in
+that direction, contract toward the better points, or shrink the whole simplex around the best
+point. The simplex therefore moves and changes size as it approaches a local minimum. The final
+three coordinates are applied to the PETS orientation as
+{math}`(\Delta\alpha,\Delta\beta,\Delta\omega)`.
+
+This is a local, unconstrained search. `step_size` defines only the initial simplex; it neither
+limits the correction angles nor guarantees that the search finds the global minimum. The PETS UB
+matrix must already provide a close starting orientation.
+
+| Method | Search | Status |
+|---|---|---|
+| `nelder_mead` | Varies all three correction angles simultaneously using the four-point simplex described above. | Implemented and used by the default preprocessing path. |
+
+
+| Parameter | Default | Meaning |
+|---|---:|---|
+| `step_size` | `0.05` degrees | Edge length of the initial simplex. The four starting points are zero correction and one positive step along each correction angle. This is not a hard search bound. |
+| `max_iterations` | `60` | Maximum number of simplex iterations for one rotation. |
+| `x_tolerance` | `1e-3` degrees | Convergence tolerance for changes in the correction angles. |
+| `f_tolerance` | `1e-3` | Convergence tolerance for changes in the comparison residual. |
+| `penalize_fewer_reflections` | `true` | Prevents a trial from appearing better only because its orientation produces a smaller matched-reflection set. |
 
 ```yaml
 preprocess:
-  optimize_orientation: true
+  orientation:
+    nelder_mead:
+      step_size: 0.05
+      max_iterations: 60
+      x_tolerance: 0.001
+      f_tolerance: 0.001
+      penalize_fewer_reflections: true
+```
+
+### Routing on cell size
+
+The coupled orientation search diagonalizes (or exponentiates) the structure matrix {math}`A` once
+per trial, an {math}`O(N^3)` operation in the beam count {math}`N`, and {math}`N` grows with
+unit-cell volume. Above a fixed volume threshold, diffBloch skips a per-trial integrity check in the
+search that costs proportionally more on a large coupled beam set, without changing the search
+itself — the fitted orientation is always re-scored under the full check once the search settles.
+Below the threshold (quartz, at {math}`\sim 113\ \text{Å}^3`, included) the check runs on every
+trial. This routing is built with {func}`diffBloch.preprocess.pipeline.fork`, which picks one of two
+step lists from the structure-factor grid before the recipe is checkpointed, so a committed `Plan` is
+unaffected by which branch produced it. The thickness fit has no such split and always runs the same
+path regardless of cell size.
+
+## Thickness
+
+Real crystals have irregular shapes. The illuminated area therefore contains regions of different
+thickness, and the thickness distribution changes as the crystal orientation changes. Under the
+column approximation, each region may be simulated at its local thickness and the resulting intensities summed incoherently.
+
+Multiple scattering transfers amplitude between coupled reflections as the electron wave propagates through the crystal.
+Pendellösung oscillations therefore cause the intensity of an observed reflection to rise and fall
+with thickness. A small change in thickness can produce a large, reflection-specific change in
+intensity.
+
+diffBloch represents the thickness distribution by an effective mean thickness for each orientation. It can use one shared effective thickness for the complete experiment, determine a separate mean value for each orientation, or learn a smooth orientation-dependent mean thickness distribution:
+
+| Method | Difference |
+|---|---|
+| Shared thickness | Uses the value in `sample.thicknesses` for every orientation. |
+| Grid search | Selects the lowest-residual thickness independently for each orientation. |
+| Neural network | Learns how apparent thickness varies smoothly with orientation angle. |
+
+We normally use one shared value for orientation refinement if the approximate specimen thickness is known:
+
+```yaml
+sample:
+  thicknesses: [850.0]  # Angstroms
+
+preprocess:
   optimize_thickness: false
 ```
+
+If the thickness is not known, it is recommended to run thickness optimization before orientation optimization or structural refinement. The result establishes thickness before other parameters are
+changed. A representative value can then be used as the shared thickness if separate values are not
+required.
+
+The grid search evaluates `n_steps` evenly spaced thicknesses from `min_thickness` to
+`max_thickness`, inclusive, for every orientation. Each candidate is passed through the Bloch-wave
+calculation and scored against experiment. The lowest-residual thickness is stored for that
+orientation. The search uses the starting unrefined structure, so its purpose is to establish the
+experimental geometry before atomic parameters are changed.
+
+```yaml
+preprocess:
+  optimize_thickness: true
+  thickness:
+    min_thickness: 100.0
+    max_thickness: 2000.0
+    n_steps: 100
+    plot: true
+```
+
+With `plot: true`, diffBloch writes one residual-versus-thickness PNG for each orientation to
+`thickness_optim/` beside the structure input. Every tested thickness is shown and a dashed line
+marks the selected minimum. These plots show whether the minimum is well defined, whether different
+orientations favor the same thickness range, and whether the chosen search interval is too narrow.
+
+## Numerical convergence
+
+Determine `g_max`, `sg_max`, and `rocking_curve_sampling` before optimizing thickness or
+orientation and before refining the structure. Numerical convergence depends mainly on the
+simulation basis and integration grid, not on whether the starting orientation or atomic structure
+has already been optimized. Thickness is the important exception because it changes the width of
+the rocking curve. See [Convergence testing](convergence-testing.md) for the convergence procedure
+and the thickness-dependent sampling check.
 
 ## The `Plan`
 
@@ -100,6 +214,12 @@ attaches the configured mosaic reduction. The configured reduction currently def
 mosaic-spread metadata. Passing `mosaicity=None` at the lower-level API keeps the bare `PlainSum`.
 Rocking integration and mosaicity are parts of the built orientation plan, not separately displayed
 default stages.
+
+Mosaicity describes the spread of crystal orientations within the illuminated volume. Different
+mosaic domains are slightly misoriented, so a reflection is excited over a wider angular range than
+it would be in a single perfectly oriented crystal. Mosaicity therefore broadens the calculated
+rocking curve and changes the integrated intensity, especially for reflections whose excitation
+condition varies rapidly with angle.
 
 ## API shape: from experiment records to an initial `Plan`
 
@@ -203,21 +323,3 @@ orientations = require_built_plans(plan)
 print(len(orientations))
 print(plan.structure_factor_grid.structure_factor_hkl.shape)
 ```
-
-## Routing on cell size
-
-The coupled orientation search diagonalizes (or exponentiates) the structure matrix {math}`A` once
-per trial, an {math}`O(N^3)` operation in the beam count {math}`N`, and {math}`N` grows with
-unit-cell volume. Above a fixed volume threshold, diffBloch skips a per-trial integrity check in the
-search that costs proportionally more on a large coupled beam set, without changing the search
-itself — the fitted orientation is always re-scored under the full check once the search settles.
-Below the threshold (quartz, at {math}`\sim 113\ \text{Å}^3`, included) the check runs on every
-trial. This routing is built with {func}`diffBloch.preprocess.pipeline.fork`, which picks one of two
-step lists from the structure-factor grid before the recipe is checkpointed, so a committed `Plan` is
-unaffected by which branch produced it.
-
-Numerical convergence testing — sweeping `g_max`, `sg_max`, and rocking-curve sampling until the
-simulated intensities stop changing — uses the same `Plan -> Plan` step shape, built with
-{func}`diffBloch.preprocess.driver.converge_numerics`. See
-[Hyperparameter selection](hyperparameter-selection.md) for the physics behind that sweep and a
-runnable example.


### PR DESCRIPTION
## Summary

Extracts the documentation half of #87 (bcolmey's `pets-cell-and-docsite` branch) into a standalone, immediately-mergeable PR. Every passage that documented #87-only behavior has been pruned or restored to main's semantics, so the docsite stays accurate against main if this lands first. #87 then shrinks to its code changes plus the feature docs that belong with them.

## What's included

- **New `docs/convergence-testing.md`** — the convergence-testing content carved out of `hyperparameter-selection.md`: what convergence means vs agreement with experiment, the `g_max`/`sg_max`/`rocking_curve_sampling` controls and their cost scaling, the thin-crystal `sinc²` argument for why thickness changes the required tilt sampling, and the runnable `converge_numerics` API example (kept verbatim from main's current example — correct paths and settings).
- **`docs/hyperparameter-selection.md`** — rebuilt as a complete config reference: every `experiment.yaml` field with its default and meaning, plus the "auto-filled from CIF/PETS" table for values that are deliberately not config. Every default was verified against main's `schema.py`/`specs.py` field by field.
- **`docs/preprocessing.md`** — expanded substantially: the UB-matrix/goniometer-angle math, a real explanation of the Nelder–Mead orientation search and its parameters (main's current page still documents a `palatinus_modified_simplex` method that no longer exists in the schema), thickness grid-search guidance with the `plot: true` diagnostic, and a new "Numerical convergence" section pointing at the new page. Main's API-composition sections (`Plan -> Plan` steps, the composing example, the checkpoint-loading example) are retained — they remain accurate on main.
- **`docs/architecture.md`** — condensed from a deep implementation narrative into a high-level pipeline overview (bcolmey's restructure, carried as-is apart from the accuracy pruning below).
- **`docs/index.md`** — navigation split: "Convergence testing" and "Config reference" become separate entries; the new page joins the toctree.
- **`docs/api/preprocess.md`** — one wording tweak from the branch; the `steps.mosaicity` automodule entry is retained (the module exists on main).

## What was pruned, and why

The branch's docs describe three feature pillars that exist only in #87's code. Publishing them now would make the docsite document unshipped behavior:

| Pruned | Where it appeared | What the PR says instead |
|---|---|---|
| `inputs.multi_dataset` pooling | inputs.md section, config rows, architecture/preprocessing passages | Removed; returns with #87 |
| PETS unit-cell authority + 1%/5% mismatch checks | dedicated sections in inputs/preprocessing/architecture, auto-fill table row | Removed; returns with #87 |
| Gaussian mosaicity from PETS `_diffrn_measurement_details` | preprocessing/architecture math, `blochwave.mosaicity: true` default | Restored to main's semantics: `Mosaicity(window=5)` moving-average reduction, not PETS-derived |
| `stage_order: thickness_first` default | config table, architecture prose | Main's actual default `orientation_first`, both options documented |
| `rocking_curve_sampling: 50`, `snap_to_standard_energy` | config table, auto-fill table | Main's actual default `42`; energy row without the snap behavior |

`docs/inputs.md` and `docs/api/specs.md` ended up untouched — their branch diffs were entirely feature documentation. Likewise the three source files whose changes looked docstring-only (`core/crystal.py`, `engine/plan.py`, `preprocess/coupling.py`): AST comparison confirmed no behavioral change, but all three rewrite the cell-correction story to #87's PETS-authority semantics (one even references a `MosaicAverage` class that doesn't exist on main), so they stay with #87. The `README.md`/`REFERENCES.md`/`CITATION.cff` changes were also left out as neither docstring nor docsite.

## Verification

- `sphinx-build -W -b html docs …` (CI's strict settings, warnings as errors): **build succeeded**.
- Swept the result for `multi_dataset`, Gaussian/apparent mosaicity, cell-authority language, stale `examples/experiments/*` paths, old `diffbloch run <cmd>` spellings, and dead intra-doc anchors: none remain.
- Config-reference defaults cross-checked against main's `SampleConfig`, `BlochwaveConfig`, `PreprocessConfig`, `NelderMeadSearch`, `ThicknessGrid`, `ApparentThicknessNetwork`, `OptimizerConfig`, `DataSplitConfig`, and `Inputs`.

## Relationship to #87

All documentation content here is bcolmey's work from #87, minimally edited for main-accuracy. When #87 lands, its docs commits will conflict with these files; the resolution is mechanical (take #87's feature passages back on top of this structure). Alternatively #87 can rebase and drop its doc hunks after this merges.

