### PR TITLE
Website: publications page, diffbloch.com links, GitHub icon, matrix_exp citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 ![Ruff](https://img.shields.io/badge/Ruff-D7FF64?logo=ruff&logoColor=black)
 ![mypy](https://img.shields.io/badge/mypy-strict-blue)
 [![License: MIT](https://img.shields.io/badge/License-MIT-97ca00)](LICENSE)
-[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-0969da?logo=sphinx&logoColor=white)](https://differentiable-electron-crystallography.github.io/diffBloch/)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-0969da?logo=sphinx&logoColor=white)](https://diffbloch.com/)
 
 Differentiable Bloch-wave structure refinement for 3D electron diffraction.
 
 
-📖 **Documentation:** <https://differentiable-electron-crystallography.github.io/diffBloch/> — API reference (Sphinx + furo), rendered from the source on every green `main`.
+📖 **Documentation:** <https://diffbloch.com/> — API reference (Sphinx + furo), rendered from the source on every green `main`.
 
 ## Quickstart
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,30 @@
+/* Splits the sidebar brand title and a GitHub icon link onto one row, below the logo.
+   Pairs with the sidebar/brand.html template override. */
+.sidebar-brand-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0 var(--sidebar-item-spacing-horizontal) var(--sidebar-item-spacing-vertical);
+}
+
+.sidebar-brand-title-link {
+  color: var(--color-sidebar-brand-text);
+  text-decoration: none;
+}
+
+.sidebar-brand-title-link .sidebar-brand-text {
+  font-size: 1.5rem;
+  overflow-wrap: break-word;
+}
+
+.sidebar-brand-github-link {
+  display: inline-flex;
+  color: var(--color-sidebar-link-text);
+  opacity: 0.75;
+  transition: opacity 0.1s ease-in-out;
+}
+
+.sidebar-brand-github-link:hover {
+  opacity: 1;
+}

--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -1,0 +1,33 @@
+{#-
+Overrides furo's default sidebar/brand.html to place a GitHub icon link next to the project
+title, below the logo. The upstream template wraps logo+title in a single <a> to the home page;
+that can't also contain a second link to GitHub (nested <a> tags are invalid), so the title row
+is split out into its own flex row with two sibling links instead.
+-#}
+{%- if logo_url %}
+<a class="sidebar-brand centered" href="{{ pathto(master_doc) }}">
+  <div class="sidebar-logo-container">
+    <img class="sidebar-logo" src="{{ logo_url }}" alt="Logo"/>
+  </div>
+</a>
+{%- endif %}
+{%- if theme_light_logo and theme_dark_logo %}
+<a class="sidebar-brand centered" href="{{ pathto(master_doc) }}">
+  <div class="sidebar-logo-container">
+    <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="Light Logo"/>
+    <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="Dark Logo"/>
+  </div>
+</a>
+{%- endif %}
+{% if not theme_sidebar_hide_name %}
+<div class="sidebar-brand-row">
+  <a class="sidebar-brand-title-link" href="{{ pathto(master_doc) }}">
+    <span class="sidebar-brand-text">{{ docstitle if docstitle else project }}</span>
+  </a>
+  <a class="sidebar-brand-github-link" href="https://github.com/Differentiable-Electron-Crystallography/diffBloch" target="_blank" rel="noopener noreferrer" aria-label="View diffBloch on GitHub">
+    <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
+    </svg>
+  </a>
+</div>
+{%- endif %}

--- a/docs/bloch_wave_simulation.md
+++ b/docs/bloch_wave_simulation.md
@@ -137,7 +137,8 @@ There are two mathematically equivalent ways to evaluate this, and diffBloch imp
   {math}`\psi_{\mathbf{g}}(t) = \sum_i C_0^{(i)-1}C_{\mathbf{g}}^{(i)}\exp(2\pi i\gamma^{(i)}t)` —
   the classical closed-form Bloch wave solution, cheap once diagonalised.
 - **`matrix_exp`** evaluates the matrix exponential directly, without an intermediate
-  eigendecomposition. It is the default: eigendecomposition of a **non-Hermitian** matrix (the case
+  eigendecomposition ([Pennington, Wang & Koch, 2014](https://www.sciencedirect.com/science/article/pii/S0304399114000485)).
+  It is the default: eigendecomposition of a **non-Hermitian** matrix (the case
   whenever `absorption: true` adds an imaginary component to {math}`A`) is numerically unstable to
   differentiate through, so `bloch_eigen` is rejected outright when absorption is enabled.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,5 +122,10 @@ html_theme = "furo"
 html_title = "diffBloch"
 html_baseurl = "https://differentiable-electron-crystallography.github.io/diffBloch/"
 html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 html_logo = "_static/logo.png"
 ogp_site_url = html_baseurl
+
+# templates/sidebar/brand.html overrides furo's default to add a GitHub icon link next to the
+# sidebar title.
+templates_path = ["_templates"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ diffBloch performs the refinement as two complementary values: a crystal structu
 | [Devices and scaling](devices-and-scaling.md) | CPU and GPU execution, memory controls, and refinement profiling. |
 | [Reproducibility](reproducibility.md) | Records identifying the inputs and preprocessing used for a refinement. |
 | [Examples](examples.md) | Runnable experiments included with diffBloch. |
+| [Publications and references](publications-and-references.md) | Publications using diffBloch and the sources the codebase draws on. |
 
 ## Quickstart
 
@@ -92,6 +93,7 @@ refinement.md
 devices-and-scaling.md
 reproducibility.md
 examples.md
+publications-and-references.md
 ```
 
 ```{toctree}

--- a/docs/publications-and-references.md
+++ b/docs/publications-and-references.md
@@ -1,25 +1,33 @@
-# References 
+# Publications and references
 
-diffBloch stands on published science and several open-source projects. This file attempts to record all relevant sources used throughout the codebase. 
+## Publications using diffBloch
 
+- Colmey, B., Doherty, T. A. S., Malik, S. A. & Midgley, P. A. (2026). *The role of absorption in
+  three-dimensional electron diffraction dynamical structure refinement.* Submitted to Acta
+  Crystallographica A. <https://arxiv.org/abs/2602.08935>
 
+- Malik, S. A., Doherty, T. A. S., Colmey, B., Roberts, S. J., Gal, Y. & Midgley, P. A. (2026).
+  *Hybrid physics-machine learning models for quantitative electron diffraction refinements.*
+  Nature Communications. <https://www.nature.com/articles/s41467-026-71673-9>
+
+## General references
+
+diffBloch stands on published science and several open-source projects. This section records the
+sources used throughout the codebase.
 
 - **Electron scattering factors (Lobato parametrization).**
   Lobato, I. & Van Dyck, D. (2014). *An accurate parameterization for scattering factors, electron
   densities and electrostatic potentials for neutral atoms that obey all physical constraints.*
   **Acta Crystallographica A70(6), 636–649.** DOI: [10.1107/S205327331401643X](https://doi.org/10.1107/S205327331401643X)
   — open access ([PDF](https://nano.uantwerpen.be/nanorefs/pdfs/OA_10.1107_S205327331401643X.pdf)).
-  
 
 - **Dynamical electron diffraction (Bloch-wave method).**
   Spence, J. C. H. & Zuo, J. M. (1992). *Electron Microdiffraction.* Plenum Press, New York.
-  
 
 - **Bloch-wave matrix-exponential propagation (GPU-accelerated).**
   Pennington, R. S., Wang, F. & Koch, C. T. (2014). *Stacked-Bloch-wave electron diffraction
   simulations using GPU acceleration.* **Ultramicroscopy 141, 32–37.**
   <https://www.sciencedirect.com/science/article/pii/S0304399114000485>
-  
 
 - **Dynamical refinement of 3D electron diffraction data (rocking-curve integration framework).**
   Palatinus, L., Petříček, V. & Corrêa, C. A. (2015). *Structure refinement using precession electron
@@ -28,18 +36,15 @@ diffBloch stands on published science and several open-source projects. This fil
   [10.1107/S2053273315001266](https://doi.org/10.1107/S2053273315001266); with the companion tests
   paper Palatinus, L. et al. (2015). *…: tests on experimental data.* **Acta Crystallographica B71,
   740–751.** DOI: [10.1107/S2052520615017023](https://doi.org/10.1107/S2052520615017023).
-  
-
 
 - **Orientation refinement (hexagonal modified-simplex search).**
   Palatinus, L., Jacob, D., Cuvillier, P., Klementová, M., Sinkler, W. & Marks, L. D. (2013).
   *Structure refinement from precession electron diffraction data.* **Acta Crystallographica A69,
-  171–188.** DOI: [10.1107/S010876731204946X](https://doi.org/10.1107/S010876731204946X). 
+  171–188.** DOI: [10.1107/S010876731204946X](https://doi.org/10.1107/S010876731204946X).
 
+### Software we depend on, extract from, or verify against
 
-## Software we depend on, extract from, or verify against
-
-### Runtime dependencies
+**Runtime dependencies**
 - **gemmi** — CIF/mmCIF and PETS parsing, unit-cell handling, and space-group symmetry operations
   (the blessed parser behind `io/`). Wojdyr, M. (2022), *GEMMI: A library for structural biology*,
   Journal of Open Source Software 7(73), 4200. DOI: [10.21105/joss.04200](https://doi.org/10.21105/joss.04200)
@@ -50,10 +55,22 @@ diffBloch stands on published science and several open-source projects. This fil
 - **pydantic** — boundary validation for config and IO records. <https://github.com/pydantic/pydantic>
 - **PyYAML** — experiment/config and lock parsing. <https://github.com/yaml/pyyaml>
 
-### Planned dependencies (seams already in place)
+**Planned dependencies (seams already in place)**
 - **diffpy.structure** — special-position and ADP symmetry-constraint expansion, behind the
   `io.symmetry_setup` seam (lands with the constraints/symmetry stage). <https://github.com/diffpy/diffpy.structure>
 
-### Development & verification oracles (not runtime dependencies)
+**Development & verification oracles (not runtime dependencies)**
 - **abTEM** — Madsen, J. & Susi, T. (2021), *The abTEM code: transmission electron microscopy from
   first principles*, Open Research Europe 1:24. <https://open-research-europe.ec.europa.eu/articles/1-24>
+
+## Citing diffBloch
+
+```bibtex
+@misc{diffBloch,
+  author  = {Doherty, Tiarnan and Malik, Shreshth and Colmey, Benjamin and Maitland, Iain, and Midgley, Paul},
+  title   = {diffBloch},
+  version = {0.2.0},
+  year = {2026},
+  url     = {https://github.com/Differentiable-Electron-Crystallography/diffBloch}
+}
+```


### PR DESCRIPTION
- New Publications and references page (docs/publications-and-references.md), linking the two diffBloch papers and mirroring REFERENCES.md
- README doc links now point to diffbloch.com
- GitHub icon next to the sidebar title (custom furo sidebar/brand.html + custom.css)
- Cites Pennington, Wang & Koch (2014) wherever matrix_exp is introduced, plus REFERENCES.md