### PR TITLE
Restore precession diffraction support

### DIFF
--- a/src/diffBloch/io/pets.py
+++ b/src/diffBloch/io/pets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Literal
 
 import gemmi
 import numpy as np
@@ -16,6 +17,9 @@ from diffBloch.io.record import ExperimentalRecord
 _DSTAR_MAX = re.compile(r"dstarmax:\s*([\d.]+)", re.IGNORECASE)
 _FLOAT_TEXT = r"[-+]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][-+]?\d+)?|inf(?:inity)?|nan)"
 _MOSAICITY = re.compile(rf"mosaicity:\s*({_FLOAT_TEXT})", re.IGNORECASE)
+_DATA_COLLECTION_GEOMETRY = re.compile(
+    r"data\s+collection\s+geometry\s*:\s*([^\r\n;]+)", re.IGNORECASE
+)
 
 
 def read_experimental_data(path: str | Path) -> ExperimentalRecord:
@@ -43,6 +47,7 @@ def parse_experimental_block(
         cell_parameters=cellpar,
         cell_parameters_su=cellpar_su,
         wavelength=required_float(block, "_diffrn_radiation_wavelength"),
+        data_collection_geometry=_data_collection_geometry(block),
         dstar_max=_dstar_max(block),
         mosaicity_degrees=_mosaicity(block),
         ub_matrix=_ub_matrix(block),
@@ -121,6 +126,33 @@ def _mosaicity(block: gemmi.cif.Block) -> float | None:
         return None
     match = _MOSAICITY.search(str(text))
     return float(match.group(1)) if match else None
+
+
+def _data_collection_geometry(
+    block: gemmi.cif.Block,
+) -> Literal["continuous_rotation", "precession"]:
+    """Return PETS2's acquisition geometry in the package's canonical spelling.
+
+    PETS2 writes this value into the informal ``_diffrn_measurement_details`` text block rather
+    than a structured CIF tag. Older files may omit it; those retain diffBloch's historical
+    continuous-rotation default. An explicit unknown value fails at the I/O boundary rather than
+    silently selecting scientifically different integration geometry.
+    """
+    text = block.find_value("_diffrn_measurement_details")
+    if text is None:
+        return "continuous_rotation"
+    match = _DATA_COLLECTION_GEOMETRY.search(str(text))
+    if match is None:
+        return "continuous_rotation"
+    value = re.sub(r"[\s_-]+", "_", match.group(1).strip().lower())
+    if value == "continuous_rotation":
+        return "continuous_rotation"
+    if value == "precession":
+        return "precession"
+    raise ValueError(
+        "PETS data collection geometry must be 'continuous rotation' or 'precession'; "
+        f"got {match.group(1).strip()!r}"
+    )
 
 
 def _ub_matrix(block: gemmi.cif.Block) -> NDArray[np.float64]:

--- a/src/diffBloch/io/record.py
+++ b/src/diffBloch/io/record.py
@@ -196,6 +196,10 @@ class ExperimentalRecord(BaseModel):
     cell_parameters: FloatArray
     cell_parameters_su: FloatArray
     wavelength: float
+    # PETS2 records the acquisition mode in the free-text measurement-details block. The
+    # ``_diffrn_zone_axis_precession_angle`` column is used for the integration semi-angle in both
+    # modes, so its name alone cannot distinguish continuous rotation from precession.
+    data_collection_geometry: Literal["continuous_rotation", "precession"] = "continuous_rotation"
     # PETS2's own processing-resolution cutoff (Angstrom^-1), parsed from the free-text
     # _diffrn_measurement_details block when present; None if that field is absent or the PETS
     # version that wrote this file doesn't record it (a manual/config g_max is then the only option).

--- a/src/diffBloch/preprocess/experiment.py
+++ b/src/diffBloch/preprocess/experiment.py
@@ -278,7 +278,10 @@ def setup_datasets(
             raise ValueError(
                 f"ignore_orientations excludes every PETS rotation of dataset {dataset_index}"
             )
-        integration = IntegrationGeometry(semiangle=record.integration_semiangle)
+        integration = IntegrationGeometry(
+            semiangle=record.integration_semiangle,
+            geometry=record.data_collection_geometry,
+        )
         mosaicity = resolve_dataset_mosaicity(
             config.blochwave.mosaicity,
             record,

--- a/src/diffBloch/preprocess/orientation.py
+++ b/src/diffBloch/preprocess/orientation.py
@@ -115,20 +115,37 @@ def rocking_curve_tilts(
 ) -> FloatArray:
     """Rocking-curve integration tilts as ``(N, 3, 3)`` rotation matrices, ``N = sampling``.
 
-    ``sampling`` tilts at angles ``linspace(-semiangle, +semiangle, sampling)`` degrees, each a
-    rotation about **x** -- the goniometer axis in the PETS coordinate frame, where these matrices
-    left-multiply the already-PETS-rotated orientation (``R_tilt @ orientation``). ``sampling = 1``
-    is special-cased to a single tilt at angle 0 (the identity), so composing the integration with a
-    unit sampling is a no-op -- ``np.linspace`` would otherwise return the *start* ``-semiangle``
-    for ``num = 1``, off-centre from the nominal orientation.
+    For ``continuous_rotation``, ``sampling`` tilts span
+    ``linspace(-semiangle, +semiangle, sampling)`` degrees about **x**, the goniometer axis in the
+    PETS coordinate frame. ``sampling = 1`` is the identity so that unit-sample rocking integration
+    composes off. For ``precession``, samples lie at the fixed cone semi-angle and uniformly spaced
+    azimuths over ``[0, 360)`` using ``R_z(phi) R_x(semiangle) R_z(-phi)``. This is the convention
+    used by the legacy preprocessing path.
 
-    Continuous-rotation geometry only; ``precession`` (a cone) is a later discriminated mode and
-    raises ``NotImplementedError`` here. Callers unpack a validated
+    In both modes these matrices left-multiply the already-PETS-rotated nominal orientation
+    (``R_tilt @ orientation``). Callers unpack a validated
     :class:`~diffBloch.specs.RockingCurve` into these raw arguments (the value-type owns the
     invariants), matching :func:`hexagonal_tilt`'s raw-float style.
     """
+    if geometry == "precession":
+        azimuths = np.deg2rad(np.linspace(0.0, 360.0, sampling, endpoint=False))
+        polar = np.deg2rad(semiangle)
+        cos_phi, sin_phi = np.cos(azimuths), np.sin(azimuths)
+        cos_polar, sin_polar = np.cos(polar), np.sin(polar)
+        tilts = np.empty((sampling, 3, 3), dtype=np.float64)
+        # Expanded R_z(phi) @ R_x(polar) @ R_z(-phi), vectorized over cone azimuth.
+        tilts[:, 0, 0] = cos_phi**2 + cos_polar * sin_phi**2
+        tilts[:, 0, 1] = (1.0 - cos_polar) * cos_phi * sin_phi
+        tilts[:, 0, 2] = sin_polar * sin_phi
+        tilts[:, 1, 0] = tilts[:, 0, 1]
+        tilts[:, 1, 1] = sin_phi**2 + cos_polar * cos_phi**2
+        tilts[:, 1, 2] = -sin_polar * cos_phi
+        tilts[:, 2, 0] = -sin_polar * sin_phi
+        tilts[:, 2, 1] = sin_polar * cos_phi
+        tilts[:, 2, 2] = cos_polar
+        return tilts
     if geometry != "continuous_rotation":
-        raise NotImplementedError(f"rocking-curve geometry {geometry!r} is not implemented")
+        raise ValueError("geometry must be 'continuous_rotation' or 'precession'")
     if sampling == 1:
         angles = np.zeros(1)  # single sample sits at the nominal orientation -> identity tilt
     else:

--- a/src/diffBloch/specs.py
+++ b/src/diffBloch/specs.py
@@ -256,7 +256,7 @@ class RockingCurve:
     :class:`IntegrationGeometry`) supplies the tilt half-width ``semiangle`` -- the *same* physical
     angular range as the Klar beam-selection window, shared with :class:`BeamSelection` so the two
     cannot disagree -- and the ``geometry`` that selects the sweep (``continuous_rotation``,
-    goniometer x-axis tilts, implemented; or ``precession``, a deferred cone mode).
+    goniometer x-axis tilts; or ``precession``, uniformly sampled around a fixed-angle cone).
     """
 
     sampling: int = 42  # number of tilts across +/- semiangle; 1 = single static solve (identity)

--- a/tests/unit/test_io_quartz.py
+++ b/tests/unit/test_io_quartz.py
@@ -46,6 +46,7 @@ def test_read_quartz_pets_fixture() -> None:
     assert record.wavelength == 0.02510
     assert record.dstar_max == pytest.approx(1.800)
     assert record.mosaicity_degrees == pytest.approx(0.050)
+    assert record.data_collection_geometry == "continuous_rotation"
     assert record.cell_parameters.tolist() == pytest.approx([4.9226, 4.9226, 5.4003, 90, 90, 120])
     assert record.cell_parameters_su.shape == (6,)
     assert record.n_rotations == 99
@@ -175,6 +176,10 @@ _diffrn_orient_matrix_UB_23 0
 _diffrn_orient_matrix_UB_31 0
 _diffrn_orient_matrix_UB_32 0
 _diffrn_orient_matrix_UB_33 1
+_diffrn_measurement_details
+;
+data collection geometry: precession
+;
 loop_
 _diffrn_zone_axis_id
 _diffrn_zone_axis_u
@@ -205,4 +210,5 @@ _refln_zone_axis_id
     assert record.zone_axes.tolist() == [[0.0, 0.0, 1.0]]
     assert record.intensities.tolist() == [12.5]
     assert record.sigmas.tolist() == [0.7]
-    assert record.dstar_max is None  # no _diffrn_measurement_details block in this PETS version
+    assert record.data_collection_geometry == "precession"
+    assert record.dstar_max is None

--- a/tests/unit/test_multi_dataset.py
+++ b/tests/unit/test_multi_dataset.py
@@ -94,6 +94,14 @@ def test_setup_datasets_gives_each_dataset_its_own_integration_geometry() -> Non
     assert datasets[1].integration.semiangle == 2.0
 
 
+def test_setup_datasets_preserves_each_dataset_collection_geometry() -> None:
+    structure, record, config = _quartz_inputs()
+    precession = record.model_copy(update={"data_collection_geometry": "precession"})
+    _, datasets = setup_datasets(structure, (record, precession), config)
+    assert datasets[0].integration.geometry == "continuous_rotation"
+    assert datasets[1].integration.geometry == "precession"
+
+
 def test_setup_datasets_translates_global_ignore_to_file_local_slices() -> None:
     structure, record, config = _quartz_inputs()
     n = record.n_rotations

--- a/tests/unit/test_orientation_derivation.py
+++ b/tests/unit/test_orientation_derivation.py
@@ -16,6 +16,7 @@ from diffBloch.core.crystal import cell_matrix_from_parameters
 from diffBloch.preprocess.orientation import (
     busing_levy_matrix,
     goniometer_rotation,
+    hexagonal_tilt,
     orientation_basis,
     orientation_matrices,
     rocking_curve_tilts,
@@ -122,6 +123,21 @@ def test_rocking_curve_tilts_unit_sampling_is_the_identity() -> None:
     assert np.allclose(rocking_curve_tilts(1.0, 1), np.eye(3)[None])
 
 
-def test_rocking_curve_tilts_reject_unimplemented_geometry() -> None:
-    with pytest.raises(NotImplementedError, match="precession"):
-        rocking_curve_tilts(1.0, 42, geometry="precession")
+def test_precession_tilts_sample_the_fixed_angle_cone() -> None:
+    tilts = rocking_curve_tilts(1.0, 4, geometry="precession")
+    assert tilts.shape == (4, 3, 3)
+    assert np.allclose(np.linalg.det(tilts), 1.0)
+    assert np.allclose(tilts @ np.swapaxes(tilts, 1, 2), np.eye(3))
+    assert np.allclose(
+        tilts,
+        np.stack([hexagonal_tilt(azimuth, 1.0) for azimuth in (0.0, 90.0, 180.0, 270.0)]),
+    )
+
+
+def test_precession_unit_sampling_retains_the_cone_angle() -> None:
+    # Unlike continuous rotation, one precession sample is the phi=0 cone orientation, matching
+    # the legacy precession generator rather than silently turning integration off.
+    assert np.allclose(
+        rocking_curve_tilts(1.0, 1, geometry="precession"),
+        hexagonal_tilt(0.0, 1.0)[None],
+    )


### PR DESCRIPTION
Restores PETS acquisition-geometry parsing and end-to-end precession-cone integration. Continuous-rotation behavior remains unchanged. Includes typed geometry propagation and regression coverage for PETS parsing, per-dataset setup, and cone sampling.\n\nValidation:\n- Ruff passed\n- mypy passed\n- 46 focused tests passed