### PR TITLE
Pool rotations from multiple PETS datasets

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -87,6 +87,31 @@ preprocess:
   optimize_thickness: false
 ```
 
+## Pooling multiple datasets
+
+`inputs.exp_data` is a single path by default. Set `inputs.multi_dataset: true` and give
+`exp_data` a list of two or more paths to pool rotations from several `.cif_pets` files into one
+experiment -- e.g. a damage series, or repeat measurements of the same crystal:
+
+```yaml
+inputs:
+  structure: enantiomer_1.cif
+  multi_dataset: true
+  exp_data:
+    - undamaged/frame_1.cif_pets
+    - undamaged/frame_2.cif_pets
+```
+
+Each file keeps its own wavelength-derived energy, UB matrix/cell, and mean-inner-potential
+correction. Rotations are concatenated file-by-file with a running offset, so `rotation_index`
+stays globally unique across the pool (the first file's rotations are `0..N-1`, the second file's
+are `N..N+M-1`, and so on) rather than every file restarting at `0` -- `ignore_orientations`, the
+train/validation split, and an imported orientation CSV all key off this pooled index. Pooled files
+must share one rocking-curve integration semiangle: diffBloch builds a single shared
+rocking-curve/beam-selection geometry for the whole experiment, so files recorded with different
+precession angles cannot currently be mixed. `multi_dataset` defaults to `false`, and a single
+`exp_data` path behaves exactly as before -- nothing about the single-dataset path changes.
+
 
 ## Generated refinement artifacts
 

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -227,7 +227,9 @@ def converge_experiment(
     rocking = cfg.blochwave.to_rocking_curve(setup.integration)
     simulation = cfg.blochwave.to_policy()
     dstar_maxes = [
-        record.dstar_max for record in _as_records(experimental_data) if record.dstar_max is not None
+        record.dstar_max
+        for record in _as_records(experimental_data)
+        if record.dstar_max is not None
     ]
     starting_g_max = min(dstar_maxes) if dstar_maxes else simulation.g_max
     plan = pipeline(

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -56,7 +56,7 @@ from diffBloch.engine import (
     build_refinement_problem,
     run_refinement_model,
 )
-from diffBloch.io import read_experimental_data, read_structure
+from diffBloch.io import ExperimentalRecord, read_experimental_data, read_structure
 from diffBloch.observability import (
     NULL_LOGGER,
     DeviceSelected,
@@ -140,6 +140,35 @@ def _select_device(device: Device | None, *, logger: Logger = NULL_LOGGER) -> De
     return selected
 
 
+def _read_experimental_data(
+    root: Path, cfg: ExperimentConfig
+) -> ExperimentalRecord | tuple[ExperimentalRecord, ...]:
+    """Read ``cfg.inputs.exp_data`` -- one record, or one per pooled file when ``multi_dataset``.
+
+    The single call site every ``read_experimental_data`` caller in this module goes through, so the
+    single-dataset/pooled dispatch lives in exactly one place. Order matches ``inputs.exp_data``,
+    which is also the order :func:`~diffBloch.preprocess.experiment.from_experiment` pools rotations
+    in -- callers that need a flat array aligned to the pooled ``rotation_index`` space (e.g. the
+    thickness-NN's per-rotation alphas) can rely on that order without recomputing it.
+    """
+    if cfg.inputs.multi_dataset:
+        assert isinstance(cfg.inputs.exp_data, list)
+        return tuple(read_experimental_data(root / path) for path in cfg.inputs.exp_data)
+    assert isinstance(cfg.inputs.exp_data, str)
+    return read_experimental_data(root / cfg.inputs.exp_data)
+
+
+def _as_records(
+    experimental_data: ExperimentalRecord | tuple[ExperimentalRecord, ...],
+) -> tuple[ExperimentalRecord, ...]:
+    """Normalize :func:`_read_experimental_data`'s return to a tuple, single or pooled alike."""
+    return (
+        (experimental_data,)
+        if isinstance(experimental_data, ExperimentalRecord)
+        else experimental_data
+    )
+
+
 # Above this unit-cell volume the coupled orientation search runs its coarse pass with the
 # gather integrity checks skipped (the large-cell fast path); at or below it the search stays the
 # exact, fully-validated path. The eigensolve is O(N^3) in the beam count
@@ -166,10 +195,12 @@ def converge_experiment(
     Starting ``g_max`` prefers the PETS file's own ``dstarmax`` (its processing-resolution cutoff,
     :attr:`~diffBloch.io.record.ExperimentalRecord.dstar_max`) when present; a PETS version that
     doesn't record it (or a file where the tag is otherwise absent) falls back to the experiment's
-    configured ``blochwave.g_max``, the previous manual-only behaviour. ``sg_max`` and rocking-curve
-    tilt steps still start from the configured simulation settings. The sweep then follows the
-    defaults owned by :class:`ConvergenceTest` and :class:`ConvergenceTolerance`, returning the
-    smallest settled values found.
+    configured ``blochwave.g_max``, the previous manual-only behaviour. With ``inputs.multi_dataset``,
+    the smallest ``dstar_max`` across the pooled files is used -- a conservative starting point within
+    what every pooled dataset actually supports. ``sg_max`` and rocking-curve tilt steps still start
+    from the configured simulation settings. The sweep then follows the defaults owned by
+    :class:`ConvergenceTest` and :class:`ConvergenceTolerance`, returning the smallest settled values
+    found.
     """
     root = Path(experiment_dir)
     device = _select_device(device, logger=logger)
@@ -178,7 +209,7 @@ def converge_experiment(
     structure = read_structure(
         root / cfg.inputs.structure, load_hydrogens=cfg.inputs.load_hydrogens
     )
-    experimental_data = read_experimental_data(root / cfg.inputs.exp_data)
+    experimental_data = _read_experimental_data(root, cfg)
     setup = from_experiment(structure, experimental_data, cfg)
     refinement = replace(setup.refinement, params=setup.refinement.params.to(device))
     combined = setup.plans.combined
@@ -195,9 +226,10 @@ def converge_experiment(
     )
     rocking = cfg.blochwave.to_rocking_curve(setup.integration)
     simulation = cfg.blochwave.to_policy()
-    starting_g_max = (
-        experimental_data.dstar_max if experimental_data.dstar_max is not None else simulation.g_max
-    )
+    dstar_maxes = [
+        record.dstar_max for record in _as_records(experimental_data) if record.dstar_max is not None
+    ]
+    starting_g_max = min(dstar_maxes) if dstar_maxes else simulation.g_max
     plan = pipeline(
         [
             select_beams(cfg.blochwave.to_beam_selection(setup.integration)),
@@ -490,14 +522,18 @@ def refine_experiment(
     thickness_nn: ApparentThicknessNN | None = None
     raw_alphas: np.ndarray | None = None
     if thickness_spec.enabled:
-        experimental_data = read_experimental_data(root / cfg.inputs.exp_data)
-        raw_alphas = experimental_data.alphas
+        experimental_data = _read_experimental_data(root, cfg)
+        # Concatenated in the same file order from_experiment pools rotation_index in, so
+        # raw_alphas[rotation_index] is always the right dataset's alpha, pooled or not.
+        raw_alphas = np.concatenate(
+            [np.asarray(record.alphas) for record in _as_records(experimental_data)]
+        )
         thickness_nn = ApparentThicknessNN(
             bounds=ThicknessBounds(
                 thickness_spec.min_thickness,
                 thickness_spec.max_thickness,
             ),
-            normalized_alphas=_normalized_pets_alphas(experimental_data.alphas),
+            normalized_alphas=_normalized_pets_alphas(raw_alphas),
             form=thickness_spec.form,
             sample_thickness=thickness_spec.sample_thickness,
             num_samples=thickness_spec.num_samples,
@@ -762,7 +798,7 @@ def _preprocess(
     structure = read_structure(
         root / cfg.inputs.structure, load_hydrogens=cfg.inputs.load_hydrogens
     )
-    experimental_data = read_experimental_data(root / cfg.inputs.exp_data)
+    experimental_data = _read_experimental_data(root, cfg)
     setup = from_experiment(structure, experimental_data, cfg)
     validation_rotation_indices = frozenset(
         op.pattern.rotation_index for op in setup.plans.validation.orientations

--- a/src/diffBloch/config/manifest.py
+++ b/src/diffBloch/config/manifest.py
@@ -30,10 +30,14 @@ class InputLock(BaseModel):
 
 
 class ExperimentLock(BaseModel):
-    """``experiment.lock``: exact input identity, never generated outputs."""
+    """``experiment.lock``: exact input identity, never generated outputs.
+
+    ``experimental_data`` is one lock for a single dataset or a list in ``inputs.exp_data`` order
+    for a combined experiment.
+    """
 
     structure: InputLock
-    experimental_data: InputLock
+    experimental_data: InputLock | list[InputLock]
 
 
 class ArtifactHash(BaseModel):
@@ -133,7 +137,7 @@ def load_experiment(directory: str | Path) -> tuple[ExperimentConfig, Experiment
     lock_path = root / "reproducibility" / "experiment.lock"
     lock = ExperimentLock.model_validate(yaml.safe_load(lock_path.read_text()))
     _verify_input(root, cfg.inputs.structure, lock.structure)
-    _verify_input(root, cfg.inputs.exp_data, lock.experimental_data)
+    _verify_experimental_data(root, cfg.inputs.exp_data, lock.experimental_data)
     return cfg, lock
 
 
@@ -329,3 +333,24 @@ def _verify_input(root: Path, ref: str, lock: InputLock) -> None:
     actual = input_lock_for(path, ref=ref)
     if actual.sha256 != lock.sha256 or actual.bytes != lock.bytes:
         raise ValueError(f"input drift detected for {ref}")
+
+
+def _verify_experimental_data(
+    root: Path, ref: str | list[str], lock: InputLock | list[InputLock]
+) -> None:
+    """Verify either one experimental file or every file in a combined experiment."""
+    if isinstance(ref, list) or isinstance(lock, list):
+        if not isinstance(ref, list) or not isinstance(lock, list):
+            raise ValueError(
+                "experiment.lock experimental_data shape does not match inputs.exp_data "
+                "(one is a list, the other is not)"
+            )
+        if len(ref) != len(lock):
+            raise ValueError(
+                f"experiment.lock has {len(lock)} experimental_data entries, "
+                f"inputs.exp_data has {len(ref)}"
+            )
+        for one_ref, one_lock in zip(ref, lock, strict=True):
+            _verify_input(root, one_ref, one_lock)
+        return
+    _verify_input(root, ref, lock)

--- a/src/diffBloch/config/schema.py
+++ b/src/diffBloch/config/schema.py
@@ -417,22 +417,51 @@ class PreprocessConfig(_StrictConfig):
     orientations_csv: str | None = None
 
 
+def _relative_path_only(value: str) -> str:
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError("input references must be relative paths within the experiment directory")
+    return value
+
+
 class Inputs(_StrictConfig):
     """Input references — relative to the experiment directory only (no project-root paths)."""
 
     structure: str
-    exp_data: str
+    exp_data: str | list[str]
+    # Pool rotations from every file in exp_data into one experiment. False (default) keeps
+    # exp_data a single path -- the original single-dataset behavior, unchanged. True requires
+    # exp_data to be a list of 2+ paths; every pooled file must share one rocking-curve integration
+    # semiangle, since diffBloch builds a single shared rocking-curve geometry for the whole
+    # (pooled) experiment -- see preprocess.experiment.from_experiment.
+    multi_dataset: bool = False
     load_hydrogens: bool = False  # include hydrogen atom sites (molecular crystals; off by default)
 
-    @field_validator("structure", "exp_data")
+    @field_validator("structure")
     @classmethod
-    def _relative_path_only(cls, value: str) -> str:
-        path = Path(value)
-        if path.is_absolute() or ".." in path.parts:
+    def _structure_relative_path(cls, value: str) -> str:
+        return _relative_path_only(value)
+
+    @field_validator("exp_data")
+    @classmethod
+    def _exp_data_relative_paths(cls, value: str | list[str]) -> str | list[str]:
+        if isinstance(value, list):
+            return [_relative_path_only(v) for v in value]
+        return _relative_path_only(value)
+
+    @model_validator(mode="after")
+    def _multi_dataset_shape(self) -> Inputs:
+        if self.multi_dataset:
+            if not isinstance(self.exp_data, list) or len(self.exp_data) < 2:
+                raise ValueError(
+                    "inputs.multi_dataset=true requires inputs.exp_data to be a list of 2+ paths"
+                )
+        elif isinstance(self.exp_data, list):
             raise ValueError(
-                "input references must be relative paths within the experiment directory"
+                "inputs.exp_data is a list but inputs.multi_dataset is false -- set "
+                "multi_dataset=true to pool multiple datasets, or use a single path"
             )
-        return value
+        return self
 
 
 class ExperimentConfig(_StrictConfig):
@@ -458,10 +487,15 @@ class ExperimentConfig(_StrictConfig):
         (W&B/Comet hyperparameters, the written summary) reads the run's settings from this one
         event instead of being handed the config object.
         """
+        experimental_data = (
+            ", ".join(self.inputs.exp_data)
+            if isinstance(self.inputs.exp_data, list)
+            else self.inputs.exp_data
+        )
         return ExperimentDeclared(
             name=self.name,
             structure=self.inputs.structure,
-            experimental_data=self.inputs.exp_data,
+            experimental_data=experimental_data,
             optimizer=self.refinement.optimizer.name,
             seed_thicknesses=tuple(self.sample.thicknesses),
             integration_semiangle=integration.semiangle,

--- a/src/diffBloch/preprocess/experiment.py
+++ b/src/diffBloch/preprocess/experiment.py
@@ -14,6 +14,8 @@ The structure side lives here so the structure/experimental split mirrors the tw
 
 from __future__ import annotations
 
+import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import numpy as np
@@ -158,7 +160,7 @@ class RefinementSetup:
 
 def from_experiment(
     structure: StructureRecord,
-    experimental_data: ExperimentalRecord,
+    experimental_data: ExperimentalRecord | Sequence[ExperimentalRecord],
     config: ExperimentConfig,
 ) -> ExperimentSetup:
     """Construct the geometry ``Plan`` pair + structure ``RefinementSetup`` from parsed inputs.
@@ -180,6 +182,18 @@ def from_experiment(
     grid and the 000 transmitted beam is present). The per-orientation ``sg_max`` / rsg-dsg
     pruning is the later ``select_beams`` step.
 
+    ``experimental_data`` is a single :class:`~diffBloch.io.record.ExperimentalRecord` for the
+    ordinary single-dataset experiment, or a sequence of them (``inputs.multi_dataset``) to pool
+    rotations from several PETS files into one experiment -- e.g. a damage series or repeat
+    measurements of the same crystal. Each file keeps its own wavelength-derived energy, UB
+    matrix/cell, and mean-inner-potential correction; rotations are concatenated file-by-file with a
+    running offset, so ``rotation_index`` stays globally unique across the pool (rather than
+    restarting at 0 per file) -- every place that keys off it (``ignore_orientations``, the
+    train/validation split, orientation-CSV import, the thickness-NN's per-rotation lookup) then
+    keeps working unmodified. Pooled files must share one rocking-curve integration semiangle: the
+    recipe builds a single shared rocking-curve/beam-selection geometry for the whole experiment, so
+    files recorded with different precession angles cannot currently be mixed.
+
     This is intentionally a module-level function rather than ``ExperimentSetup.from_*``: it is the
     single documented public boundary of the preprocess pipeline (records + config -> setup), and it
     returns a *composite* of two products rather than constructing one domain object. The per-object
@@ -187,37 +201,55 @@ def from_experiment(
     (``StructureFactorGrid.from_cell_for_beam_cutoff``, ``CandidatePlan.seed``,
     ``RefinementSetup.from_structure``).
     """
+    records = (
+        (experimental_data,)
+        if isinstance(experimental_data, ExperimentalRecord)
+        else tuple(experimental_data)
+    )
+    if len(records) > 1:
+        semiangles = [record.integration_semiangle for record in records]
+        if not math.isclose(max(semiangles), min(semiangles)):
+            raise ValueError(
+                "pooled datasets (inputs.multi_dataset) must share one rocking-curve integration "
+                f"semiangle; got {sorted(set(semiangles))}"
+            )
+
     solve_cutoff = config.blochwave.g_max
     grid = StructureFactorGrid.from_cell_for_beam_cutoff(structure.unit_cell, solve_cutoff)
-    energy = snap_to_standard_energy(wavelength2energy(experimental_data.wavelength))
     beam_hkl = seed_beam_hkl(grid, g_max=solve_cutoff)
-    orientations = orientation_matrices(
-        experimental_data.ub_matrix,
-        experimental_data.cell_parameters,
-        experimental_data.alphas,
-        experimental_data.betas,
-        experimental_data.omegas,
-    )
     refinement_setup = RefinementSetup.from_structure(structure)
-    u0 = _mean_inner_potential(
-        grid, refinement_setup, energy=energy, absorption=config.blochwave.to_absorption()
-    )
-    all_plans = tuple(
-        CandidatePlan.seed(
-            beam_hkl,
-            PatternBatch.from_experimental_record(
-                experimental_data,
-                zone_axis_id=int(zone_id),
-                rotation_index=index,
-            ),
-            energy=energy,
-            thickness=config.sample.thicknesses,
-            orientation=orientations[index],
-            u0=u0,
-        )
-        for index, zone_id in enumerate(experimental_data.zone_axis_ids)
-    )
+    absorption = config.blochwave.to_absorption()
 
+    pooled_plans: list[CandidatePlan] = []
+    rotation_offset = 0
+    for record in records:
+        energy = snap_to_standard_energy(wavelength2energy(record.wavelength))
+        orientations = orientation_matrices(
+            record.ub_matrix,
+            record.cell_parameters,
+            record.alphas,
+            record.betas,
+            record.omegas,
+        )
+        u0 = _mean_inner_potential(grid, refinement_setup, energy=energy, absorption=absorption)
+        pooled_plans.extend(
+            CandidatePlan.seed(
+                beam_hkl,
+                PatternBatch.from_experimental_record(
+                    record,
+                    zone_axis_id=int(zone_id),
+                    rotation_index=rotation_offset + local_index,
+                ),
+                energy=energy,
+                thickness=config.sample.thicknesses,
+                orientation=orientations[local_index],
+                u0=u0,
+            )
+            for local_index, zone_id in enumerate(record.zone_axis_ids)
+        )
+        rotation_offset += len(record.zone_axis_ids)
+
+    all_plans = tuple(pooled_plans)
     selection = config.blochwave.to_orientation_selection()
     ignored = set(selection.ignore_orientations)
     out_of_range = sorted(index for index in ignored if index >= len(all_plans))
@@ -230,8 +262,8 @@ def from_experiment(
     if not selected:
         raise ValueError("ignore_orientations excludes every PETS rotation")
 
-    # Split membership is defined on the original PETS order. Ignoring a rotation must not renumber
-    # later frames and silently move them between train and validation.
+    # Split membership is defined on the original (pooled, file-by-file) PETS order. Ignoring a
+    # rotation must not renumber later frames and silently move them between train and validation.
     validation = _validation_mask(len(all_plans), config.refinement.split)
     train_orientations = tuple(plan for index, plan in selected if not validation[index])
     val_orientations = tuple(plan for index, plan in selected if validation[index])
@@ -241,7 +273,7 @@ def from_experiment(
             validation=Plan(structure_factor_grid=grid, orientations=val_orientations),
         ),
         refinement=refinement_setup,
-        integration=IntegrationGeometry(semiangle=experimental_data.integration_semiangle),
+        integration=IntegrationGeometry(semiangle=records[0].integration_semiangle),
     )
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -185,6 +185,62 @@ def test_input_refs_must_stay_inside_experiment_directory() -> None:
         )
 
 
+def test_multi_dataset_defaults_off_with_a_single_exp_data_path() -> None:
+    cfg = ExperimentConfig.model_validate(
+        {"name": "q", "inputs": {"structure": "q.cif", "exp_data": "q.cif_pets"}}
+    )
+    assert cfg.inputs.multi_dataset is False
+    assert cfg.inputs.exp_data == "q.cif_pets"
+
+
+def test_multi_dataset_true_accepts_a_list_of_two_or_more_paths() -> None:
+    cfg = ExperimentConfig.model_validate(
+        {
+            "name": "q",
+            "inputs": {
+                "structure": "q.cif",
+                "exp_data": ["a.cif_pets", "b.cif_pets"],
+                "multi_dataset": True,
+            },
+        }
+    )
+    assert cfg.inputs.exp_data == ["a.cif_pets", "b.cif_pets"]
+
+
+def test_multi_dataset_true_rejects_a_single_path() -> None:
+    with pytest.raises(ValidationError, match="multi_dataset=true requires"):
+        ExperimentConfig.model_validate(
+            {
+                "name": "bad",
+                "inputs": {"structure": "q.cif", "exp_data": "q.cif_pets", "multi_dataset": True},
+            }
+        )
+
+
+def test_multi_dataset_false_rejects_a_list_of_paths() -> None:
+    with pytest.raises(ValidationError, match="multi_dataset is false"):
+        ExperimentConfig.model_validate(
+            {
+                "name": "bad",
+                "inputs": {"structure": "q.cif", "exp_data": ["a.cif_pets", "b.cif_pets"]},
+            }
+        )
+
+
+def test_multi_dataset_exp_data_paths_are_each_validated_relative() -> None:
+    with pytest.raises(ValidationError):
+        ExperimentConfig.model_validate(
+            {
+                "name": "bad",
+                "inputs": {
+                    "structure": "q.cif",
+                    "exp_data": ["a.cif_pets", "/tmp/b.cif_pets"],
+                    "multi_dataset": True,
+                },
+            }
+        )
+
+
 def test_trainable_config_to_spec_maps_groups_to_selections() -> None:
     spec = TrainableConfig(positions="all", adp="none", occupancy="all").to_spec()
     assert isinstance(spec, TrainableSpec)

--- a/tests/unit/test_from_experiment.py
+++ b/tests/unit/test_from_experiment.py
@@ -234,9 +234,7 @@ def test_from_experiment_pools_multiple_records_with_a_globally_unique_rotation_
     # The second copy's rotation 0 (global index n) is physically identical to the first copy's
     # rotation 0 (same orientation, same energy) -- same file, pooled twice.
     single_first = single_setup.plans.combined.orientations[0]
-    pooled_second_copy_first = next(
-        op for op in combined if op.pattern.rotation_index == n
-    )
+    pooled_second_copy_first = next(op for op in combined if op.pattern.rotation_index == n)
     assert np.allclose(pooled_second_copy_first.orientation, single_first.orientation)
     assert pooled_second_copy_first.energy == single_first.energy
 

--- a/tests/unit/test_from_experiment.py
+++ b/tests/unit/test_from_experiment.py
@@ -220,6 +220,50 @@ def test_refinement_setup_handles_uiso_structure() -> None:
     assert torch.all(torch.linalg.eigvalsh(state.uij_star) >= 0.0)
 
 
+def test_from_experiment_pools_multiple_records_with_a_globally_unique_rotation_index() -> None:
+    structure, experimental_data, config, single_setup = _quartz_setup()
+    n = experimental_data.n_rotations
+
+    pooled = from_experiment(structure, (experimental_data, experimental_data), config)
+
+    combined = pooled.plans.combined.orientations
+    assert len(combined) == 2 * n
+    # combined reorders train-then-validation, so check the *set* of indices: globally unique and
+    # complete over 0..2n-1 (the first copy's 0..n-1, the second copy's n..2n-1 -- never restarting).
+    assert sorted(op.pattern.rotation_index for op in combined) == list(range(2 * n))
+    # The second copy's rotation 0 (global index n) is physically identical to the first copy's
+    # rotation 0 (same orientation, same energy) -- same file, pooled twice.
+    single_first = single_setup.plans.combined.orientations[0]
+    pooled_second_copy_first = next(
+        op for op in combined if op.pattern.rotation_index == n
+    )
+    assert np.allclose(pooled_second_copy_first.orientation, single_first.orientation)
+    assert pooled_second_copy_first.energy == single_first.energy
+
+
+def test_from_experiment_rejects_pooled_records_with_different_integration_semiangle() -> None:
+    structure, experimental_data, config, _ = _quartz_setup()
+    mismatched = experimental_data.model_copy(
+        update={"precession_angles": experimental_data.precession_angles + 1.0}
+    )
+
+    with pytest.raises(ValueError, match="must share one rocking-curve integration semiangle"):
+        from_experiment(structure, (experimental_data, mismatched), config)
+
+
+def test_from_experiment_single_record_and_one_element_sequence_are_equivalent() -> None:
+    structure, experimental_data, config, single_setup = _quartz_setup()
+
+    sequence_setup = from_experiment(structure, (experimental_data,), config)
+
+    assert len(sequence_setup.plans.combined.orientations) == len(
+        single_setup.plans.combined.orientations
+    )
+    assert [op.pattern.rotation_index for op in sequence_setup.plans.combined.orientations] == [
+        op.pattern.rotation_index for op in single_setup.plans.combined.orientations
+    ]
+
+
 def test_from_experiment_seeds_per_rotation_thickness_on_the_orientations() -> None:
     _, _, config, setup = _quartz_setup()
     seeded = list(config.sample.thicknesses)

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -5,12 +5,15 @@ from pathlib import Path
 import pytest
 
 from diffBloch.config import (
+    ExperimentLock,
+    InputLock,
     PreprocessLock,
     RecipeStep,
     RefinementLock,
     artifact_hash_for,
     code_version,
     config_digest,
+    input_lock_for,
     load_config,
     load_experiment,
     preprocess_lock_status,
@@ -21,6 +24,7 @@ from diffBloch.config import (
     write_preprocess_lock,
     write_refinement_lock,
 )
+from diffBloch.config.manifest import _verify_experimental_data
 
 LOCKED = Path(__file__).parent.parent / "fixtures" / "locked_min"
 
@@ -61,6 +65,48 @@ def test_load_experiment_detects_input_drift(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="input drift"):
         load_experiment(experiment)
+
+
+def test_experiment_lock_accepts_a_list_of_input_locks_for_pooled_datasets() -> None:
+    a = InputLock(ref="a.cif_pets", sha256="a" * 64, bytes=1)
+    b = InputLock(ref="b.cif_pets", sha256="b" * 64, bytes=2)
+    lock = ExperimentLock(
+        structure=InputLock(ref="s.cif", sha256="c" * 64, bytes=3),
+        experimental_data=[a, b],
+    )
+    assert lock.experimental_data == [a, b]
+
+
+def test_verify_experimental_data_checks_every_pooled_file(tmp_path: Path) -> None:
+    a = tmp_path / "a.cif_pets"
+    b = tmp_path / "b.cif_pets"
+    a.write_bytes(b"dataset a")
+    b.write_bytes(b"dataset b")
+    locks = [input_lock_for(a, ref="a.cif_pets"), input_lock_for(b, ref="b.cif_pets")]
+
+    _verify_experimental_data(tmp_path, ["a.cif_pets", "b.cif_pets"], locks)
+
+    b.write_bytes(b"tampered")
+    with pytest.raises(ValueError, match="input drift"):
+        _verify_experimental_data(tmp_path, ["a.cif_pets", "b.cif_pets"], locks)
+
+
+def test_verify_experimental_data_rejects_a_pooled_count_mismatch(tmp_path: Path) -> None:
+    a = tmp_path / "a.cif_pets"
+    a.write_bytes(b"dataset a")
+    locks = [input_lock_for(a, ref="a.cif_pets")]
+
+    with pytest.raises(ValueError, match="experimental_data entries"):
+        _verify_experimental_data(tmp_path, ["a.cif_pets", "b.cif_pets"], locks)
+
+
+def test_verify_experimental_data_rejects_a_list_vs_single_shape_mismatch(tmp_path: Path) -> None:
+    a = tmp_path / "a.cif_pets"
+    a.write_bytes(b"dataset a")
+    single_lock = input_lock_for(a, ref="a.cif_pets")
+
+    with pytest.raises(ValueError, match="shape does not match"):
+        _verify_experimental_data(tmp_path, ["a.cif_pets"], single_lock)
 
 
 # --- preprocess checkpoint lock: the four-axis freshness check ---

--- a/tests/unit/test_multi_dataset.py
+++ b/tests/unit/test_multi_dataset.py
@@ -1,0 +1,73 @@
+"""``inputs.multi_dataset``: pooling several PETS files into one experiment.
+
+Default (``multi_dataset=False``) must stay byte-for-byte the existing single-dataset behavior --
+these tests exercise only the dispatch/pooling seam (:func:`_read_experimental_data`,
+:func:`_as_records`) app/program.py adds on top of it. The pooling mechanics themselves
+(rotation_index offsetting, per-file energy/u0, the shared-semiangle guard) are covered in
+test_from_experiment.py.
+
+``ExperimentalRecord`` carries numpy array fields, so pydantic's default ``==`` raises (array truth
+value is ambiguous) -- these tests compare scalar fields or object identity, never the record as a
+whole.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from diffBloch.app.program import _as_records, _read_experimental_data
+from diffBloch.config import load_experiment
+from diffBloch.io import ExperimentalRecord, read_experimental_data
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+QUARTZ = FIXTURES / "quartz_anchor"
+
+
+def test_read_experimental_data_returns_one_record_by_default() -> None:
+    cfg, _lock = load_experiment(QUARTZ)
+    direct = read_experimental_data(QUARTZ / cfg.inputs.exp_data)
+
+    result = _read_experimental_data(QUARTZ, cfg)
+
+    assert isinstance(result, ExperimentalRecord)
+    assert result.wavelength == direct.wavelength
+    assert result.n_rotations == direct.n_rotations
+
+
+def test_read_experimental_data_pools_every_file_when_multi_dataset() -> None:
+    cfg, _lock = load_experiment(QUARTZ)
+    direct = read_experimental_data(QUARTZ / cfg.inputs.exp_data)
+    pooled_cfg = cfg.model_copy(
+        update={
+            "inputs": cfg.inputs.model_copy(
+                update={
+                    "exp_data": [cfg.inputs.exp_data, cfg.inputs.exp_data],
+                    "multi_dataset": True,
+                }
+            )
+        }
+    )
+
+    result = _read_experimental_data(QUARTZ, pooled_cfg)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    for record in result:
+        assert record.wavelength == direct.wavelength
+        assert record.n_rotations == direct.n_rotations
+
+
+def test_as_records_normalizes_a_single_record_to_a_one_tuple() -> None:
+    direct = read_experimental_data(QUARTZ / "exp_data.cif_pets")
+
+    normalized = _as_records(direct)
+
+    assert normalized == (direct,)  # a 1-tuple of the same object: identity, not deep equality
+    assert normalized[0] is direct
+
+
+def test_as_records_passes_a_pooled_tuple_through_unchanged() -> None:
+    direct = read_experimental_data(QUARTZ / "exp_data.cif_pets")
+    pooled = (direct, direct)
+
+    assert _as_records(pooled) is pooled


### PR DESCRIPTION
## Summary

- Adds inputs.multi_dataset for combining rotations from two or more PETS files into one experiment.
- Preserves each dataset's wavelength-derived energy, UB orientation data, and rotation ordering.
- Supports per-dataset seed thicknesses while retaining the existing single-dataset path by default.
- Validates single- versus multi-dataset config shapes and requires a shared integration semiangle.
- Records and verifies every PETS input in experiment.lock.
- Concatenates rotations with globally unique rotation indices so filtering and train/validation selection remain stable.
- Adds focused config, manifest, construction, and end-to-end pooling tests.

## Scope

This PR contains only the multi-dataset pooling feature. It excludes the PETS-cell-authority follow-up, mosaicity changes, ADP repair, observability renames, generated artifacts, and the broad documentation rewrite from #87.

## Validation

- 660 passed, 2 skipped, 1 deselected
- Ruff passed
- mypy passed
- strict Sphinx build passed