### PR TITLE
Support per-dataset thickness NNs for multi-dataset refinement

### DIFF
--- a/docs/hyperparameter-selection.md
+++ b/docs/hyperparameter-selection.md
@@ -39,10 +39,6 @@ sample:
   mean_thickness_by_dataset:
     dataset_1.cif_pets: 400.0
     dataset_2.cif_pets: 800.0
-
-refinement:
-  thickness_nn:
-    enabled: false
 ```
 
 ## `blochwave`
@@ -210,6 +206,10 @@ Apparent-thickness neural network used by the default refinement path (`Thicknes
 | `max_thickness` | `2000.0` | Upper bound, Å, for the network's thickness output. |
 | `init_seed` | `0` | Random seed for the network's initial weights. |
 
+With `inputs.multi_dataset: true`, one network is trained per dataset, each scoped to its own
+rotations and normalizing its own tilt range; these fields configure every network identically
+(including `init_seed` — per-dataset seeds would make results depend on `exp_data` ordering).
+
 ## `inputs`
 
 Input file references, relative to the experiment directory only (`Inputs`).
@@ -236,8 +236,9 @@ geometry, and thickness seed. Two situations call for it:
 
 Each dataset is preprocessed and checkpointed on its own (`plan.<stem>.npz` per file, with its own
 integration geometry -- precession angles may differ between files), and the settled per-dataset
-plans are pooled in memory just before refinement. See
-[Inputs and outputs](inputs.md) for the mechanics (per-dataset checkpoints, the
+plans are pooled in memory just before refinement. The learned thickness model follows the same
+per-dataset shape: one `refinement.thickness_nn` network per file, reported per dataset. See
+[Inputs and outputs](inputs.md#multiple-datasets) for the mechanics (per-dataset checkpoints, the
 first-file authoritative cell, one-energy rule, rotation-index offsets) and
 [Reproducibility](reproducibility.md) for what each per-dataset lock verifies.
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -59,15 +59,16 @@ inputs:
   exp_data:
     - crystal_1.cif_pets
     - crystal_2.cif_pets
-
-refinement:
-  thickness_nn:
-    enabled: false
 ```
 
 The rotations from all files are combined against one structure. Each dataset keeps its own
 orientations and thicknesses. The files must describe the same crystal and use the same electron
 energy. The first `.cif_pets` file supplies the unit cell used for the combined refinement.
+
+When the learned thickness model is enabled (`refinement.thickness_nn`, the default), each dataset
+trains its own network over its own tilt range — pooled datasets with overlapping tilt ranges are
+never forced onto one shared thickness-vs-alpha curve. The refinement report carries one
+`Thickness NN -- <ref>` section and one `thickness_nn_shape_<stem>.png` plot per dataset.
 
 ## Outputs
 
@@ -78,6 +79,7 @@ Running preprocessing or refinement adds results to the experiment directory:
 | `refined_structure.cif` | Refined crystal structure. |
 | `refinement_report.txt` | Final residuals, reflection counts, and refinement summary. |
 | `thickness_optim/` | Thickness-search plots when plotting is enabled. |
+| `thickness_nn_shape_<stem>.png` | Learned thickness curve per `.cif_pets` dataset, when the thickness network and plotting are enabled. |
 | `reproducibility/experiment.lock` | Record of the input files. |
 | `reproducibility/plan.<stem>.npz` | Saved preprocessing for each `.cif_pets` dataset. |
 | `reproducibility/plan.<stem>.lock` | Inputs and settings used for the saved preprocessing. |

--- a/docs/refinement.md
+++ b/docs/refinement.md
@@ -67,7 +67,7 @@ training objective.
 | `refined_structure.cif` | Best constrained coordinates, occupancies, and ADPs in CIF form. |
 | `refinement_report.txt` | Best epoch metrics, which objective selected it, and the compact HKL count. |
 | `refined_parameters.npz` | Exact raw optimizer parameters for the best epoch. |
-| `refined_components.npz` | Trainable component tensors for the best epoch, when components are composed. |
+| `refined_components.npz` | Trainable component tensors for the best epoch, when components are composed. Thickness-network tensors are stored per dataset under `apparent_thickness[<ref>]__<parameter>` names. |
 | `plan.<stem>.npz` / `plan.<stem>.lock` | Settled preprocessing plan and its provenance lock, one pair per `inputs.exp_data` file. |
 | `refinement.lock` | Binds the refined outputs to every dataset's plan lock (`plan_lock_sha256s`), config digest, and code version; written only when every plan lock exists. |
 

--- a/src/diffBloch/app/loggers/plotting.py
+++ b/src/diffBloch/app/loggers/plotting.py
@@ -90,12 +90,14 @@ def plot_thickness_nn_shape(
     output_path: str | Path,
     *,
     xlabel: str = "alpha (degrees)",
+    title: str = "Thickness NN final shape",
 ) -> None:
     """Save one PNG: the fitted thickness NN's predicted thickness vs. rotation angle.
 
     ``rows`` is ``(angle, thickness)`` pairs, one per rotation, in any order -- plotted sorted by
     angle so the curve reads left to right. This is the final learned shape after refinement
-    completes, not a training-progress plot.
+    completes, not a training-progress plot. ``title`` names the dataset when several networks
+    each get a plot, so the PNGs are self-identifying.
     """
     import matplotlib
 
@@ -120,7 +122,7 @@ def plot_thickness_nn_shape(
     )
     ax.set_xlabel(xlabel)
     ax.set_ylabel("Predicted thickness (Å)")
-    ax.set_title("Thickness NN final shape")
+    ax.set_title(title)
     _apply_house_style(ax)
     fig.tight_layout()
     output_path = Path(output_path)

--- a/src/diffBloch/app/loggers/summary.py
+++ b/src/diffBloch/app/loggers/summary.py
@@ -106,7 +106,7 @@ class SummaryLogger:
     _steps: list[RefinementStep] = field(default_factory=list, init=False, repr=False)
     _completed: RefinementCompleted | None = field(default=None, init=False, repr=False)
     _rotations: list[RefinedRotationMetrics] = field(default_factory=list, init=False, repr=False)
-    _profile: ThicknessProfile | None = field(default=None, init=False, repr=False)
+    _profiles: list[ThicknessProfile] = field(default_factory=list, init=False, repr=False)
     _started_at: float = field(default=0.0, init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -127,7 +127,7 @@ class SummaryLogger:
         elif isinstance(event, RefinedRotationMetrics):
             self._rotations.append(event)
         elif isinstance(event, ThicknessProfile):
-            self._profile = event
+            self._profiles.append(event)
         elif isinstance(event, RefinementOutputsWritten):
             self._write(event)
 
@@ -339,46 +339,49 @@ class SummaryLogger:
             block(validation)
 
     def _thickness_profile(self, lines: list[str], rule: Callable[[str], None]) -> None:
-        rule("Thickness NN")
-        profile = self._profile
-        if profile is None:
+        if not self._profiles:
+            rule("Thickness NN")
             lines.append(" enabled: no (preprocess-baked per-rotation thickness only)")
             return
-        lines.append(
-            f" enabled: yes ({profile.form}, bounds "
-            f"[{profile.min_thickness:g}, {profile.max_thickness:g}] A)"
-        )
-        lines.append("")
-        lines.append(
-            ascii_table(
-                ["Rotation", "alpha (degrees)", "Thickness (A)"],
-                [
-                    [str(index), f"{alpha:.4f}", f"{thickness:.2f}"]
-                    for index, alpha, thickness in zip(
-                        profile.rotation_indices,
-                        profile.alphas,
-                        profile.thicknesses,
-                        strict=True,
-                    )
-                ],
+        for profile in self._profiles:
+            title = "Thickness NN" if profile.label is None else f"Thickness NN -- {profile.label}"
+            rule(title)
+            lines.append(
+                f" enabled: yes ({profile.form}, bounds "
+                f"[{profile.min_thickness:g}, {profile.max_thickness:g}] A)"
             )
-        )
-        if not self.plot:
-            return
-        plot_path = self.path.parent / "thickness_nn_shape.png"
-        try:
-            from diffBloch.app.loggers.plotting import plot_thickness_nn_shape
-
-            plot_thickness_nn_shape(
-                list(zip(profile.alphas, profile.thicknesses, strict=True)), plot_path
-            )
-            lines.append("")
-            lines.append(f" plot: {plot_path.name}")
-        except ModuleNotFoundError:
             lines.append("")
             lines.append(
-                " plot: skipped (matplotlib not installed -- see the diffBloch[plot] extra)"
+                ascii_table(
+                    ["Rotation", "alpha (degrees)", "Thickness (A)"],
+                    [
+                        [str(index), f"{alpha:.4f}", f"{thickness:.2f}"]
+                        for index, alpha, thickness in zip(
+                            profile.rotation_indices,
+                            profile.alphas,
+                            profile.thicknesses,
+                            strict=True,
+                        )
+                    ],
+                )
             )
+            if not self.plot:
+                continue
+            suffix = "" if profile.label is None else f"_{profile.label.replace('/', '_')}"
+            plot_path = self.path.parent / f"thickness_nn_shape{suffix}.png"
+            try:
+                from diffBloch.app.loggers.plotting import plot_thickness_nn_shape
+
+                plot_thickness_nn_shape(
+                    list(zip(profile.alphas, profile.thicknesses, strict=True)), plot_path
+                )
+                lines.append("")
+                lines.append(f" plot: {plot_path.name}")
+            except ModuleNotFoundError:
+                lines.append("")
+                lines.append(
+                    " plot: skipped (matplotlib not installed -- see the diffBloch[plot] extra)"
+                )
 
     def _refined_structure(
         self, lines: list[str], rule: Callable[[str], None], structure_path: Path

--- a/src/diffBloch/app/loggers/summary.py
+++ b/src/diffBloch/app/loggers/summary.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 import gemmi
 
+from diffBloch.config.schema import dataset_checkpoint_stem
 from diffBloch.core.crystal import cell_volume
 from diffBloch.io import read_structure
 from diffBloch.observability import (
@@ -94,9 +95,9 @@ class SummaryLogger:
     rendered and written; a run that never emits that event writes nothing, which is the correct
     behaviour for an aborted run (there is no committed structure to describe).
 
-    ``plot`` (default ``True``) additionally writes the thickness-NN shape PNG beside the report when
-    a :class:`~diffBloch.observability.ThicknessProfile` was seen and matplotlib is installed; the
-    report notes the omission otherwise, exactly as before.
+    ``plot`` (default ``True``) additionally writes one thickness-NN shape PNG beside the report
+    per :class:`~diffBloch.observability.ThicknessProfile` seen (one per dataset, named by its
+    checkpoint stem) when matplotlib is installed; the report notes the omission otherwise.
     """
 
     path: Path
@@ -106,7 +107,7 @@ class SummaryLogger:
     _steps: list[RefinementStep] = field(default_factory=list, init=False, repr=False)
     _completed: RefinementCompleted | None = field(default=None, init=False, repr=False)
     _rotations: list[RefinedRotationMetrics] = field(default_factory=list, init=False, repr=False)
-    _profiles: list[ThicknessProfile] = field(default_factory=list, init=False, repr=False)
+    _profiles: dict[str, ThicknessProfile] = field(default_factory=dict, init=False, repr=False)
     _started_at: float = field(default=0.0, init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -127,7 +128,9 @@ class SummaryLogger:
         elif isinstance(event, RefinedRotationMetrics):
             self._rotations.append(event)
         elif isinstance(event, ThicknessProfile):
-            self._profiles.append(event)
+            # Keyed by dataset so a re-reported profile replaces its section (last event wins),
+            # while insertion order keeps sections in exp_data order.
+            self._profiles[event.label] = event
         elif isinstance(event, RefinementOutputsWritten):
             self._write(event)
 
@@ -343,9 +346,8 @@ class SummaryLogger:
             rule("Thickness NN")
             lines.append(" enabled: no (preprocess-baked per-rotation thickness only)")
             return
-        for profile in self._profiles:
-            title = "Thickness NN" if profile.label is None else f"Thickness NN -- {profile.label}"
-            rule(title)
+        for profile in self._profiles.values():
+            rule(f"Thickness NN -- {profile.label}")
             lines.append(
                 f" enabled: yes ({profile.form}, bounds "
                 f"[{profile.min_thickness:g}, {profile.max_thickness:g}] A)"
@@ -367,13 +369,17 @@ class SummaryLogger:
             )
             if not self.plot:
                 continue
-            suffix = "" if profile.label is None else f"_{profile.label.replace('/', '_')}"
-            plot_path = self.path.parent / f"thickness_nn_shape{suffix}.png"
+            # The checkpoint stem is the established filesystem-safe dataset name; refs are
+            # validated stem-unique, so per-dataset plot files cannot collide.
+            stem = dataset_checkpoint_stem(profile.label)
+            plot_path = self.path.parent / f"thickness_nn_shape_{stem}.png"
             try:
                 from diffBloch.app.loggers.plotting import plot_thickness_nn_shape
 
                 plot_thickness_nn_shape(
-                    list(zip(profile.alphas, profile.thicknesses, strict=True)), plot_path
+                    list(zip(profile.alphas, profile.thicknesses, strict=True)),
+                    plot_path,
+                    title=f"Thickness NN final shape -- {profile.label}",
                 )
                 lines.append("")
                 lines.append(f" plot: {plot_path.name}")

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -569,6 +569,8 @@ def refine_experiment(
                     sample_thickness=thickness_spec.sample_thickness,
                     num_samples=thickness_spec.num_samples,
                     init_seed=thickness_spec.init_seed,
+                    rotation_range=(0, len(raw_alphas)),
+                    label=_exp_data_refs(cfg)[0],
                 ),
             )
         model = build_refinement_model(
@@ -641,22 +643,12 @@ def _report_refinement_outcome(
             )
         )
     if raw_alphas is not None:
+        # Each network filters the pooled orientations to its own rotation_range itself.
         for thickness_nn in thickness_nns:
-            orientations = (
-                engine.orientations
-                if thickness_nn.rotation_range is None
-                else tuple(
-                    orientation
-                    for orientation in engine.orientations
-                    if thickness_nn.rotation_range[0]
-                    <= orientation.pattern.rotation_index
-                    < thickness_nn.rotation_range[1]
-                )
-            )
             logger.report(
                 thickness_nn.profile(
                     result.best_model.component_params[thickness_nn.key],
-                    orientations,
+                    engine.orientations,
                     raw_alphas,
                 )
             )

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -104,7 +104,12 @@ from diffBloch.preprocess.driver import ConvergenceState, run_convergence
 from diffBloch.preprocess.experiment import RefinementSetup
 from diffBloch.preprocess.inference import InferenceResult
 from diffBloch.preprocess.scoring import build_engine
-from diffBloch.specs import IntegrationGeometry, ScoredHklSelection, TrialCoupling
+from diffBloch.specs import (
+    ApparentThicknessNetwork,
+    IntegrationGeometry,
+    ScoredHklSelection,
+    TrialCoupling,
+)
 
 __all__ = [
     "converge_experiment",
@@ -541,38 +546,7 @@ def refine_experiment(
     if thickness_spec.enabled:
         records = _read_experimental_data(root, cfg)
         raw_alphas = np.concatenate([np.asarray(record.alphas) for record in records])
-        bounds = ThicknessBounds(thickness_spec.min_thickness, thickness_spec.max_thickness)
-        if cfg.inputs.multi_dataset:
-            offsets = np.cumsum([0, *(record.n_rotations for record in records)])
-            thickness_nns = tuple(
-                ApparentThicknessNN(
-                    bounds=bounds,
-                    normalized_alphas=_normalized_pets_alphas(raw_alphas[start:end]),
-                    key=f"apparent_thickness[{dataset_ref}]",
-                    form=thickness_spec.form,
-                    sample_thickness=thickness_spec.sample_thickness,
-                    num_samples=thickness_spec.num_samples,
-                    init_seed=thickness_spec.init_seed,
-                    rotation_range=(start, end),
-                    label=dataset_ref,
-                )
-                for dataset_ref, start, end in zip(
-                    _exp_data_refs(cfg), offsets[:-1], offsets[1:], strict=True
-                )
-            )
-        else:
-            thickness_nns = (
-                ApparentThicknessNN(
-                    bounds=bounds,
-                    normalized_alphas=_normalized_pets_alphas(raw_alphas),
-                    form=thickness_spec.form,
-                    sample_thickness=thickness_spec.sample_thickness,
-                    num_samples=thickness_spec.num_samples,
-                    init_seed=thickness_spec.init_seed,
-                    rotation_range=(0, len(raw_alphas)),
-                    label=_exp_data_refs(cfg)[0],
-                ),
-            )
+        thickness_nns = _thickness_networks(cfg, records, thickness_spec)
         model = build_refinement_model(
             initial=initial,
             components=thickness_nns,
@@ -655,6 +629,39 @@ def _report_refinement_outcome(
     logger.report(
         RefinementOutputsWritten(
             structure=result.artifacts["refined_structure"], artifacts=result.artifacts
+        )
+    )
+
+
+def _thickness_networks(
+    cfg: ExperimentConfig,
+    records: tuple[ExperimentalRecord, ...],
+    spec: ApparentThicknessNetwork,
+) -> tuple[ApparentThicknessNN, ...]:
+    """One thickness network per dataset, scoped to its pooled rotation-index range.
+
+    Ranges follow the cumulative pre-ignore rotation counts in ``inputs.exp_data`` order --
+    exactly how :func:`~diffBloch.preprocess.pool` numbers the pooled ``rotation_index`` space --
+    so the networks partition that space and composition finds exactly one thickness per
+    orientation. Alphas are normalized independently per dataset so overlapping tilt ranges do
+    not share one thickness-vs-alpha curve. A single dataset is simply the N=1 case.
+    """
+    bounds = ThicknessBounds(spec.min_thickness, spec.max_thickness)
+    offsets = np.cumsum([0, *(record.n_rotations for record in records)])
+    return tuple(
+        ApparentThicknessNN(
+            bounds=bounds,
+            normalized_alphas=_normalized_pets_alphas(np.asarray(record.alphas)),
+            key=f"apparent_thickness[{ref}]",
+            form=spec.form,
+            sample_thickness=spec.sample_thickness,
+            num_samples=spec.num_samples,
+            init_seed=spec.init_seed,
+            rotation_range=(int(start), int(end)),
+            label=ref,
+        )
+        for ref, record, start, end in zip(
+            _exp_data_refs(cfg), records, offsets[:-1], offsets[1:], strict=True
         )
     )
 

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -536,35 +536,50 @@ def refine_experiment(
     logger.report(cfg.to_declaration(integrations))
     initial = refinement.params if device is None else refinement.params.to(device)
     thickness_spec = cfg.refinement.thickness_nn.to_spec()
-    thickness_nn: ApparentThicknessNN | None = None
+    thickness_nns: tuple[ApparentThicknessNN, ...] = ()
     raw_alphas: np.ndarray | None = None
     if thickness_spec.enabled:
-        # Concatenated in inputs.exp_data order -- the order pool() numbers rotation_index in --
-        # so raw_alphas[rotation_index] resolves even with ignore gaps. ExperimentConfig rejects
-        # thickness_nn + multi_dataset at load time, so this is single-dataset today; the
-        # concatenation is already pooled-order-correct for the day the network learns a
-        # per-dataset input.
         records = _read_experimental_data(root, cfg)
         raw_alphas = np.concatenate([np.asarray(record.alphas) for record in records])
-        thickness_nn = ApparentThicknessNN(
-            bounds=ThicknessBounds(
-                thickness_spec.min_thickness,
-                thickness_spec.max_thickness,
-            ),
-            normalized_alphas=_normalized_pets_alphas(raw_alphas),
-            form=thickness_spec.form,
-            sample_thickness=thickness_spec.sample_thickness,
-            num_samples=thickness_spec.num_samples,
-            init_seed=thickness_spec.init_seed,
-        )
+        bounds = ThicknessBounds(thickness_spec.min_thickness, thickness_spec.max_thickness)
+        if cfg.inputs.multi_dataset:
+            offsets = np.cumsum([0, *(record.n_rotations for record in records)])
+            thickness_nns = tuple(
+                ApparentThicknessNN(
+                    bounds=bounds,
+                    normalized_alphas=_normalized_pets_alphas(raw_alphas[start:end]),
+                    key=f"apparent_thickness[{dataset_ref}]",
+                    form=thickness_spec.form,
+                    sample_thickness=thickness_spec.sample_thickness,
+                    num_samples=thickness_spec.num_samples,
+                    init_seed=thickness_spec.init_seed,
+                    rotation_range=(start, end),
+                    label=dataset_ref,
+                )
+                for dataset_ref, start, end in zip(
+                    _exp_data_refs(cfg), offsets[:-1], offsets[1:], strict=True
+                )
+            )
+        else:
+            thickness_nns = (
+                ApparentThicknessNN(
+                    bounds=bounds,
+                    normalized_alphas=_normalized_pets_alphas(raw_alphas),
+                    form=thickness_spec.form,
+                    sample_thickness=thickness_spec.sample_thickness,
+                    num_samples=thickness_spec.num_samples,
+                    init_seed=thickness_spec.init_seed,
+                ),
+            )
         model = build_refinement_model(
             initial=initial,
-            components=(thickness_nn,),
+            components=thickness_nns,
             component_params={
                 thickness_nn.key: thickness_nn.initial_params(
                     dtype=initial.asu_positions.dtype,
                     device=initial.asu_positions.device,
                 )
+                for thickness_nn in thickness_nns
             },
         )
     else:
@@ -592,7 +607,7 @@ def refine_experiment(
         engine,
         result,
         validation_rotation_indices=validation_rotation_indices,
-        thickness_nn=thickness_nn,
+        thickness_nns=thickness_nns,
         raw_alphas=raw_alphas,
     )
     return result
@@ -604,7 +619,7 @@ def _report_refinement_outcome(
     result: ModelRefinementResult,
     *,
     validation_rotation_indices: frozenset[int],
-    thickness_nn: ApparentThicknessNN | None,
+    thickness_nns: tuple[ApparentThicknessNN, ...],
     raw_alphas: np.ndarray | None,
 ) -> None:
     """Emit the settled-result events the refinement loop itself cannot produce.
@@ -625,14 +640,26 @@ def _report_refinement_outcome(
                 is_validation=row.rotation_index in validation_rotation_indices,
             )
         )
-    if thickness_nn is not None and raw_alphas is not None:
-        logger.report(
-            thickness_nn.profile(
-                result.best_model.component_params[thickness_nn.key],
-                engine.orientations,
-                raw_alphas,
+    if raw_alphas is not None:
+        for thickness_nn in thickness_nns:
+            orientations = (
+                engine.orientations
+                if thickness_nn.rotation_range is None
+                else tuple(
+                    orientation
+                    for orientation in engine.orientations
+                    if thickness_nn.rotation_range[0]
+                    <= orientation.pattern.rotation_index
+                    < thickness_nn.rotation_range[1]
+                )
             )
-        )
+            logger.report(
+                thickness_nn.profile(
+                    result.best_model.component_params[thickness_nn.key],
+                    orientations,
+                    raw_alphas,
+                )
+            )
     logger.report(
         RefinementOutputsWritten(
             structure=result.artifacts["refined_structure"], artifacts=result.artifacts

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -158,7 +158,7 @@ def _reproducibility_dir(root: Path) -> Path:
 
     Keeps ``root`` itself down to the handful of files someone actually reads (``experiment.yaml``,
     the input structure/experimental-data files, ``refined_structure.cif``,
-    ``refinement_report.txt``, the thickness-NN shape plot) -- everything else, including
+    ``refinement_report.txt``, the per-dataset thickness-NN shape plots) -- everything else, including
     ``experiment.lock`` (input-identity verification, not a generated output, but bookkeeping all
     the same), lives here instead: preprocess/refinement checkpoints and their locks, and the raw
     parameter/component ``.npz`` snapshots.

--- a/src/diffBloch/config/schema.py
+++ b/src/diffBloch/config/schema.py
@@ -507,17 +507,9 @@ class ExperimentConfig(_StrictConfig):
     refinement: RefinementConfig = Field(default_factory=RefinementConfig)
 
     @model_validator(mode="after")
-    def _multi_dataset_supported_refinement(self) -> ExperimentConfig:
-        # Fail at config load, not after the (potentially hours-long) preprocess: the thickness
-        # network keys only on each rotation's normalized alpha, so pooled datasets with
-        # overlapping tilt ranges would be forced onto one shared thickness-vs-alpha curve.
-        # thickness_nn defaults ON, so a pooled experiment must opt out explicitly.
-        if self.inputs.multi_dataset and self.refinement.thickness_nn.enabled:
-            raise ValueError(
-                "refinement.thickness_nn is not supported with inputs.multi_dataset (the network "
-                "cannot represent per-dataset thickness; that is future work) -- set "
-                "refinement.thickness_nn.enabled: false to pool datasets"
-            )
+    def _multi_dataset_cross_checks(self) -> ExperimentConfig:
+        # thickness_nn needs no gate here: refinement builds one network per dataset, so pooled
+        # experiments are supported with the default config.
         per_dataset = set(self.sample.mean_thickness_by_dataset)
         if per_dataset:
             if not self.inputs.multi_dataset or not isinstance(self.inputs.exp_data, list):

--- a/src/diffBloch/engine/components.py
+++ b/src/diffBloch/engine/components.py
@@ -188,6 +188,8 @@ class ApparentThicknessNN:
     sample_thickness: bool = False
     num_samples: int = 40
     init_seed: int = 0
+    rotation_range: tuple[int, int] | None = None
+    label: str | None = None
 
     def __post_init__(self) -> None:
         if self.form != "min_thickness":
@@ -198,6 +200,15 @@ class ApparentThicknessNN:
             raise ValueError("normalized_alphas must lie in [-1, 1]")
         if self.num_samples < 1:
             raise ValueError("num_samples must be >= 1")
+        if self.rotation_range is not None:
+            start, end = self.rotation_range
+            if start < 0 or end <= start:
+                raise ValueError("rotation_range must be a non-empty [start, end) with start >= 0")
+            if end - start != len(self.normalized_alphas):
+                raise ValueError(
+                    "rotation_range width must match len(normalized_alphas) "
+                    f"({end - start} != {len(self.normalized_alphas)})"
+                )
 
     def initial_params(
         self,
@@ -256,6 +267,7 @@ class ApparentThicknessNN:
             rotation_indices=tuple(indices),
             alphas=tuple(float(raw_alphas[index]) for index in indices),
             thicknesses=tuple(thicknesses),
+            label=self.label,
         )
 
     def forward_context(
@@ -279,9 +291,16 @@ class ApparentThicknessNN:
             raise ValueError(f"apparent thickness NN params tensors missing {missing!r}")
         w0 = params["layer0.weight"]
         source_index = orientation.pattern.rotation_index
-        if source_index < 0 or source_index >= len(self.normalized_alphas):
+        if self.rotation_range is not None:
+            start, end = self.rotation_range
+            if source_index < start or source_index >= end:
+                return ForwardContext(thickness=None)
+            local_index = source_index - start
+        else:
+            local_index = source_index
+        if local_index < 0 or local_index >= len(self.normalized_alphas):
             raise ValueError("source rotation index is outside normalized_alphas")
-        x = w0.new_tensor(self.normalized_alphas[source_index]).reshape(1, 1)
+        x = w0.new_tensor(self.normalized_alphas[local_index]).reshape(1, 1)
         x = torch.tanh(F.linear(x, w0, params["layer0.bias"]))
         x = torch.tanh(F.linear(x, params["layer1.weight"], params["layer1.bias"]))
         output = F.linear(x, params["layer2.weight"], params["layer2.bias"])
@@ -300,7 +319,7 @@ class ApparentThicknessNN:
             (len(self.normalized_alphas), self.num_samples),
             generator=generator,
             dtype=w0.dtype,
-        )[source_index].to(w0.device)
+        )[local_index].to(w0.device)
         thickness = F.softplus(mu + sigma * epsilon)
         return ForwardContext(thickness=thickness)
 

--- a/src/diffBloch/engine/components.py
+++ b/src/diffBloch/engine/components.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 import numpy as np
@@ -168,13 +168,21 @@ def _orientation_angle_fraction(orientation: Tensor) -> Tensor:
 
 @dataclass(frozen=True)
 class ApparentThicknessNN:
-    """Legacy apparent-thickness neural network from checkpoint-preprocess.
+    """Per-dataset apparent-thickness neural network.
 
-    The fixed ``1 -> 64 -> 64 -> 2`` tanh MLP consumes the PETS alpha angle after dataset-wide
+    The fixed ``1 -> 64 -> 64 -> 2`` tanh MLP consumes the PETS alpha angle after per-dataset
     min-max normalization to ``[-1, 1]``. Its first output is mapped affinely from that nominal
     interval into ``bounds``; as in the legacy implementation this is not a hard bound. In sampling
     mode the second output parameterizes a Gaussian width and the reparameterized, positive
     thickness samples are passed to the Bloch solve.
+
+    Each network is scoped to one dataset's half-open ``rotation_range`` in pooled source-rotation
+    indices, with ``normalized_alphas`` holding exactly that range's values. A rotation outside the
+    range yields a context with no thickness: the model composition takes the one component that
+    does claim it, so per-dataset networks partition the pooled index space without any shared
+    routing table. ``label`` is the dataset's ``inputs.exp_data`` ref and names the component in
+    reports. Pooled datasets deliberately share ``init_seed`` -- identical initialization is
+    deterministic, and per-position seeds would make results depend on ``exp_data`` ordering.
 
     Legacy code drew new random samples on every forward call. Here the standard-normal draws are
     fixed by ``init_seed`` and source rotation index, retaining the same sampled model while keeping
@@ -188,8 +196,8 @@ class ApparentThicknessNN:
     sample_thickness: bool = False
     num_samples: int = 40
     init_seed: int = 0
-    rotation_range: tuple[int, int] | None = None
-    label: str | None = None
+    rotation_range: tuple[int, int] = field(kw_only=True)
+    label: str = field(kw_only=True)
 
     def __post_init__(self) -> None:
         if self.form != "min_thickness":
@@ -200,15 +208,14 @@ class ApparentThicknessNN:
             raise ValueError("normalized_alphas must lie in [-1, 1]")
         if self.num_samples < 1:
             raise ValueError("num_samples must be >= 1")
-        if self.rotation_range is not None:
-            start, end = self.rotation_range
-            if start < 0 or end <= start:
-                raise ValueError("rotation_range must be a non-empty [start, end) with start >= 0")
-            if end - start != len(self.normalized_alphas):
-                raise ValueError(
-                    "rotation_range width must match len(normalized_alphas) "
-                    f"({end - start} != {len(self.normalized_alphas)})"
-                )
+        start, end = self.rotation_range
+        if start < 0 or end <= start:
+            raise ValueError("rotation_range must be a non-empty [start, end) with start >= 0")
+        if end - start != len(self.normalized_alphas):
+            raise ValueError(
+                "rotation_range width must match len(normalized_alphas) "
+                f"({end - start} != {len(self.normalized_alphas)})"
+            )
 
     def initial_params(
         self,
@@ -247,15 +254,23 @@ class ApparentThicknessNN:
         orientations: Sequence[OrientationPlanLike],
         raw_alphas: Sequence[float] | NDArray[np.float64],
     ) -> ThicknessProfile:
-        """Evaluate the trained curve at every orientation's tilt angle, as a reportable value.
+        """Evaluate the trained curve at every in-range orientation's tilt angle, reportably.
 
         The component owns this because it owns the behaviour: sampling its own output is not
         something an orchestrator or a logger should reimplement, and a sink must never run the
-        forward model itself. ``raw_alphas`` is indexed by source PETS rotation index.
+        forward model itself. That ownership includes the scope -- callers pass the full pooled
+        ``orientations`` and each network keeps its own ``rotation_range``. ``raw_alphas`` is
+        indexed by pooled source PETS rotation index, so it too is passed unsliced.
         """
-        indices = [orientation.pattern.rotation_index for orientation in orientations]
+        start, end = self.rotation_range
+        in_range = [
+            orientation
+            for orientation in orientations
+            if start <= orientation.pattern.rotation_index < end
+        ]
+        indices = [orientation.pattern.rotation_index for orientation in in_range]
         thicknesses: list[float] = []
-        for index, orientation in zip(indices, orientations, strict=True):
+        for index, orientation in zip(indices, in_range, strict=True):
             context = self.forward_context(params, rotation_index=index, orientation=orientation)
             if context.thickness is None:
                 raise ValueError("thickness component produced no thickness")
@@ -291,15 +306,11 @@ class ApparentThicknessNN:
             raise ValueError(f"apparent thickness NN params tensors missing {missing!r}")
         w0 = params["layer0.weight"]
         source_index = orientation.pattern.rotation_index
-        if self.rotation_range is not None:
-            start, end = self.rotation_range
-            if source_index < start or source_index >= end:
-                return ForwardContext(thickness=None)
-            local_index = source_index - start
-        else:
-            local_index = source_index
-        if local_index < 0 or local_index >= len(self.normalized_alphas):
-            raise ValueError("source rotation index is outside normalized_alphas")
+        start, end = self.rotation_range
+        if source_index < start or source_index >= end:
+            # Another dataset's rotation: the network that does claim it supplies the thickness.
+            return ForwardContext()
+        local_index = source_index - start
         x = w0.new_tensor(self.normalized_alphas[local_index]).reshape(1, 1)
         x = torch.tanh(F.linear(x, w0, params["layer0.bias"]))
         x = torch.tanh(F.linear(x, params["layer1.weight"], params["layer1.bias"]))

--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -603,27 +603,36 @@ class RefinedRotationMetrics:
 
 @dataclass(frozen=True)
 class ThicknessProfile:
-    """The trained apparent-thickness curve, sampled at every rotation's tilt angle.
+    """One dataset's trained apparent-thickness curve, sampled at its rotations' tilt angles.
 
-    Emitted once after refinement when a thickness component was composed. The whole curve rides on
-    the dataclass as parallel tuples (one entry per rotation, in plan order) rather than as ~100
-    separate events or ~300 flat measurement keys -- the shape :class:`ThicknessOptimized` already
-    uses for its candidate grid. ``measurements`` carries only the scalar summary.
+    Emitted once per composed thickness network after refinement -- one event per dataset, each
+    labeled by its ``inputs.exp_data`` ref. The whole curve rides on the dataclass as parallel
+    tuples (one entry per rotation, in plan order) rather than as ~100 separate events or ~300
+    flat measurement keys -- the shape :class:`ThicknessOptimized` already uses for its candidate
+    grid. ``measurements`` carries only the scalar summary.
+
+    ``channel`` embeds the label (the per-instance form the :class:`Event` protocol anticipates)
+    so metric sinks that key series on ``channel/name`` keep pooled datasets' curves apart.
     """
 
-    channel: ClassVar[str] = "thickness_profile"
     form: str
     min_thickness: float
     max_thickness: float
     rotation_indices: tuple[int, ...]
     alphas: tuple[float, ...]
     thicknesses: tuple[float, ...]
-    label: str | None = None
+    label: str
 
     def __post_init__(self) -> None:
         lengths = {len(self.rotation_indices), len(self.alphas), len(self.thicknesses)}
         if len(lengths) != 1:
             raise ValueError("thickness profile columns must have equal length")
+        if not self.label:
+            raise ValueError("thickness profile label must name its dataset")
+
+    @property
+    def channel(self) -> str:
+        return f"thickness_profile[{self.label}]"
 
     @property
     def step(self) -> int | None:

--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -618,6 +618,7 @@ class ThicknessProfile:
     rotation_indices: tuple[int, ...]
     alphas: tuple[float, ...]
     thicknesses: tuple[float, ...]
+    label: str | None = None
 
     def __post_init__(self) -> None:
         lengths = {len(self.rotation_indices), len(self.alphas), len(self.thicknesses)}

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -358,22 +358,19 @@ def test_multi_dataset_rejects_exp_data_paths_with_colliding_checkpoint_stems() 
         )
 
 
-def test_multi_dataset_rejects_the_default_on_thickness_nn_at_config_load() -> None:
-    """thickness_nn defaults ON; a pooled config must opt out explicitly, and fails fast if not."""
-    base = {
-        "name": "bad",
-        "inputs": {
-            "structure": "q.cif",
-            "exp_data": ["a.cif_pets", "b.cif_pets"],
-            "multi_dataset": True,
-        },
-    }
-    with pytest.raises(ValidationError, match="thickness_nn is not supported"):
-        ExperimentConfig.model_validate(base)
+def test_multi_dataset_accepts_default_thickness_nn() -> None:
+    cfg = ExperimentConfig.model_validate(
+        {
+            "name": "q",
+            "inputs": {
+                "structure": "q.cif",
+                "exp_data": ["a.cif_pets", "b.cif_pets"],
+                "multi_dataset": True,
+            },
+        }
+    )
 
-    ok = {**base, "name": "q", "refinement": {"thickness_nn": {"enabled": False}}}
-    cfg = ExperimentConfig.model_validate(ok)
-    assert cfg.refinement.thickness_nn.enabled is False
+    assert cfg.refinement.thickness_nn.enabled is True
 
 
 def test_dataset_checkpoint_stem_flattens_paths_and_drops_the_pets_suffix() -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -101,7 +101,6 @@ def test_multi_dataset_mean_thicknesses_are_keyed_by_exp_data() -> None:
             "exp_data": ["a.cif_pets", "b.cif_pets"],
             "multi_dataset": True,
         },
-        "refinement": {"thickness_nn": {"enabled": False}},
     }
     cfg = ExperimentConfig.model_validate(
         {
@@ -151,7 +150,6 @@ def test_multi_dataset_mean_thicknesses_must_be_finite() -> None:
             "exp_data": ["a.cif_pets", "b.cif_pets"],
             "multi_dataset": True,
         },
-        "refinement": {"thickness_nn": {"enabled": False}},
     }
 
     with pytest.raises(ValidationError, match="finite and positive"):
@@ -288,8 +286,6 @@ def test_multi_dataset_true_accepts_a_list_of_two_or_more_paths() -> None:
                 "exp_data": ["a.cif_pets", "b.cif_pets"],
                 "multi_dataset": True,
             },
-            # required opt-out: thickness_nn defaults ON and is unsupported for pooled experiments
-            "refinement": {"thickness_nn": {"enabled": False}},
         }
     )
     assert cfg.inputs.exp_data == ["a.cif_pets", "b.cif_pets"]

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -155,7 +155,6 @@ def test_dataset_config_digest_scopes_per_dataset_mean_thickness() -> None:
         "multi_dataset": True,
     }
     raw["sample"]["mean_thickness_by_dataset"] = {EXP_REF: 400.0, "b.cif_pets": 800.0}
-    raw["refinement"]["thickness_nn"]["enabled"] = False
     pooled = cfg.__class__.model_validate(raw)
     changed_raw = pooled.model_dump()
     changed_raw["sample"]["mean_thickness_by_dataset"]["b.cif_pets"] = 900.0

--- a/tests/unit/test_multi_dataset.py
+++ b/tests/unit/test_multi_dataset.py
@@ -117,7 +117,6 @@ def test_setup_datasets_seeds_each_dataset_with_its_configured_mean_thickness() 
             "b.cif_pets": 800.0,
         },
     }
-    raw["refinement"]["thickness_nn"]["enabled"] = False
     multi_config = ExperimentConfig.model_validate(raw)
 
     _, datasets = setup_datasets(structure, (record, record), multi_config)
@@ -239,7 +238,7 @@ def _multi_experiment(tmp_path: Path) -> Path:
         "exp_data": ["a.cif_pets", "b.cif_pets"],
         "multi_dataset": True,
     }
-    # thickness_nn defaults ON and is rejected for pooled experiments at config load.
+    # Disabled to keep these preprocess-focused tests off the (supported) per-dataset networks.
     base.setdefault("refinement", {})["thickness_nn"] = {"enabled": False}
     (exp / "experiment.yaml").write_text(yaml.safe_dump(base))
     lock = {

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -12,7 +12,10 @@ import pytest
 
 pytest.importorskip("matplotlib")
 
-from diffBloch.app.loggers.plotting import ThicknessPlotLogger  # noqa: E402
+from diffBloch.app.loggers.plotting import (  # noqa: E402
+    ThicknessPlotLogger,
+    plot_thickness_nn_shape,
+)
 from diffBloch.observability import OrientationOptimized, ThicknessOptimized  # noqa: E402
 
 _EVENT = ThicknessOptimized(
@@ -81,3 +84,14 @@ def test_report_writes_a_separate_png_per_rotation(tmp_path: Path) -> None:
     )
 
     assert {p.name for p in output_dir.iterdir()} == {"3.png", "4.png"}
+
+
+def test_thickness_nn_shape_plot_carries_its_dataset_title(tmp_path: Path) -> None:
+    png = tmp_path / "thickness_nn_shape_a.png"
+
+    plot_thickness_nn_shape(
+        [(0.0, 400.0), (10.0, 450.0)], png, title="Thickness NN final shape -- a.cif_pets"
+    )
+
+    assert png.is_file()
+    assert png.stat().st_size > 0

--- a/tests/unit/test_program_refine.py
+++ b/tests/unit/test_program_refine.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 import torch
 
-from diffBloch.app.program import _write_refinement_outputs
+from diffBloch.app.program import _thickness_networks, _write_refinement_outputs
 from diffBloch.config.manifest import read_refinement_lock
 from diffBloch.config.schema import ExperimentConfig
 from diffBloch.core.products import PatternBatch
@@ -17,9 +17,11 @@ from diffBloch.engine import (
     build_refinement_model,
 )
 from diffBloch.io import read_structure
+from diffBloch.io.record import ExperimentalRecord
 from diffBloch.observability import ObjectiveManifest, ObjectiveTerm, RefinementStep
 from diffBloch.preprocess import RefinementSetup, build_orientation_plans
 from diffBloch.preprocess.plan import CandidatePlan, Plan
+from diffBloch.specs import ApparentThicknessNetwork
 
 _MINIMAL_CIF = """data_q
 _cell_length_a 5
@@ -55,6 +57,72 @@ _atom_site_aniso_U_13
 _atom_site_aniso_U_12
 O1 0.03 0.04 0.05 0.001 0.002 0.003
 """
+
+
+def _record_with_alphas(alphas: tuple[float, ...]) -> ExperimentalRecord:
+    n = len(alphas)
+    return ExperimentalRecord(
+        unit_cell=np.eye(3),
+        cell_parameters=np.asarray([1.0, 1.0, 1.0, 90.0, 90.0, 90.0]),
+        cell_parameters_su=np.full((6,), np.nan),
+        wavelength=0.0251,
+        ub_matrix=np.eye(3),
+        zone_axis_ids=np.arange(1, n + 1),
+        zone_axes=np.zeros((n, 3)),
+        precession_angles=np.ones(n),
+        alphas=np.asarray(alphas, dtype=np.float64),
+        betas=np.zeros(n),
+        omegas=np.zeros(n),
+        scales=np.ones(n),
+        hkl=np.asarray([[1, 0, 0]], dtype=np.int64),
+        intensities=np.asarray([10.0]),
+        sigmas=np.asarray([1.0]),
+        reflection_zone_axis_ids=np.asarray([1]),
+    )
+
+
+def test_thickness_networks_partition_the_pooled_rotation_space() -> None:
+    cfg = ExperimentConfig.model_validate(
+        {
+            "name": "q",
+            "inputs": {
+                "structure": "q.cif",
+                "exp_data": ["a.cif_pets", "sub/b.cif_pets"],
+                "multi_dataset": True,
+            },
+        }
+    )
+    records = (
+        _record_with_alphas((0.0, 10.0)),
+        _record_with_alphas((100.0, 110.0, 120.0)),
+    )
+
+    networks = _thickness_networks(cfg, records, ApparentThicknessNetwork())
+
+    assert [network.key for network in networks] == [
+        "apparent_thickness[a.cif_pets]",
+        "apparent_thickness[sub/b.cif_pets]",
+    ]
+    assert [network.label for network in networks] == ["a.cif_pets", "sub/b.cif_pets"]
+    assert [network.rotation_range for network in networks] == [(0, 2), (2, 5)]
+    # Each dataset normalizes its own alpha span, so overlapping tilt ranges stay independent.
+    assert networks[0].normalized_alphas == (-1.0, 1.0)
+    assert networks[1].normalized_alphas == (-1.0, 0.0, 1.0)
+
+
+def test_thickness_networks_treat_a_single_dataset_as_the_n_1_case() -> None:
+    cfg = ExperimentConfig.model_validate(
+        {"name": "q", "inputs": {"structure": "q.cif", "exp_data": "q.cif_pets"}}
+    )
+    records = (_record_with_alphas((0.0, 5.0, 10.0)),)
+
+    networks = _thickness_networks(cfg, records, ApparentThicknessNetwork())
+
+    assert len(networks) == 1
+    assert networks[0].key == "apparent_thickness[q.cif_pets]"
+    assert networks[0].label == "q.cif_pets"
+    assert networks[0].rotation_range == (0, 3)
+    assert networks[0].normalized_alphas == (-1.0, 0.0, 1.0)
 
 
 def _refinement_result_for(

--- a/tests/unit/test_refinement_components.py
+++ b/tests/unit/test_refinement_components.py
@@ -16,6 +16,7 @@ from diffBloch.engine import (
     ForwardContext,
     PerOrientationThickness,
     QuadraticThicknessProfile,
+    RefinementEngine,
     RefinementProblem,
     ThicknessBounds,
     TrainableSpec,
@@ -115,13 +116,19 @@ def test_refinement_model_records_component_params_as_read_only_mapping() -> Non
 def test_apparent_thickness_nn_validates_legacy_settings() -> None:
     with pytest.raises(ValueError, match="num_samples"):
         ApparentThicknessNN(
-            bounds=ThicknessBounds(400.0, 1100.0), normalized_alphas=(0.0,), num_samples=0
+            bounds=ThicknessBounds(400.0, 1100.0),
+            normalized_alphas=(0.0,),
+            num_samples=0,
+            rotation_range=(0, 1),
+            label="a.cif_pets",
         )
     with pytest.raises(ValueError, match="form"):
         ApparentThicknessNN(
             bounds=ThicknessBounds(400.0, 1100.0),
             normalized_alphas=(0.0,),
             form="quadratic",  # type: ignore[arg-type]
+            rotation_range=(0, 1),
+            label="a.cif_pets",
         )
 
 
@@ -153,18 +160,153 @@ def test_apparent_thickness_nn_can_be_scoped_to_one_dataset() -> None:
     )
 
 
+def _orientation_at(engine: RefinementEngine, rotation_index: int) -> OrientationPlanLike:
+    orientation = engine.orientations[0]
+    return dataclasses.replace(
+        orientation, pattern=dataclasses.replace(orientation.pattern, rotation_index=rotation_index)
+    )
+
+
+def test_apparent_thickness_nn_scoped_network_indexes_alphas_locally() -> None:
+    engine = _engine()
+    scoped = ApparentThicknessNN(
+        bounds=ThicknessBounds(200.0, 800.0),
+        normalized_alphas=(-1.0, 1.0),
+        rotation_range=(5, 7),
+        label="b.cif_pets",
+    )
+    unscoped = ApparentThicknessNN(
+        bounds=ThicknessBounds(200.0, 800.0),
+        normalized_alphas=(-1.0, 1.0),
+        rotation_range=(0, 2),
+        label="a.cif_pets",
+    )
+    params = scoped.initial_params(dtype=torch.float64, device=torch.device("cpu"))
+
+    at_global_6 = scoped.forward_context(
+        params, rotation_index=6, orientation=_orientation_at(engine, 6)
+    ).thickness
+    at_local_1 = unscoped.forward_context(
+        params, rotation_index=1, orientation=_orientation_at(engine, 1)
+    ).thickness
+
+    assert at_global_6 is not None and at_local_1 is not None
+    assert torch.equal(at_global_6, at_local_1)
+
+
+def test_apparent_thickness_nn_scoped_sampling_uses_the_local_epsilon_row() -> None:
+    engine = _engine()
+    scoped = ApparentThicknessNN(
+        bounds=ThicknessBounds(100.0, 3500.0),
+        normalized_alphas=(0.25, 0.75),
+        sample_thickness=True,
+        num_samples=7,
+        init_seed=3,
+        rotation_range=(5, 7),
+        label="b.cif_pets",
+    )
+    unscoped = dataclasses.replace(scoped, rotation_range=(0, 2), label="a.cif_pets")
+    params = scoped.initial_params(dtype=torch.float64, device=torch.device("cpu"))
+
+    first = scoped.forward_context(
+        params, rotation_index=6, orientation=_orientation_at(engine, 6)
+    ).thickness
+    second = scoped.forward_context(
+        params, rotation_index=6, orientation=_orientation_at(engine, 6)
+    ).thickness
+    local = unscoped.forward_context(
+        params, rotation_index=1, orientation=_orientation_at(engine, 1)
+    ).thickness
+
+    assert first is not None and second is not None and local is not None
+    assert first.shape == (7,)
+    assert bool((first > 0.0).all())
+    assert torch.equal(first, second)
+    assert torch.equal(first, local)
+
+
+def test_disjoint_networks_compose_to_exactly_one_thickness_per_rotation() -> None:
+    engine = _engine()  # its single orientation carries rotation_index 0
+    first = ApparentThicknessNN(
+        bounds=ThicknessBounds(200.0, 800.0),
+        normalized_alphas=(0.0,),
+        key="apparent_thickness[a.cif_pets]",
+        rotation_range=(0, 1),
+        label="a.cif_pets",
+    )
+    second = ApparentThicknessNN(
+        bounds=ThicknessBounds(200.0, 800.0),
+        normalized_alphas=(0.0,),
+        key="apparent_thickness[b.cif_pets]",
+        rotation_range=(1, 2),
+        label="b.cif_pets",
+    )
+    params = _params()
+    component_params = {
+        component.key: component.initial_params(dtype=torch.float64, device=torch.device("cpu"))
+        for component in (first, second)
+    }
+    model = build_refinement_model(
+        initial=params, components=(first, second), component_params=component_params
+    )
+
+    # Only `first` claims rotation 0; `second` yields no thickness and composition succeeds.
+    objective = engine.objective_value_model(model)
+    assert torch.isfinite(objective.total)
+
+    overlapping = dataclasses.replace(second, rotation_range=(0, 1))
+    clashing = build_refinement_model(
+        initial=params, components=(first, overlapping), component_params=component_params
+    )
+    with pytest.raises(ValueError, match="multiple refinement components provided thickness"):
+        engine.objective_value_model(clashing)
+
+
+def test_apparent_thickness_nn_profile_reports_only_its_own_rotation_range() -> None:
+    engine = _engine()
+    component = ApparentThicknessNN(
+        bounds=ThicknessBounds(200.0, 800.0),
+        normalized_alphas=(-1.0, 1.0),
+        rotation_range=(1, 3),
+        label="b/c.cif_pets",
+    )
+    params = component.initial_params(dtype=torch.float64, device=torch.device("cpu"))
+    orientations = [_orientation_at(engine, index) for index in (0, 1, 2, 3)]
+    raw_alphas = [10.0, 20.0, 30.0, 40.0]
+
+    profile = component.profile(params, orientations, raw_alphas)
+
+    assert profile.rotation_indices == (1, 2)
+    assert profile.alphas == (20.0, 30.0)
+    assert len(profile.thicknesses) == 2
+    assert profile.label == "b/c.cif_pets"
+
+
 def test_apparent_thickness_nn_rejects_mismatched_dataset_range() -> None:
     with pytest.raises(ValueError, match="rotation_range width"):
         ApparentThicknessNN(
             bounds=ThicknessBounds(200.0, 800.0),
             normalized_alphas=(0.0,),
             rotation_range=(5, 7),
+            label="a.cif_pets",
+        )
+    with pytest.raises(ValueError, match="rotation_range must be"):
+        ApparentThicknessNN(
+            bounds=ThicknessBounds(200.0, 800.0),
+            normalized_alphas=(0.0,),
+            rotation_range=(3, 3),
+            label="a.cif_pets",
         )
 
 
 def test_apparent_thickness_nn_legacy_mean_is_differentiable() -> None:
     engine = _engine()
-    component = ApparentThicknessNN(bounds=ThicknessBounds(200.0, 800.0), normalized_alphas=(0.0,))
+    component = ApparentThicknessNN(
+        bounds=ThicknessBounds(200.0, 800.0),
+        normalized_alphas=(0.0,),
+        rotation_range=(0, 1),
+        label="a.cif_pets",
+    )
     params = component.initial_params(
         dtype=torch.float64,
         device=torch.device("cpu"),
@@ -192,6 +334,8 @@ def test_apparent_thickness_nn_legacy_gaussian_sampling_is_positive_and_determin
         sample_thickness=True,
         num_samples=7,
         init_seed=3,
+        rotation_range=(0, 1),
+        label="a.cif_pets",
     )
     params = component.initial_params(dtype=torch.float64, device=torch.device("cpu"))
     leaves = {name: value.detach().clone().requires_grad_(True) for name, value in params.items()}
@@ -215,7 +359,12 @@ def test_apparent_thickness_nn_legacy_gaussian_sampling_is_positive_and_determin
 def test_run_refinement_model_optimizes_apparent_thickness_nn_params() -> None:
     engine = _engine()
     structure_params = _params()
-    component = ApparentThicknessNN(bounds=ThicknessBounds(200.0, 800.0), normalized_alphas=(0.0,))
+    component = ApparentThicknessNN(
+        bounds=ThicknessBounds(200.0, 800.0),
+        normalized_alphas=(0.0,),
+        rotation_range=(0, 1),
+        label="a.cif_pets",
+    )
     component_params = component.initial_params(
         dtype=torch.float64,
         device=torch.device("cpu"),

--- a/tests/unit/test_refinement_components.py
+++ b/tests/unit/test_refinement_components.py
@@ -125,6 +125,43 @@ def test_apparent_thickness_nn_validates_legacy_settings() -> None:
         )
 
 
+def test_apparent_thickness_nn_can_be_scoped_to_one_dataset() -> None:
+    engine = _engine()
+    component = ApparentThicknessNN(
+        bounds=ThicknessBounds(200.0, 800.0),
+        normalized_alphas=(-1.0, 1.0),
+        rotation_range=(5, 7),
+        key="apparent_thickness[a.cif_pets]",
+        label="a.cif_pets",
+    )
+    params = component.initial_params(dtype=torch.float64, device=torch.device("cpu"))
+    inside = dataclasses.replace(
+        engine.orientations[0],
+        pattern=dataclasses.replace(engine.orientations[0].pattern, rotation_index=5),
+    )
+    outside = dataclasses.replace(
+        engine.orientations[0],
+        pattern=dataclasses.replace(engine.orientations[0].pattern, rotation_index=2),
+    )
+
+    assert (
+        component.forward_context(params, rotation_index=5, orientation=inside).thickness
+        is not None
+    )
+    assert (
+        component.forward_context(params, rotation_index=2, orientation=outside).thickness is None
+    )
+
+
+def test_apparent_thickness_nn_rejects_mismatched_dataset_range() -> None:
+    with pytest.raises(ValueError, match="rotation_range width"):
+        ApparentThicknessNN(
+            bounds=ThicknessBounds(200.0, 800.0),
+            normalized_alphas=(0.0,),
+            rotation_range=(5, 7),
+        )
+
+
 def test_apparent_thickness_nn_legacy_mean_is_differentiable() -> None:
     engine = _engine()
     component = ApparentThicknessNN(bounds=ThicknessBounds(200.0, 800.0), normalized_alphas=(0.0,))

--- a/tests/unit/test_summary_logger.py
+++ b/tests/unit/test_summary_logger.py
@@ -97,7 +97,7 @@ def _run(
     experiment: ExperimentDeclared | None = None,
     steps: tuple[RefinementStep, ...] = (),
     rotations: tuple[RefinedRotationMetrics, ...] = (),
-    profile: ThicknessProfile | None = None,
+    profiles: tuple[ThicknessProfile, ...] = (),
     manifest: ObjectiveManifest | None = None,
     completed: RefinementCompleted | None = None,
 ) -> str:
@@ -124,7 +124,7 @@ def _run(
     )
     for rotation in rotations:
         logger.report(rotation)
-    if profile is not None:
+    for profile in profiles:
         logger.report(profile)
     logger.report(RefinementOutputsWritten(structure=str(structure)))
     return (tmp_path / "refinement_report.txt").read_text()
@@ -245,27 +245,74 @@ def test_summary_adds_a_validation_section_only_when_rotations_are_held_out(
     assert "Validation set" not in none_held_out
 
 
-def test_summary_reports_the_thickness_profile_when_one_was_trained(tmp_path: Path) -> None:
-    text = _run(
-        tmp_path,
-        rotations=(_rotation(0),),
-        profile=ThicknessProfile(
-            form="quadratic",
-            min_thickness=100.0,
-            max_thickness=1000.0,
-            rotation_indices=(0,),
-            alphas=(12.5,),
-            thicknesses=(430.25,),
-        ),
+def _profile(
+    label: str,
+    *,
+    rotation_indices: tuple[int, ...] = (0,),
+    alphas: tuple[float, ...] = (12.5,),
+    thicknesses: tuple[float, ...] = (430.25,),
+) -> ThicknessProfile:
+    return ThicknessProfile(
+        form="quadratic",
+        min_thickness=100.0,
+        max_thickness=1000.0,
+        rotation_indices=rotation_indices,
+        alphas=alphas,
+        thicknesses=thicknesses,
+        label=label,
     )
 
+
+def test_summary_reports_the_thickness_profile_when_one_was_trained(tmp_path: Path) -> None:
+    text = _run(tmp_path, rotations=(_rotation(0),), profiles=(_profile("q.cif_pets"),))
+
+    assert "Thickness NN -- q.cif_pets" in text
     assert "enabled: yes (quadratic, bounds [100, 1000] A)" in text
     assert "alpha (degrees)" in text
     assert "12.5000" in text and "430.25" in text
 
     pytest.importorskip("matplotlib", reason="optional diffBloch[plot] extra")
-    assert (tmp_path / "thickness_nn_shape.png").is_file()
-    assert "plot: thickness_nn_shape.png" in text
+    assert (tmp_path / "thickness_nn_shape_q.png").is_file()
+    assert "plot: thickness_nn_shape_q.png" in text
+
+
+def test_summary_reports_one_thickness_section_per_dataset(tmp_path: Path) -> None:
+    text = _run(
+        tmp_path,
+        rotations=(_rotation(0),),
+        profiles=(
+            _profile("a.cif_pets"),
+            _profile("sub/b.cif_pets", rotation_indices=(1,), alphas=(-3.5,), thicknesses=(210.0,)),
+        ),
+    )
+
+    assert "Thickness NN -- a.cif_pets" in text
+    assert "Thickness NN -- sub/b.cif_pets" in text
+    assert "430.25" in text and "210.00" in text
+
+    pytest.importorskip("matplotlib", reason="optional diffBloch[plot] extra")
+    # Filenames use the dataset checkpoint stem: path separators fold to "__", suffix drops.
+    assert (tmp_path / "thickness_nn_shape_a.png").is_file()
+    assert (tmp_path / "thickness_nn_shape_sub__b.png").is_file()
+
+
+def test_summary_keeps_the_last_thickness_profile_reported_per_dataset(tmp_path: Path) -> None:
+    text = _run(
+        tmp_path,
+        rotations=(_rotation(0),),
+        profiles=(
+            _profile("a.cif_pets"),
+            _profile("a.cif_pets", thicknesses=(555.5,)),
+        ),
+    )
+
+    assert text.count("Thickness NN -- a.cif_pets") == 1
+    assert "555.50" in text
+    assert "430.25" not in text
+
+
+def test_thickness_profile_channel_names_its_dataset() -> None:
+    assert _profile("sub/b.cif_pets").channel == "thickness_profile[sub/b.cif_pets]"
 
 
 def test_summary_degrades_without_the_declaration_events(tmp_path: Path) -> None:
@@ -289,7 +336,10 @@ def test_thickness_profile_rejects_ragged_columns() -> None:
             rotation_indices=(0, 1),
             alphas=(12.5,),
             thicknesses=(430.25,),
+            label="q.cif_pets",
         )
+    with pytest.raises(ValueError, match="label"):
+        _profile("")
 
 
 def test_ascii_table_widens_a_column_to_its_content() -> None:


### PR DESCRIPTION
## Summary

Recovers a working implementation that existed in an earlier stash and was later replaced by a validator that rejected `refinement.thickness_nn` entirely under `inputs.multi_dataset`. One `ApparentThicknessNN` per dataset now handles this correctly instead of rejecting it.

- Each dataset gets its own network, keyed by its `exp_data` ref (`apparent_thickness[<ref>]`) so `component_params` entries never collide.
- Each network is scoped to its dataset's `rotation_range` (computed from cumulative per-record rotation counts, in `inputs.exp_data` order) and normalizes alpha independently within that range.
- A rotation outside a network's range returns `ForwardContext(thickness=None)`; the existing per-orientation component composition in `engine/forward.py` already handles this correctly (exactly one component must supply a non-`None` thickness per orientation, or it raises) -- no new composition logic needed.
- `SummaryLogger` reports one "Thickness NN -- \<label\>" section and one `thickness_nn_shape_<label>.png` plot per dataset instead of a single shared one.
- Removes the config-load-time rejection this previously required (`refinement.thickness_nn.enabled: false` under `multi_dataset`).

## Test plan
- [x] `ruff check .` / `ruff format --check .` -- clean
- [x] `mypy src/diffBloch` -- clean
- [x] `pytest tests/unit -k "thickness or multi_dataset or config"` -- 107 passed, 2 skipped