### PR TITLE
Restore device, scaling, and profiling documentation

### DIFF
--- a/docs/bloch_wave_simulation.md
+++ b/docs/bloch_wave_simulation.md
@@ -127,6 +127,6 @@ There are two mathematically equivalent ways to evaluate this, and diffBloch imp
 The calculated intensity in reflection {math}`\mathbf{g}` is {math}`I_{\mathbf{g}}(t) =
 |\psi_{\mathbf{g}}(t)|^2`. A continuous-rotation frame sums this over sampled sub-orientations
 across the rocking curve (and, when `blochwave.mosaicity` is enabled, smoothed over a moving-average
-window derived from the PETS apparent mosaicity) rather than evaluating a single static orientation
+window derived from the apparent mosaicity recorded in `.cif_pets`) rather than evaluating a single static orientation
 — see [Preprocessing](preprocessing.md) for how those tilts and beam couplings are assembled around
 this solve.

--- a/docs/convergence-testing.md
+++ b/docs/convergence-testing.md
@@ -23,7 +23,7 @@ The main controls governing simulation convergence are:
 |---|---|
 | `g_max` | Largest reflection {math}`g` vector simulated. Off-diagonal structure factors extend to {math}`2g_\mathrm{max}`. |
 | `sg_max` | A beam is simulated at a sampled orientation when {math}`|S_g| < sg_\mathrm{max}`. |
-| `rocking_curve_sampling` | Number of crystal orientations sampled across each PETS virtual frame and summed to give its integrated intensity. |
+| `rocking_curve_sampling` | Number of crystal orientations sampled across each `.cif_pets` virtual frame and summed to give its integrated intensity. |
 
 Increasing `g_max` or `sg_max` increases the number of beams {math}`N`, with simulation cost scaling
 approximately as {math}`N^3`. Increasing `rocking_curve_sampling` adds more structure-matrix solves,

--- a/docs/devices-and-scaling.md
+++ b/docs/devices-and-scaling.md
@@ -1,0 +1,68 @@
+# Devices and scaling
+
+`--device`, `--workers`, and `--max-batch` control how a run executes. They do not change the
+experiment settings or invalidate preprocessing checkpoints.
+
+## Device
+
+```bash
+uv run diffbloch refine <experiment_dir> --device cuda
+uv run diffbloch refine <experiment_dir> --device cpu
+```
+
+CUDA is the default. If CUDA is unavailable, diffBloch falls back to the CPU. Both devices perform
+the same calculation, but a GPU is much faster for large structure matrices.
+
+## Workers
+
+`--workers` runs independent orientation-plan builds and orientation searches in parallel. The
+default is one worker:
+
+```bash
+uv run diffbloch preprocess <experiment_dir> --workers 4
+```
+
+When using multiple workers, limit the host thread pools to avoid assigning a full set of CPU
+threads to every worker.
+
+## Maximum batch size
+
+`--max-batch` limits the number of structure matrices passed to one matrix-exponential operation.
+It controls memory use rather than the scientific result. The default selects a batch size from
+the matrix size and available memory.
+
+## GPU and CPU timings
+
+The following timings were measured on the same machine with identical experiment settings:
+
+| Experiment | GPU | CPU | CPU/GPU time |
+|---|---:|---:|---:|
+| Quartz, absorptive refinement, 40 epochs | 57.1 s | 72.8 s | 1.3× |
+| CsPbBr₃, absorptive preprocessing, 59 rotations | 16 min 57 s | 5 h 00 min | 18× |
+| CsPbBr₃, absorptive refinement, 40 epochs | 20 min 52 s | approximately 15.3 h | 44× |
+
+CPU execution is reasonable for small structure matrices. GPU acceleration becomes increasingly
+important as the number of dynamically coupled beams increases.
+
+## Profiling refinement
+
+`--profile` reports the time spent calculating structure factors, solving each rotation, computing
+gradients, and updating the structural parameters:
+
+```bash
+uv run diffbloch refine <experiment_dir> --device cuda --profile
+```
+
+Profiling synchronizes the GPU during each measured section and therefore slows the run. It is
+intended for diagnosis, not routine refinement.
+
+The following results used a GPU and three refinement epochs:
+
+| Structure | Refined parameters | Solved sections | Mean structure-matrix size | Forward per epoch | Gradient calculation per epoch |
+|---|---:|---:|---:|---:|---:|
+| Methyl, multiple datasets | 962 | 176 | 297 | approximately 0.62 s | approximately 3.06 s |
+| CsPbBr₃, absorptive | 48 | 236 | 690 | approximately 4.17 s | approximately 25.5 s |
+
+The gradient calculation dominates both examples. CsPbBr₃ has far fewer refined parameters but is
+slower because its structure matrices are larger. Runtime is therefore governed mainly by the
+number of dynamically coupled beams, not the number of refined structural parameters.

--- a/docs/hyperparameter-selection.md
+++ b/docs/hyperparameter-selection.md
@@ -8,7 +8,7 @@ data. Importantly, values specified in the `experiment.yaml` will override defau
 
 This page lists every config, its default, and what it controls. For guidance in selecting appropriate `g_max`, `sg_max`, and `rocking_curve_sampling` specifically, see [Convergence testing](convergence-testing.md).
 
-## What is *not* config: auto-filled from CIF/PETS
+## Values read from `.cif` and `.cif_pets`
 
 Some values that other refinement packages expose as settings are deliberately **not** config
 fields in diffBloch — they are read from the structure `.cif` or `.cif_pets` file at load time, so
@@ -16,12 +16,12 @@ they cannot silently drift from the data they describe:
 
 | Value | Source | Notes |
 |---|---|---|
-| Electron energy / wavelength | `.cif_pets` wavelength | Converted to energy and snapped onto the nearest standard TEM voltage when close (`snap_to_standard_energy`). PETS records wavelength to limited precision, so this recovers the operator-selected voltage exactly. |
-| Unit cell (`a, b, c, α, β, γ`) | `.cif_pets`, checked against `.cif` | PETS's cell is authoritative for all simulation geometry; the structure CIF's own cell is only a consistency check (logs a warning past 1%, raises past 5%). See [Inputs and outputs](inputs.md#unit-cell). |
-| UB orientation matrix | `.cif_pets`, per rotation | Each rotation's own PETS UB seeds its starting orientation, later refined by `preprocess.orientation` (below) if enabled. |
+| Electron energy / wavelength | `.cif_pets` wavelength | Converted to energy and snapped onto the nearest standard TEM voltage when close (`snap_to_standard_energy`). The wavelength is recorded to limited precision, so this recovers the operator-selected voltage exactly. |
+| Unit cell (`a, b, c, α, β, γ`) | `.cif_pets`, checked against `.cif` | The `.cif_pets` cell is authoritative for all simulation geometry; the structure CIF's own cell is only a consistency check (logs a warning past 1%, raises past 5%). See [Inputs and outputs](inputs.md#unit-cell). |
+| UB orientation matrix | `.cif_pets`, per rotation | Each rotation's UB supplies its starting orientation, later refined by `preprocess.orientation` (below) if enabled. |
 | Integration semiangle | `.cif_pets` precession angle | The tilt half-width, read per file; under `inputs.multi_dataset` each dataset's recipe uses its own (precession angles may differ between files). |
 | Apparent mosaicity (degrees) | `.cif_pets` `_diffrn_measurement_details` | Only read when `blochwave.mosaicity: true`; missing from the file then raises rather than defaulting silently. |
-| Atomic positions, ADPs, occupancies, symmetry ops | structure `.cif` | Unaffected by PETS's cell override — fractional coordinates are simply reinterpreted against PETS's metric. |
+| Atomic positions, ADPs, occupancies, symmetry ops | structure `.cif` | Unaffected by the `.cif_pets` cell override — fractional coordinates are interpreted using the `.cif_pets` cell. |
 | Structure-factor support radius | derived, `2 * blochwave.g_max` | Not independently configurable: a beam set bounded by `\|g\| <= g_max` produces `F(g - h)` terms reaching `2 * g_max`, so a separate support setting could silently contradict the solve cutoff. |
 
 ## `sample`
@@ -34,44 +34,77 @@ Fixed sample properties (`diffBloch.config.schema.SampleConfig`).
 
 ## `blochwave`
 
-The beam-selection, coupling, and dynamical-solver settings (`BlochwaveConfig`), ordered here by
-how often you'd actually reach for them.
+Bloch wave simulation hyperparameters.
 
 | Field | Default | What it does |
 |---|---|---|
-| `g_max` | `2.25` | Solve cutoff (Å⁻¹): maximum reciprocal-vector length of beams entering the Bloch wave matrix. See [Convergence testing](convergence-testing.md). |
-| `sg_max` | `0.01` | Maximum excitation-error magnitude (Å⁻¹) for a beam to enter the simulation at a sampled tilt. |
-| `rocking_curve_sampling` | `50` | Tilt samples integrated per rocking curve. See [Convergence testing](convergence-testing.md). |
+| `solver` | `"matrix_exp"` | Solver used for preprocessing, inference, and refinement. Use `matrix_exp` when absorption is enabled. |
 | `absorption` | `false` | Include anomalous absorption as an imaginary structure-factor contribution. |
-| `mosaicity` | `false` | `true` converts the apparent mosaicity from `.cif_pets` into a moving-average width from the rocking-curve angular spacing; `false` applies no smoothing. The legacy `{window: N}` form sets the width directly. |
-| `rsg` | `0.66` | Klar beam-selection cutoff: relative excitation-error radius. |
-| `dsg` | `0.0015` | Klar beam-selection cutoff: excitation-error offset. |
-| `coupling_mode` | `"union"` | `"union"`: couple the union of excited beams across each tilt-chunk's boundary tilts. `"per_tilt"`: couple only each tilt's own excited beams (more accurate, more expensive). |
-| `union_adaptive` | `true` | See [Adaptive tilt-chunk coupling](#adaptive-tilt-chunk-coupling) below. |
-| `union_max_new_beams_pct` | `0.01` | Adaptive-chunking split threshold — see below. |
-| `fixed_n_segments` | `12` | Number of tilt-coupling segments when `coupling_mode: "union"` and `union_adaptive: false`. |
-| `solver` | `"matrix_exp"` | Dynamical solver, used for preprocessing search, refinement, and `run infer` alike. Must stay `matrix_exp` if `absorption: true` (the alternative, `bloch_eigen`, isn't safe for the non-Hermitian absorptive structure matrix). |
-| `ignore_orientations` | `()` | Zero-based PETS rotation indices to exclude from the whole experiment (damaged/empty/diagnostic frames). |
+| `rsg` | `0.66` | Relative excitation-error cutoff. See [`rsg` and `dsg`](#rsg-and-dsg). |
+| `dsg` | `0.0015` | Absolute excitation-error margin. |
+| `rocking_curve_sampling` | `50` | Tilt samples integrated per rocking curve. See [Convergence testing](convergence-testing.md). |
+| `mosaicity` | `false` | Convert the apparent mosaicity from `.cif_pets` into a moving-average width using the spacing between rocking-curve samples. No additional orientations are simulated. |
+| `coupling_mode` | `"union"` | Beam-coupling method. See [Union coupling](#union-coupling). |
+| `union_adaptive` | `true` | Choose union sections adaptively. See [Union coupling](#union-coupling). |
+| `fixed_n_segments` | `12` | Number of union sections when adaptive splitting is disabled. See [Union coupling](#union-coupling). |
+| `union_max_new_beams_pct` | `0.01` | Threshold for adaptive splitting. See [Union coupling](#union-coupling). |
+| `g_max` | `2.25` | Largest reflection {math}`g` vector simulated (Å⁻¹). Off-diagonal structure factors extend to {math}`2g_\mathrm{max}`. |
+| `sg_max` | `0.01` | Maximum excitation-error magnitude (Å⁻¹) for a beam to enter the simulation at a sampled tilt. |
+| `ignore_orientations` | `()` | Zero-based `.cif_pets` rotation indices to exclude from the experiment. |
 
-### Adaptive tilt-chunk coupling
+### `rsg` and `dsg`
 
-`coupling_mode: "union"` couples, within each tilt chunk, the beam set that is the *union* of the
-excited beams at the chunk's two boundary tilts (see [Preprocessing](preprocessing.md) for what
-"coupling" means here). `union_adaptive` picks how those chunk boundaries are chosen:
+Virtual frames overlap, so the same reflection may be recorded in neighbouring frames. `rsg` and
+`dsg` identify the frames in which a reflection passes sufficiently far through the Bragg condition
+to be treated as fully integrated.
 
-- `true` (default): recursive bisection. Start with one chunk spanning the whole rocking curve;
-  at each step, check the chunk's midpoint tilt against the union already covered by its two
-  endpoints. If the midpoint would add more than `union_max_new_beams_pct` of *new* beams beyond
-  that union, split the chunk in two at the midpoint and recurse into each half; otherwise the
-  chunk is left as one piece. This puts more, smaller chunks where the excited beam set is
-  changing quickly across the rocking curve (e.g. near a strong systematic row) and fewer, larger
-  chunks where it's stable — without needing to know in advance where that is.
-- `false`: `fixed_n_segments` evenly-sized chunks regardless of how much the beam set actually
-  changes across them.
+For each reflection, diffBloch calculates its excitation error {math}`|S_g|` at the centre of the
+frame and the excitation-error half-range {math}`\Delta S_g` swept from the centre to the edge of
+that frame. The reflection is retained when both conditions are satisfied:
 
-Adaptive chunking costs more beam-set unions up front (to evaluate the split predicate) but
-generally solves fewer total beams than a fixed split sized conservatively enough to avoid
-under-coupling; a fixed split is more predictable when you want a fixed, known chunk count instead.
+```{math}
+\frac{|S_g|}{\Delta S_g} < rsg
+```
+
+```{math}
+\Delta S_g-|S_g| > dsg.
+```
+
+`rsg` is dimensionless. It limits the reflection's central excitation error relative to its swept
+range. Increasing `rsg` retains reflections farther from the centre of that range. `dsg` is an
+absolute margin in Å⁻¹. Increasing `dsg` rejects reflections that only just enter the integration
+range. These parameters select the reflections compared with experiment; they do not select the
+beams included in the Bloch wave calculation.
+
+### Union coupling
+
+Each virtual frame covers a small angular range of the crystal's rotation. To simulate its
+integrated intensity, diffBloch samples a rocking curve across that range.
+`rocking_curve_sampling` sets the number of samples. Each sample is a **tilt**: one crystal
+orientation within the virtual frame. The intensities calculated at all tilts are summed to give
+the simulated integrated intensity for that frame.
+
+Changing the tilt changes every reflection's excitation error {math}`S_g`. At each tilt, beams are
+selected when {math}`|S_g| < sg_\mathrm{max}`. In `per_tilt` mode, diffBloch applies this test and
+builds a separate structure matrix at every tilt. This keeps each matrix as small as possible, but
+repeatedly calculates {math}`S_g` for all candidate reflections and prevents the tilts from being
+solved together efficiently.
+
+`union` mode groups neighbouring tilts. Every tilt in a group uses one combined beam set containing
+the beams selected at the group's boundaries. The off-diagonal elements describe coupling between
+these beams through the structure factors and are reused across the group. The diagonal contains
+the excitation error of each beam and is recalculated for every tilt. The matrices are then solved
+as a batch, making better use of GPU parallelization. This is usually faster when the individual
+structure matrices are small or moderate in size.
+
+The combined beam set is larger than the set needed by any one tilt. Union mode therefore solves
+larger matrices and stores several of them on the GPU at once. When the matrices are already large,
+or GPU memory is nearly full, this cost can outweigh the benefit of batching. In that case,
+`coupling_mode: "per_tilt"` is likely to be faster and use less memory.
+
+With `union_adaptive: true`, diffBloch makes shorter groups where the beam set changes rapidly and
+longer groups where it remains stable. `union_max_new_beams_pct` controls when a group is split.
+With adaptive grouping disabled, `fixed_n_segments` sets the number of equal groups.
 
 ## `preprocess`
 
@@ -113,7 +146,7 @@ Top-level, not nested under `refinement`, because it governs preprocessing too.
 
 | Field | Default | What it does |
 |---|---|---|
-| `residual` | `"wr2"` | `"wr2"` or `"robs"`. Both re-fit an optimal multiplicative scale between calculated and observed intensities before scoring (`core.losses.optimal_scale`) — necessary since the Bloch wave solve comes off on an arbitrary structure-factor scale, not PETS's own intensity scale. Parses into the matching loss (gradient refinement) and per-thickness scores (preprocessing search) function pair — the two stages always agree on one metric. |
+| `residual` | `"wr2"` | `"wr2"` or `"robs"`. Both re-fit an optimal multiplicative scale between calculated and observed intensities before scoring (`core.losses.optimal_scale`) because calculated and `.cif_pets` intensities use different scales. Parses into the matching loss (gradient refinement) and per-thickness scores (preprocessing search) function pair — the two stages always agree on one metric. |
 
 ## `refinement`
 
@@ -177,7 +210,7 @@ list of 2+ paths) into one experiment, each dataset keeping its own energy, orie
 thickness. Two situations call for it:
 
 - **Beam damage series** — repeat measurements of the same crystal taken at increasing dose. Each
-  dataset is its own PETS file (its own UB, its own apparent thickness), but they refine one shared
+  dataset is its own `.cif_pets` file (its own UB, its own apparent thickness), but they refine one shared
   structure; combining them uses every rotation instead of picking one dataset and discarding the
   rest.
 - **Low-symmetry structures** — a single tilt series from one crystal orientation range may not

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ diffBloch performs the refinement as two complementary values: a crystal structu
 | [Preprocessing](preprocessing.md) | Crystal-orientation and thickness determination before structural refinement. |
 | [Bloch wave simulation](bloch_wave_simulation.md) | Theory and equations used to calculate dynamical diffraction intensities. |
 | [Refinement](refinement.md) | Structural parameter optimization against experimental intensities. |
+| [Devices and scaling](devices-and-scaling.md) | CPU and GPU execution, memory controls, and refinement profiling. |
 | [Reproducibility](reproducibility.md) | Records identifying the inputs and preprocessing used for a refinement. |
 | [Examples](examples.md) | Runnable experiments included with diffBloch. |
 
@@ -54,19 +55,13 @@ uv sync --dev
 ```
 
 Each diffBloch command takes the path to an experiment directory containing `experiment.yaml`, the
-starting CIF, and the PETS data:
+starting CIF, and the `.cif_pets` data:
 
 ```bash
-uv run diffbloch convergence-test <experiment_dir>
-uv run diffbloch preprocess <experiment_dir>
-uv run diffbloch infer <experiment_dir>
 uv run diffbloch refine <experiment_dir>
 ```
 
-`convergence-test` checks the simulation settings. `preprocess` determines orientation and
-thickness. `infer` calculates intensities and residuals without changing the structure. `refine`
-optimizes the selected structural parameters. Add `--refresh` to rebuild preprocessing, or select
-the processor with `--device cpu` or `--device cuda`.
+
 
 ## Citation
 
@@ -93,6 +88,7 @@ convergence-testing.md
 preprocessing.md
 bloch_wave_simulation.md
 refinement.md
+devices-and-scaling.md
 reproducibility.md
 examples.md
 ```

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -59,10 +59,6 @@ inputs:
   exp_data:
     - crystal_1.cif_pets
     - crystal_2.cif_pets
-
-refinement:
-  thickness_nn:
-    enabled: false
 ```
 
 The rotations from all files are combined against one structure. Each dataset keeps its own

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -6,7 +6,7 @@ therefore determines this experimental metadata before refining the structure an
 PETS2 reduces continuous-rotation data into overlapping **virtual frames**
 ([Klar *et al.*, 2023](https://doi.org/10.1038/s41557-023-01186-1)). Because the frames overlap, a
 given reflection can appear in several neighbouring frames, but should only be fully integrated in
-one of them -- `rsg`/`dsg` (see [Comparing simulation with experiment](workflow.md#comparing-simulation-with-experiment))
+one of them -- `rsg`/`dsg` (see [`blochwave`](hyperparameter-selection.md#blochwave))
 aid in assigning each reflection to the correct frame. diffBloch only looks at fully-integrated
 intensities: partial reflections are not simulated. It represents each virtual frame by sampled
 tilt sub-orientations and sums their simulated intensities.
@@ -24,7 +24,7 @@ diffBloch separates the two matrices using
 U = (UB)B^{-1}.
 ```
 
-For virtual frame {math}`i`, the PETS goniometer angles are then applied in their recorded order:
+For virtual frame {math}`i`, the goniometer angles recorded in `.cif_pets` are applied in their recorded order:
 
 ```{math}
 M_i = R_z(\omega_i)R_x(\alpha_i)R_y(\beta_i)(UB)B^{-1},
@@ -45,20 +45,20 @@ M_i' = M_i R_z(\Delta\omega)R_x(\Delta\alpha)R_y(\Delta\beta).
 The Bloch wave intensities are recalculated for each trial and compared with the observed
 intensities using `loss_metrics.residual`, which defaults to `wr2`.
 
-### Unit-cell authority: PETS overrides the structure CIF
+### Unit-cell authority
 
-The reciprocal-basis matrix {math}`B` above is built from **PETS's own recorded cell**, not the
-structure CIF's. PETS is authoritative for every piece of simulation geometry that needs a unit
+The reciprocal-basis matrix {math}`B` above is built from the cell recorded in `.cif_pets`, not the
+structure CIF's. The `.cif_pets` cell is authoritative for every piece of simulation geometry that needs a unit
 cell — the structure-factor grid, the reciprocal basis, the cell volume, the ADP {math}`U^*`-frame
 conversion, and the beam geometry derived from that grid. The structure CIF still supplies every
 piece of atomic content: positions, atom types, occupancies, ADPs, and symmetry operators.
-Fractional coordinates are read from the CIF unchanged; they are simply interpreted against PETS's
+Fractional coordinates are read from the CIF unchanged; they are interpreted using the `.cif_pets`
 cell rather than the CIF's own.
 
-diffBloch checks the CIF's cell against PETS's on load:
+diffBloch checks the CIF cell against the `.cif_pets` cell on load:
 
 - **> 1% relative difference** on any of `a, b, c, alpha, beta, gamma` logs a warning stating that
-  the PETS value overrides the CIF value. Day-to-day refinement/measurement drift stays well under
+  the `.cif_pets` value overrides the CIF value. Day-to-day refinement/measurement drift stays well under
   this.
 - **> 5% relative difference** raises `ValueError` and stops, listing every offending parameter, both
   values, and the percentage difference. A gap this large usually means the two files describe
@@ -68,7 +68,7 @@ diffBloch checks the CIF's cell against PETS's on load:
 For a combined experiment, the first `.cif_pets` file's cell is the shared authoritative cell. The
 structure CIF and every further `.cif_pets` file are checked against it under the same thresholds.
 Each combined dataset's own {math}`U = (UB)B^{-1}` is still derived from *that dataset's own* UB
-matrix and *its own* PETS cell — so `U` stays close to a pure rotation — only the cell it gets
+matrix and its own `.cif_pets` cell — so `U` stays close to a pure rotation — only the cell it gets
 composed with downstream is the shared authoritative one.
 
 ### Orientation-search method
@@ -85,11 +85,11 @@ experiment. Nelder--Mead ranks the four residuals and replaces the worst point b
 through the opposite face of the simplex. Depending on the new residual, it may expand farther in
 that direction, contract toward the better points, or shrink the whole simplex around the best
 point. The simplex therefore moves and changes size as it approaches a local minimum. The final
-three coordinates are applied to the PETS orientation as
+three coordinates are applied to the `.cif_pets` orientation as
 {math}`(\Delta\alpha,\Delta\beta,\Delta\omega)`.
 
 This is a local, unconstrained search. `step_size` defines only the initial simplex; it neither
-limits the correction angles nor guarantees that the search finds the global minimum. The PETS UB
+limits the correction angles nor guarantees that the search finds the global minimum. The `.cif_pets` UB
 matrix must already provide a close starting orientation.
 
 | Method | Search | Status |
@@ -252,4 +252,4 @@ adding orientations, so enabling mosaicity adds no preprocessing or refinement c
 
 Set `blochwave.mosaicity: false` (the default) to evaluate only the nominal tilt orientations and
 sum their intensities without mosaic broadening. The legacy `{window: N}` form sets the
-moving-average width directly, independent of any PETS-reported value.
+moving-average width directly, independent of the value recorded in `.cif_pets`.

--- a/docs/refinement.md
+++ b/docs/refinement.md
@@ -4,7 +4,7 @@ Refinement holds a settled `Plan` (fitted orientation, tilts, thickness — see
 [Preprocessing](preprocessing.md)) fixed and minimizes the scaling-optimized weighted {math}`wR_2`
 of [Klar *et al.* (2023)](https://doi.org/10.1038/s41557-023-01186-1) over the differentiable
 structural parameters — ASU positions, ADPs, occupancies — by gradient descent through the full
-dynamical calculation described in [Workflow](workflow.md#refinement). `R_obs`, the Bragg
+dynamical calculation described in [Workflow](workflow.md#structural-refinement). `R_obs`, the Bragg
 {math}`R`-factor restricted to {math}`I_{\mathrm{obs}} > 3\sigma` reflections, is reported alongside
 {math}`wR_2` at every step as the conventional crystallographic residual, but is not itself the
 optimized quantity.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,148 +1,137 @@
 # Workflow
 
-diffBloch converts a starting crystal structure and 3D electron-diffraction data into a
-refined structure through the following calculation:
-
-```text
-.cif structure + .cif_pets experiment
-  -> crystal potential
-  -> Bloch wave simulation
-  -> calculated/observed intensity comparison
-  -> preprocessing
-  -> structural refinement
-```
+diffBloch converts a starting crystal structure and 3D electron-diffraction data into a refined structure.
 
 This page walks through that calculation end to end.
 
-## Structural and experimental data
+Before running diffBloch, an `experiment.yaml` file must be created in the directory containing the
+starting structure `.cif` and experimental `.cif_pets` data. The YAML identifies those files and
+specifies the simulation, preprocessing, and refinement settings that are not selected from the
+input data. See [Hyperparameter selection](hyperparameter-selection.md) for the available settings
+and their defaults.
 
-The structure `.cif` supplies asymmetric-unit atoms, fractional coordinates, elemental identities,
-occupancies, atomic displacement parameters (ADPs), and space-group symmetry operations. It also
-carries its own unit cell, but that cell is used only as a consistency check, never for simulation
-geometry — see [Unit-cell authority](#unit-cell-authority) below.
+Commands are run from the repository root with `uv run`. In the examples below,
+`<experiment_dir>` denotes this directory.
 
-The `.cif_pets` file supplies the measured experimental data: observed reflection intensities and
-uncertainties for each rotation, the UB orientation matrix, electron wavelength, the goniometer
-angles, and its own unit cell.
+## Experiment directory
 
-Both files are parsed into validated numerical records before simulation begins. Malformed values
-and unsupported representations fail at this boundary. See [Inputs and outputs](inputs.md) for the file
-requirements and experiment-directory layout.
-
-### Unit-cell authority
-
-**PETS's cell, not the structure CIF's, is authoritative for every piece of simulation
-geometry**: the structure-factor grid, the reciprocal basis, the cell volume, the ADP `U*`-frame
-conversion, and the beam geometry derived from that grid. The CIF's own cell is checked against
-PETS's on load — a >1% relative difference on any of `a, b, c, alpha, beta, gamma` logs a warning
-(stating that PETS overrides the CIF), a >5% difference raises and stops, listing every offending
-parameter, both values, and the percentage difference. Fractional atomic coordinates are read from the CIF
-unchanged; they are simply interpreted against PETS's cell rather than the CIF's own. For a combined
-(`inputs.multi_dataset`) experiment, the first combined `.cif_pets` file is the shared anchor every
-other input — the CIF's and every further combined file's — is checked against, under the same two
-thresholds; see [Inputs and outputs](inputs.md#unit-cell) for the
-full rule and [Preprocessing](preprocessing.md#unit-cell-authority-pets-overrides-the-structure-cif)
-for how each combined file's own orientation matrix still comes from its own UB and cell before
-being composed with that shared anchor.
-
-## Constructing the crystal potential
-
-The asymmetric unit is expanded using the symmetry operations from the `.cif`: symmetry operation
-{math}`(R_m, \mathbf{t}_m)` maps atomic position {math}`\mathbf{r}_i` to
-{math}`\mathbf{r}'_{mi} = R_m\mathbf{r}_i + \mathbf{t}_m`. Each expanded atom then contributes to
-the elastic electron structure factor {math}`F_{\mathbf{g}}` (optionally with an imaginary
-absorptive component) -- see
-[Elastic scattering and the structure factor](bloch_wave_simulation.md#elastic-scattering-and-the-structure-factor)
-for the full expression. {math}`F_{\mathbf{g}}` is the reciprocal-space crystal potential the
-Bloch wave calculation consumes.
-
-## Bloch wave simulation
-
-For each experimental orientation, diffBloch selects the reciprocal-lattice vectors included in the
-calculation, calculates their excitation errors, and constructs and solves the Bloch structure
-matrix — the full derivation, from the elastic structure factor through the relativistic
-interaction parameter to the structure matrix and its two equivalent solvers, is in
-[Bloch wave simulation](bloch_wave_simulation.md). The incident wave begins entirely in the
-transmitted beam; propagating it through specimen thickness {math}`t` and reading off
-{math}`|\psi_{\mathbf{g}}(t)|^2` gives the calculated intensity for every included reflection.
-
-A continuous-rotation frame covers an angular interval rather than one static orientation.
-diffBloch samples that rocking curve, performs a Bloch wave solve at each sub-orientation, and sums
-the intensities incoherently:
-
-```{math}
-I_{\mathrm{frame}}(t) = \sum_k |\psi^{(k)}(t)|^2.
-```
-
-With `mosaicity: true`, diffBloch reads the apparent mosaicity from `.cif_pets` and converts it to a
-moving-average width using the angular spacing between sampled orientations. The calculated
-rocking curve is smoothed over that width before it is summed. This does not add Bloch wave solves.
-`mosaicity: false` (the default) applies no smoothing. The legacy `{window: N}` form sets the width
-directly. The output is one calculated diffraction pattern for each experimental rotation.
-
-## Comparing simulation with experiment
-
-The calculated intensities are matched to the observed reflections from the corresponding `.cif_pets`
-rotation. diffBloch distinguishes three reflection sets:
-
-- **solve beams** participate in the dynamical calculation;
-- **matched reflections** occur in both the calculated and experimental patterns;
-- **scored reflections** are the matched reflections admitted to the objective.
-
-Refinement minimises a scaling-optimised residual. The default is {math}`wR_2`.
-{math}`R_{\mathrm{obs}}`, restricted to observations satisfying {math}`I>3\sigma`, is also
-reported.
-
-## Preprocessing the experiment
-
-The PETS orientations provide the starting geometry. diffBloch searches a small angular region
-around each orientation and retains the orientation with the best agreement to the observed
-intensities.
-
-Specimen thickness strongly affects dynamical intensities. Preprocessing determines thickness before
-orientation optimization. This improves the orientation comparison and gives the thickness model a
-better starting value during refinement.
-
-Convergence tests determine the reciprocal-space cutoffs and rocking-curve sampling used during
-refinement.
-
-The output is a `Plan` containing the orientations, thicknesses, beam geometry, experimental
-observations, and calculated/observed reflection alignment. The `Plan` remains fixed during
-structural refinement. See [Preprocessing](preprocessing.md) and
-[Convergence testing](convergence-testing.md).
-
-## Refinement
-
-Refinement holds the settled `Plan` fixed and repeatedly evaluates the scientific calculation:
+A calculation begins with an experiment directory containing:
 
 ```text
-raw structural parameters
-  -> physical crystallographic structure
-  -> crystal potential
-  -> Bloch wave intensities
-  -> comparison with experiment
-  -> scalar objective
-  -> gradients and updated parameters
+<experiment_dir>/
+  experiment.yaml
+  structure.cif
+  exp_data.cif_pets
 ```
 
-Automatic differentiation calculates the gradient of the objective with respect to the selected
-atomic positions, ADPs, and occupancies. Crystallographic constraints are applied before the
-potential is calculated. Molecular constraints, such as hydrogen riding, and soft structural
-restraints can also be included. See [Refinement](refinement.md).
+The structure CIF supplies the starting atomic model. The `.cif_pets` file supplies the observed
+intensities, uncertainties, orientations, wavelength, goniometer angles, and unit cell. Both
+files are specified in `experiment.yaml`:
 
-## Learned model components
+```yaml
+name: example-experiment
 
-Differentiable models can be refined alongside the atomic structure. The current thickness neural
-network takes the experimental rotation coordinate and supplies a thickness to each Bloch wave
-calculation. Its parameters are updated using the same diffraction objective as the structure.
+inputs:
+  structure: structure.cif
+  exp_data: exp_data.cif_pets
 
-The same design can support other quantities that vary through an experiment. Planned beam
-damage models will describe changes across an ordered dataset. Future components could describe
-other systematic experimental changes or additional scattering contributions, including inelastic
-scattering.
+sample:
+  thicknesses: [800.0]  # Angstroms
+```
 
-## Logs, locks, and reproducibility
+The simulation hyperparameters include the reciprocal-space cutoffs and the number of rocking-curve
+samples. Suitable values depend on the experiment and should be established by convergence testing
+before preprocessing or refinement. See [Inputs and outputs](inputs.md) for the complete directory layout,
+multiple datasets, excluded rotations, and unit-cell checks.
 
-Logs report preprocessing, comparison metrics, and refinement progress. Locks record the input
-files, configuration, code version, and generated results. See
-[Reproducibility](reproducibility.md).
+## Convergence testing
+
+The convergence test determines suitable values for the main simulation hyperparameters:
+
+```bash
+uv run diffbloch convergence-test <experiment_dir>
+```
+
+The optional `--orientations N` argument includes more than the first orientation:
+
+```bash
+uv run diffbloch convergence-test <experiment_dir> --orientations 3
+```
+
+The command reports settled values for `gmax`, `sgmax`, and `tilt_steps`. These correspond to
+`blochwave.g_max`, `blochwave.sg_max`, and `blochwave.rocking_curve_sampling` in
+`experiment.yaml`.
+
+Convergence is normally insensitive to small orientation corrections and changes in atomic coordinates or ADPs during structural refinement. Thickness may matter: a substantially thicker crystal will have a narrower rocking curve and may require more tilt samples to maintain angular sampling. If thickness optimization gives a value far from the thickness used for the convergence test, the test should be repeated at the revised thickness. See
+[Convergence testing](convergence-testing.md).
+
+## Preprocessing
+
+Preprocessing establishes specimen thickness and optimizes the experimental orientations before structural refinement.  See [Preprocessing](preprocessing.md) for more information.
+
+Preprocessing is run with:
+
+```bash
+uv run diffbloch preprocess <experiment_dir>
+```
+
+
+When the approximate mean thickness is known, one shared starting value may be used for
+orientation optimization:
+
+```yaml
+sample:
+  thicknesses: [800.0]
+
+preprocess:
+  optimize_thickness: false
+```
+
+When the thickness is uncertain, a grid search can be run before orientation optimization:
+
+```yaml
+preprocess:
+  optimize_thickness: true
+  optimize_orientation: true
+  thickness:
+    min_thickness: 100.0
+    max_thickness: 2000.0
+    n_steps: 100
+    plot: true
+```
+
+With `plot: true`, residual-versus-thickness plots are written to `thickness_optim/`.  These plots may also be examined for debugging purposes. In the ideal cases the minimum-residual thickness should vary smoothly with orientation.
+
+## Structural refinement
+
+The structural parameters and optimizer settings are specified in `experiment.yaml`. Refinement is
+run with:
+
+```bash
+uv run diffbloch refine <experiment_dir>
+```
+
+
+The objective and validation metrics are reported throughout the run. A lower training loss without
+improved validation agreement can indicate over-fitting.
+
+See [Refinement](refinement.md) for trainable positions, ADPs, occupancies, constraints, restraints,
+and optional learned thickness components.
+
+## Outputs
+
+A completed refinement writes the main results beside the inputs and under `reproducibility/`:
+
+```text
+<experiment_dir>/
+  refined_structure.cif
+  refinement_report.txt
+  thickness_optim/                 # when thickness plots are enabled
+  reproducibility/
+```
+
+`refined_structure.cif` contains the refined structural model, while `refinement_report.txt`
+summarizes the run. The `experiment.yaml`, `.cif`, `.cif_pets`, and complete `reproducibility/` directory form
+the record associated with a reported result. The locks verify the inputs and preprocessed starting
+point; they do not guarantee identical floating-point optimizer trajectories on different
+hardware. See [Reproducibility](reproducibility.md).


### PR DESCRIPTION
## Summary

- restores the Devices and scaling guide
- explains CPU and CUDA execution, workers, and maximum batch size
- restores measured CPU/GPU timings and forward/gradient profiling results
- adds the guide to the website navigation
- carries forward the latest workflow, preprocessing, convergence, and hyperparameter documentation edits
- fixes two stale internal documentation links

## Scope

Documentation only. No source code, experiment outputs, or generated site files are included.

## Validation

The complete Sphinx site builds successfully. The local build reported only unavailable external intersphinx inventories because network access is restricted.