### PR TITLE
Use the PETS unit cell throughout simulation and refinement

### DIFF
--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -47,6 +47,7 @@ from diffBloch.config import (
     write_preprocess_lock,
     write_refinement_lock,
 )
+from diffBloch.core.crystal import cell_matrix_from_parameters, cell_volume
 from diffBloch.engine import (
     ApparentThicknessNN,
     ModelRefinementResult,
@@ -666,6 +667,25 @@ def _write_refinement_outputs(
     reciprocal = reciprocal_basis.detach().cpu().numpy()
     reciprocal_lengths = np.linalg.norm(reciprocal, axis=1)
     reciprocal_metric = reciprocal @ reciprocal.T
+    # refinement.cell_parameters is the authoritative cell reciprocal_basis was actually derived
+    # from (PETS's, not necessarily the structure CIF's own -- see from_experiment); the written
+    # header must match it, or the file would declare a cell inconsistent with the ADP/position
+    # convention its own values were refined under. None only for a RefinementSetup built directly
+    # with no override (no PETS record in scope at all), where the CIF's own cell is left as-is.
+    if refinement.cell_parameters is not None:
+        cell_tags = (
+            ("_cell_length_a", refinement.cell_parameters[0]),
+            ("_cell_length_b", refinement.cell_parameters[1]),
+            ("_cell_length_c", refinement.cell_parameters[2]),
+            ("_cell_angle_alpha", refinement.cell_parameters[3]),
+            ("_cell_angle_beta", refinement.cell_parameters[4]),
+            ("_cell_angle_gamma", refinement.cell_parameters[5]),
+        )
+        for tag, value in cell_tags:
+            block.set_pair(tag, f"{float(value):.6f}")
+        if block.find_pair("_cell_volume") is not None:
+            authoritative_unit_cell = cell_matrix_from_parameters(refinement.cell_parameters)
+            block.set_pair("_cell_volume", f"{cell_volume(authoritative_unit_cell):.5f}")
     atom_loop = block.find_loop("_atom_site_label").get_loop()
     tags = list(atom_loop.tags)
     label_column = tags.index("_atom_site_label")

--- a/src/diffBloch/core/crystal.py
+++ b/src/diffBloch/core/crystal.py
@@ -63,10 +63,11 @@ def cell_volume(cell: FloatArray) -> float:
 def orientation_basis(cell: FloatArray, orientation: FloatArray) -> FloatArray:
     """Lab-frame reciprocal basis for one orientation: ``reciprocal_cell(cell @ orientation.T)``.
 
-    The single home for the orientation convention. ``orientation`` is generally non-orthonormal
-    (it folds the ~1% measured-vs-ideal cell correction; see ``preprocess.orientation``), so this is
-    NOT ``reciprocal_basis @ orientation.T``. ``cell`` rows are the real-space basis; returns rows
-    ``a*, b*, c*`` in inverse Angstrom. ``orientation = I`` reproduces ``reciprocal_cell(cell)``.
+    The single home for the orientation convention. ``orientation`` is not guaranteed exactly
+    orthonormal -- it carries PETS's own UB-vs-cell-parameters fit residual (see
+    ``preprocess.orientation``) -- so this is NOT ``reciprocal_basis @ orientation.T``. ``cell`` rows
+    are the real-space basis; returns rows ``a*, b*, c*`` in inverse Angstrom. ``orientation = I``
+    reproduces ``reciprocal_cell(cell)``.
     """
     matrix = _cell_array(cell)
     rotation = np.asarray(orientation, dtype=np.float64)

--- a/src/diffBloch/engine/plan.py
+++ b/src/diffBloch/engine/plan.py
@@ -44,12 +44,12 @@ __all__ = [
 ]
 
 # Half-Angstrom shell added to the derived structure-factor support radius. It reconciles the two
-# metrics in play: the coupling filter cuts ``|g| < g_max`` in the *orientation* metric (which folds
-# the experimental cell correction -- ``u_matrix`` is deliberately non-orthonormal), while the grid
-# is tabulated on the ideal-cell ``reciprocal_cell`` metric. The two differ by the cell-correction
-# magnitude (~1% on quartz), so a coupled beam difference can be up to that fraction past a bare
-# ``2 * g_max`` in the grid metric. This is a numerical safety shell, not a tunable scientific knob.
-# See StructureFactorGrid.from_cell_for_beam_cutoff.
+# metrics in play: the coupling filter cuts ``|g| < g_max`` in the *orientation* metric (``u_matrix``
+# is not guaranteed exactly orthonormal -- it carries PETS's own UB-vs-cell-parameters fit residual,
+# see ``preprocess.orientation``), while the grid is tabulated on the authoritative-cell
+# ``reciprocal_cell`` metric that same ``U`` was derived to be consistent with. The two metrics
+# should very nearly agree (that residual is typically well under 1%), but this shell is cheap
+# insurance against it, not a tunable scientific knob. See StructureFactorGrid.from_cell_for_beam_cutoff.
 _SUPPORT_MARGIN = 0.5
 
 
@@ -121,11 +121,11 @@ class StructureFactorGrid:
         objective, not the solve.
 
         The support radius is ``2 * solve_g_max + _SUPPORT_MARGIN``. The half-Angstrom headroom
-        reconciles the coupling filter's *orientation* metric (which folds the experimental cell
-        correction -- ``u_matrix`` is deliberately non-orthonormal, ~1% on quartz) with this
-        ideal-cell ``reciprocal_cell`` metric, so a coupled beam difference near ``2 * solve_g_max``
-        in the former still lands inside the grid in the latter. The shell only enlarges the
-        (unused-at-the-margin) SF table; it changes neither the coupled beam set nor the scored set.
+        reconciles the coupling filter's *orientation* metric (``u_matrix`` is not guaranteed exactly
+        orthonormal -- see ``preprocess.orientation``) with this ``reciprocal_cell`` metric of the
+        same authoritative cell, so a coupled beam difference near ``2 * solve_g_max`` in the former
+        still lands inside the grid in the latter. The shell only enlarges the (unused-at-the-margin)
+        SF table; it changes neither the coupled beam set nor the scored set.
         """
         if solve_g_max <= 0.0:
             raise ValueError("solve_g_max must be positive")
@@ -189,9 +189,9 @@ class OrientationPlan:
         ``orientation_basis(grid.cell, orientation) = reciprocal_cell(cell @ orientation.T)`` and
         drives ``g`` -> ``Sg`` / ``Mii`` only. When ``None`` the orientation is the identity and the
         shared ``grid.reciprocal_basis`` is used directly (the untilted / single-orientation case),
-        making that path identical to the unoriented build. The rotation convention (and the
-        measured-cell correction folded into ``orientation``) is derived upstream in ``preprocess``;
-        the ``Fgb`` gather is keyed on ``grid.structure_factor_hkl`` and is unaffected.
+        making that path identical to the unoriented build. The rotation convention is derived
+        upstream in ``preprocess`` (see ``preprocess.orientation``); the ``Fgb`` gather is keyed on
+        ``grid.structure_factor_hkl`` and is unaffected.
 
         ``orientation`` accepts either a NumPy array or a ``Tensor`` (e.g. a prior plan's stored
         ``orientation``), so a later ``Plan -> Plan`` rebuild can pass ``old_plan.orientation``

--- a/src/diffBloch/preprocess/coupling.py
+++ b/src/diffBloch/preprocess/coupling.py
@@ -155,13 +155,13 @@ def build_coupling_segments(
     # structure-factor grid, but only the ``|g| < g_max`` core can ever couple. Scanning the whole
     # grid at every boundary tilt was the dominant per-trial cost; one pass replaces it.
     #
-    # NOTE the ``|g|`` here is in the *orientation* metric -- ``orientation`` folds the experimental
-    # cell correction (``u_matrix``: ``U = UB @ B^-1``, deliberately non-orthonormal), so this |g|
-    # differs from the ideal-cell ``reciprocal_cell`` metric the grid is tabulated on by the
-    # cell-correction magnitude (~1% on quartz). The grid's ``2 * g_max + _SUPPORT_MARGIN`` shell
-    # (:meth:`StructureFactorGrid.from_cell_for_beam_cutoff`) covers that difference; it is NOT a
-    # per-tilt variation and NOT an orthonormality bug -- coupling in the experimental-cell metric
-    # is the physically correct cut.
+    # NOTE the ``|g|`` here is in the *orientation* metric -- ``orientation`` is not guaranteed
+    # exactly orthonormal (``u_matrix``: ``U = UB @ B^-1`` carries PETS's own small
+    # UB-vs-cell-parameters fit residual; see ``preprocess.orientation``), so this |g| can differ
+    # slightly from the authoritative-cell ``reciprocal_cell`` metric the grid is tabulated on. The
+    # grid's ``2 * g_max + _SUPPORT_MARGIN`` shell (:meth:`StructureFactorGrid.from_cell_for_beam_cutoff`)
+    # covers that residual; it is NOT a per-tilt variation and NOT an orthonormality bug -- coupling
+    # in the orientation metric is the physically correct cut.
     g_nominal = candidate_beam_hkl @ orientation_basis(cell, orientation)  # constant across tilts
     radial_mask = np.linalg.norm(g_nominal, axis=1) < policy.g_max
     pool = candidate_beam_hkl[radial_mask]

--- a/src/diffBloch/preprocess/experiment.py
+++ b/src/diffBloch/preprocess/experiment.py
@@ -14,6 +14,7 @@ The structure side lives here so the structure/experimental split mirrors the tw
 
 from __future__ import annotations
 
+import logging
 import math
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -25,7 +26,7 @@ from torch import Tensor
 
 from diffBloch.config.schema import DataSplitConfig, ExperimentConfig
 from diffBloch.core.adp import cholesky_raw_from_adp
-from diffBloch.core.crystal import reciprocal_cell
+from diffBloch.core.crystal import cell_matrix_from_parameters, reciprocal_cell
 from diffBloch.core.dynamical import (
     energy2sigma,
     energy2wavelength,
@@ -52,6 +53,12 @@ __all__ = [
     "from_experiment",
     "seed_beam_hkl",
 ]
+
+_log = logging.getLogger(__name__)
+
+_CELL_PARAMETER_NAMES = ("a", "b", "c", "alpha", "beta", "gamma")
+_CELL_WARN_RTOL = 0.01  # relative difference past which a cell mismatch warns
+_CELL_FAIL_RTOL = 0.05  # relative difference past which a cell mismatch is a hard error
 
 
 @dataclass(frozen=True)
@@ -116,17 +123,29 @@ class RefinementSetup:
     spec: ConstraintSpec
     params: RefinableParams
     numbers: Tensor
+    # The (a, b, c, alpha, beta, gamma) spec.reciprocal_basis was actually built from -- PETS's
+    # authoritative cell when from_structure was given one (see from_experiment), else None (a
+    # direct construction with no override; spec.reciprocal_basis already carries the metric, this
+    # is only needed by a caller that writes it back out, e.g. the refined_structure.cif header).
+    cell_parameters: NDArray[np.float64] | None = None
 
     @classmethod
-    def from_structure(cls, structure: StructureRecord) -> RefinementSetup:
+    def from_structure(
+        cls,
+        structure: StructureRecord,
+        *,
+        cell_parameters: NDArray[np.float64] | None = None,
+    ) -> RefinementSetup:
         """Assemble the structure-side refinement inputs from a parsed :class:`StructureRecord`.
 
-        Positions and symmetry use the *ideal* CIF cell (the measured-lattice correction enters only
-        through the per-orientation matrices in the geometry plan). ADPs are mapped to the
-        reciprocal ``U*`` frame of this ideal cell by :func:`diffBloch.params.constrain`.
-        Per-rotation thickness lives elsewhere -- on each per-rotation plan (seeded by
-        ``from_experiment``, fitted by ``optimize_thickness``) -- because it varies per rotation, not per
-        structure.
+        Positions and symmetry are read directly off the CIF's fractional coordinates /
+        symmetry operators -- both are metric-independent, so they need no cell at all. ADPs are
+        mapped to the reciprocal ``U*`` frame by :func:`diffBloch.params.constrain`, using
+        ``cell_parameters`` as the metric when given (``inputs.multi_dataset``-checked PETS cell,
+        authoritative -- see ``from_experiment``); otherwise the structure's own CIF cell, for a
+        caller that has no PETS record at all (a direct construction, e.g. a test). Per-rotation
+        thickness lives elsewhere -- on each per-rotation plan (seeded by ``from_experiment``,
+        fitted by ``optimize_thickness``) -- because it varies per rotation, not per structure.
 
         Special-position degrees of freedom are constrained by the site-symmetry projector built
         natively from the structure's symmetry operators (:func:`symmetry_constraints`): an atom
@@ -136,15 +155,17 @@ class RefinementSetup:
         positions = torch.tensor(structure.frac_positions, dtype=torch.float64)
         uij_raw, u_iso_raw = _initial_adp_params(structure.adp)
         constraints = symmetry_constraints(structure)
+        resolved_cell_parameters = (
+            structure.cell_parameters if cell_parameters is None else np.asarray(cell_parameters)
+        )
+        unit_cell = cell_matrix_from_parameters(resolved_cell_parameters)
         spec = ConstraintSpec(
             position_projection=torch.tensor(constraints.position_projection, dtype=torch.float64),
             position_offset=torch.tensor(constraints.position_offset, dtype=torch.float64),
             occupancies=torch.tensor(structure.occupancies, dtype=torch.float64),
             adp_kind=structure.adp.kind,
             adp_constraints=constraints.adp_constraints,
-            reciprocal_basis=torch.tensor(
-                reciprocal_cell(structure.unit_cell), dtype=torch.float64
-            ),
+            reciprocal_basis=torch.tensor(reciprocal_cell(unit_cell), dtype=torch.float64),
         )
         return cls(
             asu_plan=build_asu_expansion_plan(
@@ -155,6 +176,7 @@ class RefinementSetup:
                 asu_positions=positions.clone(), uij_raw=uij_raw, u_iso_raw=u_iso_raw
             ),
             numbers=torch.tensor(structure.numbers, dtype=torch.int64),
+            cell_parameters=cell_parameters,
         )
 
 
@@ -213,11 +235,15 @@ def from_experiment(
                 "pooled datasets (inputs.multi_dataset) must share one rocking-curve integration "
                 f"semiangle; got {sorted(set(semiangles))}"
             )
+    authoritative_cell_parameters = _resolve_authoritative_cell(structure, records)
+    authoritative_unit_cell = cell_matrix_from_parameters(authoritative_cell_parameters)
 
     solve_cutoff = config.blochwave.g_max
-    grid = StructureFactorGrid.from_cell_for_beam_cutoff(structure.unit_cell, solve_cutoff)
+    grid = StructureFactorGrid.from_cell_for_beam_cutoff(authoritative_unit_cell, solve_cutoff)
     beam_hkl = seed_beam_hkl(grid, g_max=solve_cutoff)
-    refinement_setup = RefinementSetup.from_structure(structure)
+    refinement_setup = RefinementSetup.from_structure(
+        structure, cell_parameters=authoritative_cell_parameters
+    )
     absorption = config.blochwave.to_absorption()
 
     pooled_plans: list[CandidatePlan] = []
@@ -275,6 +301,93 @@ def from_experiment(
         refinement=refinement_setup,
         integration=IntegrationGeometry(semiangle=records[0].integration_semiangle),
     )
+
+
+def _resolve_authoritative_cell(
+    structure: StructureRecord, records: Sequence[ExperimentalRecord]
+) -> NDArray[np.float64]:
+    """Resolve the ``(a, b, c, alpha, beta, gamma)`` PETS is authoritative for.
+
+    PETS's own cell -- not the structure CIF's -- is used for every piece of simulation geometry:
+    the structure-factor grid, the reciprocal basis, the cell volume, the ADP U*-frame conversion,
+    and beam geometry (all derived from the grid ``from_experiment`` builds with this cell). The CIF
+    still supplies atomic content (positions, types, occupancies, ADPs, symmetry operators) --
+    fractional coordinates are unchanged, only now interpreted against PETS's cell rather than the
+    CIF's own. For a combined experiment (``inputs.multi_dataset``) the *first* file in
+    ``inputs.exp_data`` order is the anchor every other combined file's own orientation is applied
+    against (see ``orientation_matrices`` in ``from_experiment``'s per-record loop, unchanged: each
+    dataset's ``U`` still comes from *its own* UB and *its own* PETS cell, only the cell that ``U``
+    then gets composed with -- via ``orientation_basis`` -- is this single shared authoritative one).
+
+    The structure CIF's cell, and every further combined PETS file's cell, is checked against this
+    authoritative cell -- never the reverse, it is never adjusted to fit them. A >1% relative
+    difference on any of ``a, b, c, alpha, beta, gamma`` warns (day-to-day refinement/measurement
+    drift stays well under that); a >5% difference raises -- that far past ordinary drift, the two
+    files most likely describe different crystals or settings, and continuing would silently derive
+    the whole simulation's geometry from a mismatch this large.
+    """
+    authoritative_cell = np.asarray(records[0].cell_parameters, dtype=np.float64)
+    authoritative_label = (
+        str(records[0].source_path) if records[0].source_path is not None else "<experimental data>"
+    )
+    _check_cell_agreement(
+        authoritative_cell, authoritative_label, structure.cell_parameters, "structure CIF"
+    )
+    for record in records[1:]:
+        other_label = (
+            str(record.source_path) if record.source_path is not None else "<experimental data>"
+        )
+        _check_cell_agreement(
+            authoritative_cell,
+            authoritative_label,
+            np.asarray(record.cell_parameters, dtype=np.float64),
+            other_label,
+        )
+    return authoritative_cell
+
+
+def _check_cell_agreement(
+    authoritative_cell: NDArray[np.float64],
+    authoritative_label: str,
+    other_cell: NDArray[np.float64],
+    other_label: str,
+) -> None:
+    """Compare ``other_cell`` against the authoritative cell: warn past 1%, raise past 5%.
+
+    ``authoritative_cell`` always wins regardless of the outcome here -- this only ever informs or
+    blocks, it never changes which cell the simulation actually uses.
+    """
+    relative_diff = np.abs(other_cell - authoritative_cell) / np.abs(authoritative_cell)
+
+    def offending(threshold: float) -> str:
+        return ", ".join(
+            f"{name}: {other_label}={other_value:.6g} vs {authoritative_label}="
+            f"{authoritative_value:.6g} ({100.0 * diff:.2f}% off)"
+            for name, other_value, authoritative_value, diff in zip(
+                _CELL_PARAMETER_NAMES, other_cell, authoritative_cell, relative_diff, strict=True
+            )
+            if diff > threshold
+        )
+
+    fail_mask = relative_diff > _CELL_FAIL_RTOL
+    if np.any(fail_mask):
+        raise ValueError(
+            f"{other_label} and {authoritative_label} unit cells disagree by more than 5% on "
+            f"{int(np.count_nonzero(fail_mask))} parameter(s): {offending(_CELL_FAIL_RTOL)} -- "
+            "refusing to continue; check that these files describe the same crystal setting."
+        )
+    warn_mask = relative_diff > _CELL_WARN_RTOL
+    if np.any(warn_mask):
+        _log.warning(
+            "%s and %s unit cells disagree by more than 1%% on %d parameter(s): %s -- %s is "
+            "authoritative and overrides %s for the simulation geometry.",
+            other_label,
+            authoritative_label,
+            int(np.count_nonzero(warn_mask)),
+            offending(_CELL_WARN_RTOL),
+            authoritative_label,
+            other_label,
+        )
 
 
 def _mean_inner_potential(

--- a/src/diffBloch/preprocess/orientation.py
+++ b/src/diffBloch/preprocess/orientation.py
@@ -3,17 +3,20 @@
 Reconstructs per-rotation crystal orientation matrices from the experiment's goniometer geometry --
 the UB matrix and per-rotation tilt angles recorded in the PETS data -- with no side-car
 orientation file. The orientations are first-class inputs to the ``Plan``; ``optimize_orientation``
-refines them in-Plan -- it must not re-orthonormalise them: they fold a ~1% measured-vs-ideal cell
-correction, so a polar/SVD projection would silently drop it.
+refines them in-Plan -- it must not re-orthonormalise them: ``U`` carries PETS's own small
+UB-vs-cell-parameters fit residual, so a polar/SVD projection would silently drop it.
 
 Convention::
 
     orientation = R_z(omega) . R_x(alpha) . R_y(beta) @ U,    U = UB @ B^-1
 
-where ``B`` is the Busing-Levy reciprocal matrix built from the cell parameters and the goniometer
-rotations are active, in degrees. Geometry then uses :func:`orientation_basis` =
-``reciprocal_cell(cell @ orientation.T)`` (NOT ``reciprocal_basis @ orientation.T``), because the
-orientation matrices are generally non-orthonormal.
+where ``B`` is the Busing-Levy reciprocal matrix built from *this dataset's own* PETS cell
+parameters (the same cell ``UB`` was fit against, so ``U`` is close to a pure rotation -- see
+``diffBloch.preprocess.experiment._resolve_authoritative_cell`` for how a combined experiment's
+*shared* cell is chosen and cross-checked) and the goniometer rotations are active, in degrees.
+Geometry then uses :func:`orientation_basis` = ``reciprocal_cell(cell @ orientation.T)`` (NOT
+``reciprocal_basis @ orientation.T``), because ``orientation`` is not guaranteed exactly orthonormal
+even so.
 
 Reference: W. R. Busing & H. A. Levy, *Acta Cryst.* **22**, 457 (1967) (the UB-matrix formalism).
 """
@@ -89,9 +92,9 @@ def hexagonal_tilt(azimuth: float, polar: float) -> FloatArray:
     """Palatinus hexagonal-search tilt ``R_z(azimuth) . R_x(polar) . R_z(-azimuth)``, in degrees.
 
     A tilt of magnitude ``polar`` about the in-plane axis at ``azimuth`` -- the delta rotation
-    ``optimize_orientation`` right-multiplies onto an orientation (``orientation @ tilt``). Being a true
-    rotation (``det = 1``) it preserves the non-orthonormal ``U`` measured-cell correction exactly,
-    so the re-orthonormalisation trap is dodged by construction.
+    ``optimize_orientation`` right-multiplies onto an orientation (``orientation @ tilt``). Being a
+    true rotation (``det = 1``) it preserves whatever small fit residual ``U`` already carries
+    exactly, so the re-orthonormalisation trap is dodged by construction.
 
     Reference: L. Palatinus et al., *Acta Cryst.* **A69**, 171-188 (2013), the hexagonal
     modified-simplex search.
@@ -141,7 +144,12 @@ def rocking_curve_tilts(
 
 
 def u_matrix(ub_matrix: FloatArray, cell_parameters: FloatArray) -> FloatArray:
-    """Crystal ``U`` matrix ``U = UB @ B^-1``; generally non-orthonormal (folds cell correction)."""
+    """Crystal ``U`` matrix ``U = UB @ B^-1``, from this dataset's own PETS UB and cell parameters.
+
+    Close to a pure rotation (``B`` is built from the same cell PETS fit ``UB`` against), but not
+    guaranteed to be exactly orthonormal -- PETS's own UB-vs-cell-parameters fit carries a small
+    residual. Not re-orthonormalised (see the module docstring).
+    """
     ub = np.asarray(ub_matrix, dtype=np.float64)
     if ub.shape != (3, 3):
         raise ValueError("ub_matrix must have shape (3, 3)")

--- a/tests/unit/test_from_experiment.py
+++ b/tests/unit/test_from_experiment.py
@@ -1,5 +1,6 @@
 """``from_experiment`` boundary construction: Plan pair split + structure-side RefinementSetup."""
 
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -7,6 +8,7 @@ import pytest
 import torch
 
 from diffBloch.config import load_config
+from diffBloch.core.crystal import cell_matrix_from_parameters, reciprocal_cell
 from diffBloch.io import read_experimental_data, read_structure
 from diffBloch.io.record import AdpRecord, StructureRecord
 from diffBloch.params import constrain
@@ -333,3 +335,142 @@ def test_refinement_setup_mixed_uani_uiso_constrains_each_atom_by_kind() -> None
 def _setup_state(structure: StructureRecord) -> tuple:
     setup = RefinementSetup.from_structure(structure)
     return setup.params, setup.spec
+
+
+# --- unit-cell authority: PETS overrides the structure CIF ----------------------------------------
+
+
+def test_cell_mismatch_under_1pct_is_silent(caplog: pytest.LogCaptureFixture) -> None:
+    structure = read_structure(QUARTZ / "enantiomer_1.cif")
+    experimental_data = read_experimental_data(QUARTZ / "exp_data.cif_pets")
+    config = load_config(QUARTZ / "experiment.yaml")
+    # 0.5% off on 'a' only -- well under the 1% warn threshold.
+    nudged = experimental_data.model_copy(
+        update={
+            "cell_parameters": experimental_data.cell_parameters
+            * np.array([1.005, 1.0, 1.0, 1.0, 1.0, 1.0])
+        }
+    )
+
+    with caplog.at_level(logging.WARNING, logger="diffBloch.preprocess.experiment"):
+        setup = from_experiment(structure, nudged, config)
+
+    assert not caplog.records
+    # PETS's (nudged) cell is authoritative regardless of how closely it agrees with the CIF.
+    np.testing.assert_allclose(
+        setup.plans.combined.structure_factor_grid.cell.numpy(),
+        cell_matrix_from_parameters(nudged.cell_parameters),
+    )
+
+
+def test_cell_mismatch_over_1pct_warns_and_pets_geometry_wins(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    structure = read_structure(QUARTZ / "enantiomer_1.cif")
+    experimental_data = read_experimental_data(QUARTZ / "exp_data.cif_pets")
+    config = load_config(QUARTZ / "experiment.yaml")
+    # 2% off on 'a' only -- past the 1% warn threshold, comfortably under the 5% fail threshold.
+    mismatched = experimental_data.model_copy(
+        update={
+            "cell_parameters": experimental_data.cell_parameters
+            * np.array([1.02, 1.0, 1.0, 1.0, 1.0, 1.0])
+        }
+    )
+
+    with caplog.at_level(logging.WARNING, logger="diffBloch.preprocess.experiment"):
+        setup = from_experiment(structure, mismatched, config)
+
+    [record] = caplog.records
+    message = record.getMessage()
+    assert "more than 1%" in message
+    assert "structure CIF" in message
+    assert "overrides" in message
+    assert "a:" in message
+
+    # The structure-factor grid / reciprocal basis use PETS's cell, not the (unmodified) CIF's.
+    grid_cell = setup.plans.combined.structure_factor_grid.cell.numpy()
+    np.testing.assert_allclose(grid_cell, cell_matrix_from_parameters(mismatched.cell_parameters))
+    assert not np.allclose(grid_cell, cell_matrix_from_parameters(structure.cell_parameters))
+    # So does the ADP U*-frame conversion.
+    np.testing.assert_allclose(
+        setup.refinement.spec.reciprocal_basis.numpy(),
+        reciprocal_cell(cell_matrix_from_parameters(mismatched.cell_parameters)),
+    )
+
+
+def test_cell_mismatch_over_5pct_raises_and_names_every_offending_parameter() -> None:
+    structure = read_structure(QUARTZ / "enantiomer_1.cif")
+    experimental_data = read_experimental_data(QUARTZ / "exp_data.cif_pets")
+    config = load_config(QUARTZ / "experiment.yaml")
+    # 6% off on 'a', ~6.5% off on 'alpha' -- both past the 5% fail threshold; 'b'/'c'/'beta'/'gamma'
+    # untouched, so the error must name exactly these two and no others.
+    mismatched = experimental_data.model_copy(
+        update={
+            "cell_parameters": experimental_data.cell_parameters
+            * np.array([1.06, 1.0, 1.0, 1.07, 1.0, 1.0])
+        }
+    )
+
+    with pytest.raises(ValueError, match="more than 5%") as excinfo:
+        from_experiment(structure, mismatched, config)
+
+    message = str(excinfo.value)
+    assert "a:" in message
+    assert "alpha:" in message
+    assert "b:" not in message
+    assert "beta:" not in message
+    # Both values and the percentage difference.
+    assert f"{experimental_data.cell_parameters[0]:.6g}" in message  # PETS's (authoritative) value
+    assert f"{structure.cell_parameters[0]:.6g}" in message  # the structure CIF's value
+    assert "%" in message
+    assert "refusing to continue" in message
+
+
+def test_multi_dataset_second_file_checked_against_first_not_structure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    structure = read_structure(QUARTZ / "enantiomer_1.cif")
+    first = read_experimental_data(QUARTZ / "exp_data.cif_pets")
+    config = load_config(QUARTZ / "experiment.yaml")
+    # 2% off from the FIRST record (== the structure's own cell here) -- exercises the PETS-vs-PETS
+    # check between combined files, not the structure-vs-PETS one.
+    second = first.model_copy(
+        update={
+            "cell_parameters": first.cell_parameters * np.array([1.02, 1.0, 1.0, 1.0, 1.0, 1.0]),
+            "source_path": Path("second.cif_pets"),
+        }
+    )
+
+    with caplog.at_level(logging.WARNING, logger="diffBloch.preprocess.experiment"):
+        setup = from_experiment(structure, (first, second), config)
+
+    [record] = caplog.records
+    message = record.getMessage()
+    assert "second.cif_pets" in message
+    assert str(first.source_path) in message
+    assert "overrides" in message
+    # The FIRST combined file anchors the shared grid, not the second (nor an average of the two).
+    np.testing.assert_allclose(
+        setup.plans.combined.structure_factor_grid.cell.numpy(),
+        cell_matrix_from_parameters(first.cell_parameters),
+    )
+
+
+def test_multi_dataset_over_5pct_between_combined_files_raises() -> None:
+    structure = read_structure(QUARTZ / "enantiomer_1.cif")
+    first = read_experimental_data(QUARTZ / "exp_data.cif_pets")
+    config = load_config(QUARTZ / "experiment.yaml")
+    second = first.model_copy(
+        update={
+            "cell_parameters": first.cell_parameters * np.array([1.08, 1.0, 1.0, 1.0, 1.0, 1.0]),
+            "source_path": Path("second.cif_pets"),
+        }
+    )
+
+    with pytest.raises(ValueError, match="more than 5%") as excinfo:
+        from_experiment(structure, (first, second), config)
+
+    message = str(excinfo.value)
+    assert "second.cif_pets" in message
+    assert str(first.source_path) in message
+    assert "a:" in message


### PR DESCRIPTION
## Summary

- Uses the PETS unit cell for the structure-factor grid, reciprocal basis, cell volume, ADP conversion, beam geometry, and refined CIF output.
- Retains fractional coordinates, atoms, occupancies, ADPs, and symmetry operations from the structure CIF.
- Warns when CIF and PETS cell parameters differ by more than 1%.
- Stops when any parameter differs by more than 5%, listing each offending parameter and percentage difference.
- Uses the first PETS cell as the shared authority for a combined experiment.
- Adds focused tests for warning, rejection, and authoritative-cell behavior.

## Scope

This PR contains only PETS unit-cell authority and consistency handling. Documentation is already merged through #88. Mosaicity, ADP repair, observability changes, generated outputs, and unrelated runtime fixes are excluded.

## Validation

- 20 focused tests passed
- Ruff passed
- mypy passed