### PR TITLE
Expand Bloch wave simulation docs

### DIFF
--- a/docs/bloch_wave_simulation.md
+++ b/docs/bloch_wave_simulation.md
@@ -6,9 +6,13 @@ large simulations ({math}`N\log_2 N` in the number of Fourier components vs Bloc
 {math}`N^3`), but the Bloch wave method gives closed-form intensities that are analytically
 differentiable with respect to structural parameters and handle arbitrary crystal orientation
 naturally — both essential for gradient-based refinement against a continuous-rotation tilt series.
+
 This page derives the structure matrix diffBloch actually assembles and solves; for how orientation
-and thickness are fitted around it, see [Preprocessing](preprocessing.md), and for numerical-basis
-sizing, see [Convergence testing](convergence-testing.md).
+and thickness are fitted around it, see [Preprocessing](preprocessing.md), and for optimal choice of simulation parameters see [Convergence testing](convergence-testing.md) and [Hyperparameter selection](hyperparameter-selection.md).
+
+This section of the codebase draws heavily on the abTEM code (Madsen, J. & Susi, T. (2021), *The
+abTEM code: transmission electron microscopy from first principles*, Open Research Europe 1:24,
+<https://open-research-europe.ec.europa.eu/articles/1-24>).
 
 ## Diffraction geometry and the excitation error
 
@@ -16,14 +20,13 @@ A reciprocal lattice vector {math}`\mathbf{g}_{hkl}` satisfies the Bragg conditi
 the Ewald sphere: {math}`\mathbf{k}_g - \mathbf{k}_0 = \mathbf{g}`, for incident and diffracted
 wavevectors {math}`\mathbf{k}_0`, {math}`\mathbf{k}_g` of magnitude {math}`1/\lambda`. A finite
 crystal thickness elongates each reciprocal lattice point into a `relrod`, so a beam can be excited
-even when {math}`\mathbf{g}` misses the Ewald sphere exactly. The **excitation error**
-{math}`S_{\mathbf{g}}` quantifies that miss distance:
+even when the **excitation error** ({math}`S_{\mathbf{g}}`), the distance of the {math}`\mathbf{g}` to the Ewald sphere surface is non-zero. {math}`S_{\mathbf{g}}` is given by:
 
 ```{math}
-S_{\mathbf{g}} = \frac{|\mathbf{K}|^2 - |\mathbf{K}+\mathbf{g}|^2}{2|\mathbf{K}|},
+S_{\mathbf{g}} = \frac{|\mathbf{K}|^2 - |\mathbf{K}+\mathbf{g}|^2}{2|\mathbf{K}|}.
 ```
 
-the Spence & Zuo (1992) convention diffBloch implements directly (`core.dynamical.excitation_errors`),
+diffBloch calculates this value (`core.dynamical.excitation_errors`),
 with the beam wavevector {math}`\mathbf{K}` corrected for the mean-inner-potential offset {math}`U_0`:
 {math}`K_n = \sqrt{1/\lambda^2 + U_0}`. `blochwave.sg_max` (see
 [Hyperparameter selection](hyperparameter-selection.md)) is the cutoff on {math}`|S_{\mathbf{g}}|`
@@ -31,10 +34,9 @@ admitting a beam into the calculation at a given tilt.
 
 ## Elastic scattering and the structure factor
 
-Electrons interact with the crystal's total electrostatic potential {math}`V(\mathbf{r})`, not (as
-for X-rays) with the electron density alone. Its Fourier coefficients {math}`V_{\mathbf{g}}` sum
-over the atoms in the unit cell, each contributing its electron scattering factor
-{math}`f^e(s)` (Mott–Bethe-related to the X-ray form factor) damped by thermal motion
+Electrons interact with the crystal's total electrostatic potential {math}`V(\mathbf{r}). Its Fourier coefficients {math} `V_{\mathbf{g}}` sum
+over the atoms in the unit cell, with each atom each contributing its electron scattering factor
+{math}`f^e(s)` damped by thermal motion
 (the Debye–Waller factor) and phased by its fractional position:
 
 ```{math}
@@ -42,38 +44,17 @@ F_{\mathbf{g}} = \frac{1}{\Omega}\sum_j f^e_j(s)\,T_j(\mathbf{h})\,O_j\,
 \exp(2\pi i\,\mathbf{h}\cdot\mathbf{r}_j),
 ```
 
-the Born-approximation structure factor `core.scattering.structure_factors` computes, using the
-Lobato–Van Dyck (2014) parametrization for {math}`f^e(s)`. {math}`F_{\mathbf{g}}` is a property of
-the crystal's kinematical scattering alone; it is not yet the quantity that enters the Bloch wave
-equations.
+diffBloch first computes the Born-approximation structure factor given above (`core.scattering.structure_factors`), using the Lobato–Van Dyck (2014) parametrization for {math}`f^e(s)`. 
 
-## From {math}`F_{\mathbf{g}}` to the interaction parameter
-
-Because electrons are charged, the effective potential a fast electron feels is voltage-dependent:
-the relevant quantity, {math}`U_{\mathbf{g}}`, carries an explicit relativistic correction:
+These values may then be converted to {math}`U_{\mathbf{g}}` using:
 
 ```{math}
 U_{\mathbf{g}} = \gamma\,\frac{F_{\mathbf{g}}}{\pi\Omega} = \frac{2m|e|V_{\mathbf{g}}}{h^2},
 ```
 
 with {math}`\gamma` the relativistic mass factor, {math}`m` the (relativistic) electron mass,
-{math}`e` the elementary charge, and {math}`h` Planck's constant. diffBloch does not materialize
-{math}`U_{\mathbf{g}}` as a separate intermediate; it folds the same physics into a single scalar
-**interaction parameter** {math}`\sigma` that multiplies {math}`F_{\mathbf{g}}` directly when
-assembling the structure matrix below:
+{math}`e` the elementary charge, and {math}`h` Planck's constant. 
 
-```{math}
-\sigma = \frac{2\pi m e \lambda}{h^2}, \qquad
-m = \left(1 + \frac{Ee}{m_ec^2}\right)m_e,
-```
-
-(`core.dynamical.energy2sigma`, CODATA-2018 constants, Spence & Zuo 1992). This reproduces the
-textbook values {math}`9.2440\times10^{-4}`, {math}`7.2884\times10^{-4}`,
-{math}`6.5262\times10^{-4}\ \text{\normalfont Å}^{-1}\text{eV}^{-1}` at 100/200/300 keV. An
-accompanying dimensionless interaction constant {math}`\kappa\approx0.02089` converts the Lobato
-form-factor convention into these potential units; together
-{math}`\sigma / (\kappa\lambda\pi)` is the exact prefactor diffBloch scales every structure factor
-by before it enters the structure matrix (`core.dynamical.structure_matrix_prefactor`).
 
 ## The Bloch wave formalism
 
@@ -84,8 +65,7 @@ Expanding the electron wavefunction inside the crystal as a sum of Bloch states,
 \sum_{\mathbf{g}} C_{\mathbf{g}}^{(i)}\exp(2\pi i\mathbf{g}\cdot\mathbf{r}),
 ```
 
-and substituting into the time-independent Schrödinger equation yields, after symmetrising by the
-obliquity factors {math}`M_{ii} = 1/\sqrt{1 - g_z/K_n}` (`core.dynamical.mii_factors`), a coupled
+and substituting into the time-independent Schrödinger equation yields, a coupled
 linear system for the Fourier coefficients — an eigenvalue problem
 {math}`AC^{(i)} = 2K_n\gamma^{(i)}C^{(i)}` in the **structure matrix** {math}`A`:
 
@@ -102,6 +82,29 @@ beam within `blochwave.g_max`/`sg_max` at a given tilt is the **many-beam** solu
 a {math}`2\times2` matrix — useful for intuition (see the rocking-curve width formula in
 [Convergence testing](convergence-testing.md#simulation-convergence)) but too coarse for
 quantitative refinement once several reflections are simultaneously strongly excited.
+
+### Example structure matrix
+
+Instantiating {math}`A_{ii}`/{math}`A_{ij}` above for a concrete systematic row of five beams
+{math}`(\overline{2}00), (\overline{1}00), (000), (100), (200)` (all in the zero-order Laue zone, so
+{math}`M_{ii}=1` throughout):
+
+```{math}
+A =
+\begin{pmatrix}
+2K_nS_{\overline{2}00} & \sigma F(100) & \sigma F(200) & \sigma F(300) & \sigma F(400) \\
+\sigma F(100)^{*} & 2K_nS_{\overline{1}00} & \sigma F(100) & \sigma F(200) & \sigma F(300) \\
+\sigma F(200)^{*} & \sigma F(100)^{*} & 2K_nS_{000} & \sigma F(100) & \sigma F(200) \\
+\sigma F(300)^{*} & \sigma F(200)^{*} & \sigma F(100)^{*} & 2K_nS_{100} & \sigma F(100) \\
+\sigma F(400)^{*} & \sigma F(300)^{*} & \sigma F(200)^{*} & \sigma F(100)^{*} & 2K_nS_{200}
+\end{pmatrix}
+```
+
+The diagonal holds each beam's excitation error, growing outward along the row. Every off-diagonal
+entry depends only on the difference vector {math}`\mathbf{g}_j-\mathbf{g}_i`, so the matrix is
+Toeplitz along each band — the {math}`(000,100)` and {math}`(100,200)` couplings are both
+{math}`\sigma F(100)`. The lower triangle is the conjugate of the upper triangle, since {math}`A`
+must be Hermitian for `bloch_eigen`'s eigendecomposition to apply.
 
 ## Solving: two equivalent routes, one gradient-safe
 
@@ -124,8 +127,11 @@ There are two mathematically equivalent ways to evaluate this, and diffBloch imp
   differentiate through, so `bloch_eigen` is rejected outright when absorption is enabled — see
   `BlochwaveConfig`'s validation.
 
-The calculated intensity in reflection {math}`\mathbf{g}` is {math}`I_{\mathbf{g}}(t) =
-|\psi_{\mathbf{g}}(t)|^2`. A continuous-rotation frame sums this over sampled sub-orientations
+{math}`\psi(t)` has one entry per beam in {math}`A`'s own index set — the **solve beams** (see
+[Beam sets and scoring](preprocessing.md#beam-sets-and-scoring-inside-a-plan)) — so an intensity is
+only ever calculated for a reflection that beam selection actually admitted into {math}`A`, never
+for an arbitrary {math}`\mathbf{g}` outside it. For each solve beam, the calculated intensity is
+{math}`I_{\mathbf{g}}(t) = |\psi_{\mathbf{g}}(t)|^2`. A continuous-rotation frame sums this over sampled sub-orientations
 across the rocking curve (and, when `blochwave.mosaicity` is enabled, smoothed over a moving-average
 window derived from the apparent mosaicity recorded in `.cif_pets`) rather than evaluating a single static orientation
 — see [Preprocessing](preprocessing.md) for how those tilts and beam couplings are assembled around


### PR DESCRIPTION
Cites abTEM as the source this page's physics is adapted from, adds a worked symbolic example structure matrix, clarifies that psi(t)/intensities only cover the solve-beam basis, and fixes a couple of grammar slips.