### PR TITLE
Rewrite Bloch wave simulation formalism section

### DIFF
--- a/docs/bloch_wave_simulation.md
+++ b/docs/bloch_wave_simulation.md
@@ -6,9 +6,13 @@ large simulations ({math}`N\log_2 N` in the number of Fourier components vs Bloc
 {math}`N^3`), but the Bloch wave method gives closed-form intensities that are analytically
 differentiable with respect to structural parameters and handle arbitrary crystal orientation
 naturally — both essential for gradient-based refinement against a continuous-rotation tilt series.
+
 This page derives the structure matrix diffBloch actually assembles and solves; for how orientation
-and thickness are fitted around it, see [Preprocessing](preprocessing.md), and for numerical-basis
-sizing, see [Convergence testing](convergence-testing.md).
+and thickness are fitted around it, see [Preprocessing](preprocessing.md), and for optimal choice of simulation parameters see [Convergence testing](convergence-testing.md) and [Hyperparameter selection](hyperparameter-selection.md).
+
+This section of the codebase draws heavily on the abTEM code (Madsen, J. & Susi, T. (2021), *The
+abTEM code: transmission electron microscopy from first principles*, Open Research Europe 1:24,
+<https://open-research-europe.ec.europa.eu/articles/1-24>).
 
 ## Diffraction geometry and the excitation error
 
@@ -16,14 +20,13 @@ A reciprocal lattice vector {math}`\mathbf{g}_{hkl}` satisfies the Bragg conditi
 the Ewald sphere: {math}`\mathbf{k}_g - \mathbf{k}_0 = \mathbf{g}`, for incident and diffracted
 wavevectors {math}`\mathbf{k}_0`, {math}`\mathbf{k}_g` of magnitude {math}`1/\lambda`. A finite
 crystal thickness elongates each reciprocal lattice point into a `relrod`, so a beam can be excited
-even when {math}`\mathbf{g}` misses the Ewald sphere exactly. The **excitation error**
-{math}`S_{\mathbf{g}}` quantifies that miss distance:
+even when the **excitation error** ({math}`S_{\mathbf{g}}`), the distance of the {math}`\mathbf{g}` to the Ewald sphere surface is non-zero. {math}`S_{\mathbf{g}}` is given by:
 
 ```{math}
-S_{\mathbf{g}} = \frac{|\mathbf{K}|^2 - |\mathbf{K}+\mathbf{g}|^2}{2|\mathbf{K}|},
+S_{\mathbf{g}} = \frac{|\mathbf{K}|^2 - |\mathbf{K}+\mathbf{g}|^2}{2|\mathbf{K}|}.
 ```
 
-the Spence & Zuo (1992) convention diffBloch implements directly (`core.dynamical.excitation_errors`),
+diffBloch calculates this value (`core.dynamical.excitation_errors`),
 with the beam wavevector {math}`\mathbf{K}` corrected for the mean-inner-potential offset {math}`U_0`:
 {math}`K_n = \sqrt{1/\lambda^2 + U_0}`. `blochwave.sg_max` (see
 [Hyperparameter selection](hyperparameter-selection.md)) is the cutoff on {math}`|S_{\mathbf{g}}|`
@@ -31,10 +34,9 @@ admitting a beam into the calculation at a given tilt.
 
 ## Elastic scattering and the structure factor
 
-Electrons interact with the crystal's total electrostatic potential {math}`V(\mathbf{r})`, not (as
-for X-rays) with the electron density alone. Its Fourier coefficients {math}`V_{\mathbf{g}}` sum
-over the atoms in the unit cell, each contributing its electron scattering factor
-{math}`f^e(s)` (Mott–Bethe-related to the X-ray form factor) damped by thermal motion
+Electrons interact with the crystal's total electrostatic potential {math}`V(\mathbf{r}). Its Fourier coefficients {math} `V_{\mathbf{g}}` sum
+over the atoms in the unit cell, with each atom each contributing its electron scattering factor
+{math}`f^e(s)` damped by thermal motion
 (the Debye–Waller factor) and phased by its fractional position:
 
 ```{math}
@@ -42,68 +44,83 @@ F_{\mathbf{g}} = \frac{1}{\Omega}\sum_j f^e_j(s)\,T_j(\mathbf{h})\,O_j\,
 \exp(2\pi i\,\mathbf{h}\cdot\mathbf{r}_j),
 ```
 
-the Born-approximation structure factor `core.scattering.structure_factors` computes, using the
-Lobato–Van Dyck (2014) parametrization for {math}`f^e(s)`. {math}`F_{\mathbf{g}}` is a property of
-the crystal's kinematical scattering alone; it is not yet the quantity that enters the Bloch wave
-equations.
+diffBloch first computes the Born-approximation structure factor given above (`core.scattering.structure_factors`), using the Lobato–Van Dyck (2014) parametrization for {math}`f^e(s)`. 
 
-## From {math}`F_{\mathbf{g}}` to the interaction parameter
-
-Because electrons are charged, the effective potential a fast electron feels is voltage-dependent:
-the relevant quantity, {math}`U_{\mathbf{g}}`, carries an explicit relativistic correction:
+These values may then be converted to {math}`U_{\mathbf{g}}` using:
 
 ```{math}
 U_{\mathbf{g}} = \gamma\,\frac{F_{\mathbf{g}}}{\pi\Omega} = \frac{2m|e|V_{\mathbf{g}}}{h^2},
 ```
 
 with {math}`\gamma` the relativistic mass factor, {math}`m` the (relativistic) electron mass,
-{math}`e` the elementary charge, and {math}`h` Planck's constant. diffBloch does not materialize
-{math}`U_{\mathbf{g}}` as a separate intermediate; it folds the same physics into a single scalar
-**interaction parameter** {math}`\sigma` that multiplies {math}`F_{\mathbf{g}}` directly when
-assembling the structure matrix below:
+{math}`e` the elementary charge, and {math}`h` Planck's constant. 
 
-```{math}
-\sigma = \frac{2\pi m e \lambda}{h^2}, \qquad
-m = \left(1 + \frac{Ee}{m_ec^2}\right)m_e,
-```
-
-(`core.dynamical.energy2sigma`, CODATA-2018 constants, Spence & Zuo 1992). This reproduces the
-textbook values {math}`9.2440\times10^{-4}`, {math}`7.2884\times10^{-4}`,
-{math}`6.5262\times10^{-4}\ \text{\normalfont Å}^{-1}\text{eV}^{-1}` at 100/200/300 keV. An
-accompanying dimensionless interaction constant {math}`\kappa\approx0.02089` converts the Lobato
-form-factor convention into these potential units; together
-{math}`\sigma / (\kappa\lambda\pi)` is the exact prefactor diffBloch scales every structure factor
-by before it enters the structure matrix (`core.dynamical.structure_matrix_prefactor`).
 
 ## The Bloch wave formalism
 
-Expanding the electron wavefunction inside the crystal as a sum of Bloch states,
+The Bloch wave formalism starts from the time-independent Schrödinger equation for the incident
+electron inside the crystal potential {math}`V(\mathbf{r})`:
+
+```{math}
+-\frac{h^2}{2m}\nabla^2\psi(\mathbf{r}) - |e|V(\mathbf{r})\psi(\mathbf{r}) = \frac{h^2K^2}{2m}\psi(\mathbf{r}).
+```
+
+Expanding the wavefunction inside the crystal as a sum of Bloch states,
 
 ```{math}
 \psi(\mathbf{r}) = \sum_i c_i \exp(2\pi i\mathbf{k}^{(i)}\cdot\mathbf{r})
 \sum_{\mathbf{g}} C_{\mathbf{g}}^{(i)}\exp(2\pi i\mathbf{g}\cdot\mathbf{r}),
 ```
 
-and substituting into the time-independent Schrödinger equation yields, after symmetrising by the
-obliquity factors {math}`M_{ii} = 1/\sqrt{1 - g_z/K_n}` (`core.dynamical.mii_factors`), a coupled
-linear system for the Fourier coefficients — an eigenvalue problem
-{math}`AC^{(i)} = 2K_n\gamma^{(i)}C^{(i)}` in the **structure matrix** {math}`A`:
+and substituting into the Schrödinger equation gives the dispersion relation coupling every pair of
+beams through the potential:
+
+```{math}
+\left[K^2-(\mathbf{k}^{(i)}+\mathbf{g})^2\right]C_{\mathbf{g}}^{(i)}
++ \sum_{\mathbf{h}} U_{\mathbf{g}-\mathbf{h}}C_{\mathbf{h}}^{(i)} = 0,
+```
+
+an eigenvalue problem {math}`\det(A-\lambda I)=0`. Retaining every beam within
+`blochwave.g_max`/`sg_max` at a given tilt is the **many-beam** solution; a true solution would sum
+the infinite reciprocal lattice, but in practice diffBloch
+truncates to the beams that matter at that orientation.
+
+This raw form is not Hermitian. Symmetrising it by the per-beam factor
+{math}`M_{ii} = 1/\sqrt{1+g_{i,n}/K_n}` (with {math}`g_{i,n}` beam {math}`g_i`'s component along the
+surface normal) casts it in the compact, Hermitian form diffBloch actually solves,
+{math}`AC^{(i)} = 2K_n\gamma^{(i)}C^{(i)}`, with
 
 ```{math}
 A_{ii} = 2K_nS_{g_i}M_{ii}, \qquad
 A_{ij} = \sigma M_{ii}M_{jj}F(\mathbf{g}_j-\mathbf{g}_i) \quad (i\ne j).
 ```
 
-The diagonal holds each beam's own excitation error; the off-diagonal couples every pair of beams
-through the structure factor of their difference vector — an electron diffracted from
-{math}`(000)` into {math}`(200)` can be rescattered into {math}`(220)`, and so on. Retaining every
-beam within `blochwave.g_max`/`sg_max` at a given tilt is the **many-beam** solution; the classical
-**two-beam approximation** keeps only {math}`(000)` and one diffracted beam, reducing {math}`A` to
-a {math}`2\times2` matrix — useful for intuition (see the rocking-curve width formula in
-[Convergence testing](convergence-testing.md#simulation-convergence)) but too coarse for
-quantitative refinement once several reflections are simultaneously strongly excited.
+The diagonal holds each beam's own excitation error; entry {math}`(i,j)` couples {math}`g_i` to
+{math}`g_j` through the structure factor of their difference — an electron diffracted from
+{math}`(000)` into {math}`(200)` can be rescattered into {math}`(220)`, and so on. The lower
+triangle is the conjugate of the upper triangle, since {math}`A` is Hermitian by construction, which
+`bloch_eigen`'s eigendecomposition depends on.
 
-## Solving: two equivalent routes, one gradient-safe
+The classical **two-beam approximation** keeps only {math}`(000)` and one diffracted beam
+{math}`\mathbf{g}`, reducing the eigenvalue problem to:
+
+```{math}
+\begin{pmatrix}
+-2K_n\gamma & U_{-\mathbf{g}} \\
+U_{\mathbf{g}} & 2KS_{\mathbf{g}}-2K_n\gamma
+\end{pmatrix}
+\begin{pmatrix}
+C_0 \\
+C_{\mathbf{g}}
+\end{pmatrix}
+= 0.
+```
+
+It is useful for analytical treatments and weakly scattering objects, but breaks down once several
+reflections are simultaneously strongly excited — the case the many-beam matrix above is built to
+handle.
+
+## Solving: two equivalent routes
 
 With boundary conditions {math}`\psi(0)` fixed at the entrance surface, the wavefield at thickness
 {math}`t` is
@@ -121,12 +138,11 @@ There are two mathematically equivalent ways to evaluate this, and diffBloch imp
 - **`matrix_exp`** evaluates the matrix exponential directly, without an intermediate
   eigendecomposition. It is the default: eigendecomposition of a **non-Hermitian** matrix (the case
   whenever `absorption: true` adds an imaginary component to {math}`A`) is numerically unstable to
-  differentiate through, so `bloch_eigen` is rejected outright when absorption is enabled — see
-  `BlochwaveConfig`'s validation.
+  differentiate through, so `bloch_eigen` is rejected outright when absorption is enabled.
 
-The calculated intensity in reflection {math}`\mathbf{g}` is {math}`I_{\mathbf{g}}(t) =
-|\psi_{\mathbf{g}}(t)|^2`. A continuous-rotation frame sums this over sampled sub-orientations
+For each solve beam, the calculated intensity is
+{math}`I_{\mathbf{g}}(t) = |\psi_{\mathbf{g}}(t)|^2`. A continuous-rotation frame sums this over sampled sub-orientations
 across the rocking curve (and, when `blochwave.mosaicity` is enabled, smoothed over a moving-average
-window derived from the apparent mosaicity recorded in `.cif_pets`) rather than evaluating a single static orientation
-— see [Preprocessing](preprocessing.md) for how those tilts and beam couplings are assembled around
-this solve.
+window derived from the apparent mosaicity recorded in `.cif_pets`) rather than evaluating a single static orientation.
+
+For more information, see [Preprocessing](preprocessing.md).


### PR DESCRIPTION
Supersedes #111. Follows the derivation structure and notation already vetted for publication: adds the Schrödinger equation as the starting point, the raw dispersion relation, and explicitly defines the M_ii symmetrization factor (1/sqrt(1+g_n/K_n)) instead of leaving it unexplained. Replaces the abstract N-beam example matrix with the concrete two-beam-approximation 2x2 matrix.