### PR TITLE
Finish PETS2-attribution cleanup in hyperparameter-selection

### DIFF
--- a/docs/hyperparameter-selection.md
+++ b/docs/hyperparameter-selection.md
@@ -57,9 +57,8 @@ Bloch wave simulation hyperparameters (`BlochwaveConfig`).
 Continuous-rotation data is recorded in the `.cif_pets` file as overlapping **virtual frames**
 ([Klar *et al.*, 2023](https://doi.org/10.1038/s41557-023-01186-1)). Because the frames overlap, a
 given reflection can appear in several neighbouring frames, but should only be fully integrated in
-one of them. `rsg` and `dsg` (see [Comparing simulation with experiment](workflow.md#comparing-simulation-with-experiment))
-identify the frames in which a reflection passes sufficiently far through the Bragg condition to be
-treated as fully integrated.
+one of them. `rsg` and `dsg` identify the frames in which a reflection passes sufficiently far
+through the Bragg condition to be treated as fully integrated.
 
 For each reflection, diffBloch calculates its excitation error {math}`|S_g|` at the centre of the
 frame and the excitation-error half-range {math}`\Delta S_g` swept from the centre to the edge of

--- a/docs/hyperparameter-selection.md
+++ b/docs/hyperparameter-selection.md
@@ -54,9 +54,12 @@ Bloch wave simulation hyperparameters (`BlochwaveConfig`).
 
 ### `rsg` and `dsg`
 
-Virtual frames overlap, so the same reflection may be recorded in neighbouring frames. `rsg` and
-`dsg` identify the frames in which a reflection passes sufficiently far through the Bragg condition
-to be treated as fully integrated.
+Continuous-rotation data is recorded in the `.cif_pets` file as overlapping **virtual frames**
+([Klar *et al.*, 2023](https://doi.org/10.1038/s41557-023-01186-1)). Because the frames overlap, a
+given reflection can appear in several neighbouring frames, but should only be fully integrated in
+one of them. `rsg` and `dsg` (see [Comparing simulation with experiment](workflow.md#comparing-simulation-with-experiment))
+identify the frames in which a reflection passes sufficiently far through the Bragg condition to be
+treated as fully integrated.
 
 For each reflection, diffBloch calculates its excitation error {math}`|S_g|` at the centre of the
 frame and the excitation-error half-range {math}`\Delta S_g` swept from the centre to the edge of


### PR DESCRIPTION
Follow-up to #108: drops remaining PETS2-does-X phrasing in favor of describing what's recorded in .cif_pets.