### PR TITLE
Support per-dataset seed thicknesses

### DIFF
--- a/docs/hyperparameter-selection.md
+++ b/docs/hyperparameter-selection.md
@@ -175,7 +175,7 @@ Top-level, not nested under `refinement`, because it governs preprocessing too.
 | Field | Default | What it does |
 |---|---|---|
 | `steps` | `40` | Number of gradient-refinement epochs. |
-| `optimizer.name` | `"lbfgs"` | `"lbfgs"`, `"adam"`, or `"adamw"`. |
+| `optimizer.name` | `"adam"` | `"adam"`, `"adamw"`, or `"lbfgs"`. |
 | `optimizer.lr` | `1e-3` | Learning rate (Adam/AdamW; L-BFGS uses its own internal line search). |
 
 ### `refinement.trainable`
@@ -224,10 +224,37 @@ Input file references, relative to the experiment directory only (`Inputs`).
 ### Combining multiple datasets
 
 `inputs.multi_dataset: true` pools rotations from several `.cif_pets` files (`inputs.exp_data` as a
-list of 2+ paths) into one experiment, each dataset keeping its own orientation, and
-thickness. Two situations call for it:
+list of 2+ paths) into one experiment. Each dataset keeps its own orientation, integration
+geometry, and thickness seed. Two situations call for it:
 
-- **Beam damage** — Each
-  dataset is its own `.cif_pets` file  but they refine one shared structure.
+- **Beam damage series** — repeat measurements of the same crystal taken at increasing dose. Each
+  dataset is its own `.cif_pets` file, but they refine one shared structure.
 - **Low-symmetry structures** — a single tilt series from one crystal orientation range may not
-  cover enough of reciprocal space to constrain the structure well.
+  cover enough of reciprocal space to constrain the structure well when the space group has few
+  symmetry operations to fill in the gaps. Multiple datasets from different crystal
+  orientations/mounts fill in coverage that one series alone would leave thin.
+
+Each dataset is preprocessed and checkpointed on its own (`plan.<stem>.npz` per file, with its own
+integration geometry -- precession angles may differ between files), and the settled per-dataset
+plans are pooled in memory just before refinement. See
+[Inputs and outputs](inputs.md) for the mechanics (per-dataset checkpoints, the
+first-file authoritative cell, one-energy rule, rotation-index offsets) and
+[Reproducibility](reproducibility.md) for what each per-dataset lock verifies.
+
+Set a different initial mean thickness for each dataset like this:
+
+```yaml
+inputs:
+  structure: structure.cif
+  multi_dataset: true
+  exp_data:
+    - dataset_1.cif_pets
+    - dataset_2.cif_pets
+
+sample:
+  mean_thickness_by_dataset:
+    dataset_1.cif_pets: 400.0
+    dataset_2.cif_pets: 800.0
+```
+
+Every rotation in each dataset starts from that dataset's assigned value.

--- a/docs/hyperparameter-selection.md
+++ b/docs/hyperparameter-selection.md
@@ -175,7 +175,7 @@ Top-level, not nested under `refinement`, because it governs preprocessing too.
 | Field | Default | What it does |
 |---|---|---|
 | `steps` | `40` | Number of gradient-refinement epochs. |
-| `optimizer.name` | `"adam"` | `"adam"`, `"adamw"`, or `"lbfgs"`. |
+| `optimizer.name` | `"lbfgs"` | `"lbfgs"`, `"adam"`, or `"adamw"`. |
 | `optimizer.lr` | `1e-3` | Learning rate (Adam/AdamW; L-BFGS uses its own internal line search). |
 
 ### `refinement.trainable`

--- a/src/diffBloch/app/loggers/summary.py
+++ b/src/diffBloch/app/loggers/summary.py
@@ -200,6 +200,10 @@ class SummaryLogger:
             else "n/a"
         )
         best_epoch = f"{completed.best_step + 1:g}" if completed else "n/a"
+        seed_thickness = "; ".join(
+            f"{dataset}: {', '.join(f'{thickness:g}' for thickness in thicknesses)}"
+            for dataset, thicknesses in experiment.seed_thicknesses_by_dataset
+        )
         rows = [
             [
                 "Integration semiangle (deg)",
@@ -215,7 +219,7 @@ class SummaryLogger:
             ],
             ["sg_max (A^-1)", f"{experiment.sg_max:g}"],
             ["Absorption (T/F)", "T" if experiment.absorption else "F"],
-            ["Seed thickness (A)", ", ".join(f"{t:g}" for t in experiment.seed_thicknesses)],
+            ["Seed thickness (A)", seed_thickness],
             ["Epochs (configured)", f"{experiment.steps:g}"],
             ["Best epoch", best_epoch],
             ["Optimizer", experiment.optimizer],

--- a/src/diffBloch/config/manifest.py
+++ b/src/diffBloch/config/manifest.py
@@ -207,7 +207,9 @@ def dataset_config_digest(config: ExperimentConfig, *, exp_data: str) -> str:
             "exp_data": exp_data,
             "load_hydrogens": dump["inputs"]["load_hydrogens"],
         },
-        "sample": dump["sample"],
+        # Resolve the optional per-dataset mapping to this Plan's effective seed. This keeps a
+        # change for dataset B from invalidating dataset A's checkpoint.
+        "sample": {"thicknesses": list(config.sample.seed_thicknesses_for(exp_data))},
         "blochwave": blochwave,
         "preprocess": preprocess,
         "loss_metrics": dump["loss_metrics"],

--- a/src/diffBloch/config/schema.py
+++ b/src/diffBloch/config/schema.py
@@ -150,6 +150,7 @@ class SampleConfig(_StrictConfig):
     """
 
     thicknesses: tuple[float, ...] = (820.0,)
+    mean_thickness_by_dataset: dict[str, float] = Field(default_factory=dict)
 
     @field_validator("thicknesses")
     @classmethod
@@ -159,6 +160,21 @@ class SampleConfig(_StrictConfig):
         if any(thickness <= 0.0 for thickness in value):
             raise ValueError("thicknesses must be positive")
         return value
+
+    @field_validator("mean_thickness_by_dataset")
+    @classmethod
+    def _positive_dataset_thicknesses(cls, value: dict[str, float]) -> dict[str, float]:
+        for ref, thickness in value.items():
+            _relative_path_only(ref)
+            if thickness <= 0.0:
+                raise ValueError("per-dataset mean thicknesses must be positive")
+        return value
+
+    def seed_thicknesses_for(self, exp_data: str) -> tuple[float, ...]:
+        """Return this dataset's configured seed thickness tuple."""
+        if exp_data in self.mean_thickness_by_dataset:
+            return (self.mean_thickness_by_dataset[exp_data],)
+        return self.thicknesses
 
 
 class DataSplitConfig(_StrictConfig):
@@ -220,7 +236,7 @@ class LossMetricsConfig(_StrictConfig):
 class OptimizerConfig(_StrictConfig):
     """Explicit optimizer backend for a refinement stage (matches ``OptimizerName``)."""
 
-    name: Literal["lbfgs", "adam", "adamw"] = "lbfgs"
+    name: Literal["lbfgs", "adam", "adamw"] = "adam"
     lr: float = 1e-3
 
 
@@ -501,6 +517,20 @@ class ExperimentConfig(_StrictConfig):
                 "cannot represent per-dataset thickness; that is future work) -- set "
                 "refinement.thickness_nn.enabled: false to pool datasets"
             )
+        per_dataset = set(self.sample.mean_thickness_by_dataset)
+        if per_dataset:
+            if not self.inputs.multi_dataset or not isinstance(self.inputs.exp_data, list):
+                raise ValueError(
+                    "sample.mean_thickness_by_dataset requires inputs.multi_dataset=true"
+                )
+            expected = set(self.inputs.exp_data)
+            if per_dataset != expected:
+                missing = sorted(expected - per_dataset)
+                unknown = sorted(per_dataset - expected)
+                raise ValueError(
+                    "sample.mean_thickness_by_dataset keys must exactly match inputs.exp_data; "
+                    f"missing={missing}, unknown={unknown}"
+                )
         return self
 
     def to_declaration(self, integrations: Sequence[IntegrationGeometry]) -> ExperimentDeclared:
@@ -518,12 +548,25 @@ class ExperimentConfig(_StrictConfig):
             if isinstance(self.inputs.exp_data, list)
             else self.inputs.exp_data
         )
+        dataset_refs = (
+            tuple(self.inputs.exp_data)
+            if isinstance(self.inputs.exp_data, list)
+            else (self.inputs.exp_data,)
+        )
+        declared_seed_thicknesses = (
+            tuple(
+                self.sample.mean_thickness_by_dataset[ref]
+                for ref in dataset_refs
+            )
+            if self.sample.mean_thickness_by_dataset
+            else tuple(self.sample.thicknesses)
+        )
         return ExperimentDeclared(
             name=self.name,
             structure=self.inputs.structure,
             experimental_data=experimental_data,
             optimizer=self.refinement.optimizer.name,
-            seed_thicknesses=tuple(self.sample.thicknesses),
+            seed_thicknesses=declared_seed_thicknesses,
             integration_semiangles=tuple(integration.semiangle for integration in integrations),
             rocking_curve_sampling=self.blochwave.rocking_curve_sampling,
             dsg=self.blochwave.dsg,

--- a/src/diffBloch/config/schema.py
+++ b/src/diffBloch/config/schema.py
@@ -7,6 +7,7 @@ input references and overrides.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -157,8 +158,8 @@ class SampleConfig(_StrictConfig):
     def _positive_thicknesses(cls, value: tuple[float, ...]) -> tuple[float, ...]:
         if not value:
             raise ValueError("thicknesses must contain at least one value")
-        if any(thickness <= 0.0 for thickness in value):
-            raise ValueError("thicknesses must be positive")
+        if any(not math.isfinite(thickness) or thickness <= 0.0 for thickness in value):
+            raise ValueError("thicknesses must be finite and positive")
         return value
 
     @field_validator("mean_thickness_by_dataset")
@@ -166,8 +167,8 @@ class SampleConfig(_StrictConfig):
     def _positive_dataset_thicknesses(cls, value: dict[str, float]) -> dict[str, float]:
         for ref, thickness in value.items():
             _relative_path_only(ref)
-            if thickness <= 0.0:
-                raise ValueError("per-dataset mean thicknesses must be positive")
+            if not math.isfinite(thickness) or thickness <= 0.0:
+                raise ValueError("per-dataset mean thicknesses must be finite and positive")
         return value
 
     def seed_thicknesses_for(self, exp_data: str) -> tuple[float, ...]:
@@ -236,7 +237,7 @@ class LossMetricsConfig(_StrictConfig):
 class OptimizerConfig(_StrictConfig):
     """Explicit optimizer backend for a refinement stage (matches ``OptimizerName``)."""
 
-    name: Literal["lbfgs", "adam", "adamw"] = "adam"
+    name: Literal["lbfgs", "adam", "adamw"] = "lbfgs"
     lr: float = 1e-3
 
 
@@ -553,20 +554,15 @@ class ExperimentConfig(_StrictConfig):
             if isinstance(self.inputs.exp_data, list)
             else (self.inputs.exp_data,)
         )
-        declared_seed_thicknesses = (
-            tuple(
-                self.sample.mean_thickness_by_dataset[ref]
-                for ref in dataset_refs
-            )
-            if self.sample.mean_thickness_by_dataset
-            else tuple(self.sample.thicknesses)
+        seed_thicknesses_by_dataset = tuple(
+            (ref, self.sample.seed_thicknesses_for(ref)) for ref in dataset_refs
         )
         return ExperimentDeclared(
             name=self.name,
             structure=self.inputs.structure,
             experimental_data=experimental_data,
             optimizer=self.refinement.optimizer.name,
-            seed_thicknesses=declared_seed_thicknesses,
+            seed_thicknesses_by_dataset=seed_thicknesses_by_dataset,
             integration_semiangles=tuple(integration.semiangle for integration in integrations),
             rocking_curve_sampling=self.blochwave.rocking_curve_sampling,
             dsg=self.blochwave.dsg,

--- a/src/diffBloch/engine/forward.py
+++ b/src/diffBloch/engine/forward.py
@@ -936,7 +936,7 @@ def run_refinement_model(
     *,
     trainable: TrainableSpec,
     steps: int,
-    optimizer: OptimizerName = "adam",
+    optimizer: OptimizerName = "lbfgs",
     lr: float = 1e-3,
     logger: Logger = NULL_LOGGER,
     verbose: bool = False,

--- a/src/diffBloch/engine/forward.py
+++ b/src/diffBloch/engine/forward.py
@@ -936,7 +936,7 @@ def run_refinement_model(
     *,
     trainable: TrainableSpec,
     steps: int,
-    optimizer: OptimizerName = "lbfgs",
+    optimizer: OptimizerName = "adam",
     lr: float = 1e-3,
     logger: Logger = NULL_LOGGER,
     verbose: bool = False,

--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -515,9 +515,9 @@ class ExperimentDeclared:
     the :class:`~diffBloch.config.schema.ExperimentConfig` directly -- which is what keeps such a sink
     an ordinary :class:`Logger` rather than a component wired into the app's orchestration.
 
-    Paths, the optimizer name, and the seed-thickness list ride on the dataclass rather than in
-    ``measurements``, which stays flat-scalar for the generic backends -- the same split
-    :class:`ThicknessOptimized` makes for its candidate grid.
+    Paths, the optimizer name, and the per-dataset seed-thickness declarations ride on the
+    dataclass rather than in ``measurements``, which stays flat-scalar for the generic backends --
+    the same split :class:`ThicknessOptimized` makes for its candidate grid.
     """
 
     channel: ClassVar[str] = "experiment"
@@ -525,7 +525,9 @@ class ExperimentDeclared:
     structure: str
     experimental_data: str
     optimizer: str
-    seed_thicknesses: tuple[float, ...]
+    # One effective seed-thickness tuple per inputs.exp_data entry, preserving the dataset labels
+    # when ``sample.mean_thickness_by_dataset`` overrides the shared default.
+    seed_thicknesses_by_dataset: tuple[tuple[str, tuple[float, ...]], ...]
     # One semiangle per inputs.exp_data entry, in that order -- pooled datasets may differ.
     integration_semiangles: tuple[float, ...]
     rocking_curve_sampling: int

--- a/src/diffBloch/preprocess/experiment.py
+++ b/src/diffBloch/preprocess/experiment.py
@@ -267,9 +267,17 @@ def setup_datasets(
         )
 
     u0_by_energy: dict[float, float] = {}
+    dataset_refs = (
+        tuple(config.inputs.exp_data)
+        if isinstance(config.inputs.exp_data, list)
+        else (config.inputs.exp_data,)
+    )
     datasets: list[DatasetSetup] = []
     offset = 0
     for dataset_index, record in enumerate(records):
+        seed_thicknesses = config.sample.thicknesses
+        if config.sample.mean_thickness_by_dataset:
+            seed_thicknesses = config.sample.seed_thicknesses_for(dataset_refs[dataset_index])
         count = counts[dataset_index]
         local_ignored = tuple(
             sorted(index - offset for index in ignored if offset <= index < offset + count)
@@ -310,7 +318,7 @@ def setup_datasets(
                     rotation_index=local_index,
                 ),
                 energy=energy,
-                thickness=config.sample.thicknesses,
+                thickness=seed_thicknesses,
                 orientation=orientations[local_index],
                 u0=u0,
             )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -45,7 +45,7 @@ def test_minimal_config_validates_with_defaults() -> None:
     assert cfg.refinement.trainable.positions == "all"
     assert cfg.refinement.trainable.adp == "all"
     assert cfg.refinement.trainable.occupancy == "none"
-    assert cfg.refinement.optimizer.name == "adam"
+    assert cfg.refinement.optimizer.name == "lbfgs"
     assert cfg.loss_metrics.residual == "wr2"
     assert cfg.refinement.thickness_nn.to_spec() == ApparentThicknessNetwork()
     assert cfg.refinement.split.train_test is False
@@ -116,12 +116,54 @@ def test_multi_dataset_mean_thicknesses_are_keyed_by_exp_data() -> None:
     )
     assert cfg.sample.seed_thicknesses_for("a.cif_pets") == (400.0,)
     assert cfg.sample.seed_thicknesses_for("b.cif_pets") == (800.0,)
+    declared = cfg.to_declaration(
+        (IntegrationGeometry(semiangle=1.0), IntegrationGeometry(semiangle=2.0))
+    )
+    assert declared.seed_thicknesses_by_dataset == (
+        ("a.cif_pets", (400.0,)),
+        ("b.cif_pets", (800.0,)),
+    )
 
     with pytest.raises(ValidationError, match="keys must exactly match"):
         ExperimentConfig.model_validate(
             {
                 **base,
                 "sample": {"mean_thickness_by_dataset": {"a.cif_pets": 400.0}},
+            }
+        )
+
+
+def test_sample_thicknesses_must_be_finite() -> None:
+    base = {"name": "q", "inputs": {"structure": "q.cif", "exp_data": "q.cif_pets"}}
+
+    with pytest.raises(ValidationError, match="thicknesses must be finite and positive"):
+        ExperimentConfig.model_validate({**base, "sample": {"thicknesses": [float("nan")]}})
+
+    with pytest.raises(ValidationError, match="thicknesses must be finite and positive"):
+        ExperimentConfig.model_validate({**base, "sample": {"thicknesses": [float("inf")]}})
+
+
+def test_multi_dataset_mean_thicknesses_must_be_finite() -> None:
+    base = {
+        "name": "pooled",
+        "inputs": {
+            "structure": "q.cif",
+            "exp_data": ["a.cif_pets", "b.cif_pets"],
+            "multi_dataset": True,
+        },
+        "refinement": {"thickness_nn": {"enabled": False}},
+    }
+
+    with pytest.raises(ValidationError, match="finite and positive"):
+        ExperimentConfig.model_validate(
+            {
+                **base,
+                "sample": {
+                    "mean_thickness_by_dataset": {
+                        "a.cif_pets": 400.0,
+                        "b.cif_pets": float("nan"),
+                    }
+                },
             }
         )
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -45,7 +45,7 @@ def test_minimal_config_validates_with_defaults() -> None:
     assert cfg.refinement.trainable.positions == "all"
     assert cfg.refinement.trainable.adp == "all"
     assert cfg.refinement.trainable.occupancy == "none"
-    assert cfg.refinement.optimizer.name == "lbfgs"
+    assert cfg.refinement.optimizer.name == "adam"
     assert cfg.loss_metrics.residual == "wr2"
     assert cfg.refinement.thickness_nn.to_spec() == ApparentThicknessNetwork()
     assert cfg.refinement.split.train_test is False
@@ -89,6 +89,39 @@ def test_absorption_config_is_typed_and_requires_matrix_exp() -> None:
                     "absorption": True,
                     "solver": "bloch_eigen",
                 },
+            }
+        )
+
+
+def test_multi_dataset_mean_thicknesses_are_keyed_by_exp_data() -> None:
+    base = {
+        "name": "pooled",
+        "inputs": {
+            "structure": "q.cif",
+            "exp_data": ["a.cif_pets", "b.cif_pets"],
+            "multi_dataset": True,
+        },
+        "refinement": {"thickness_nn": {"enabled": False}},
+    }
+    cfg = ExperimentConfig.model_validate(
+        {
+            **base,
+            "sample": {
+                "mean_thickness_by_dataset": {
+                    "a.cif_pets": 400.0,
+                    "b.cif_pets": 800.0,
+                }
+            },
+        }
+    )
+    assert cfg.sample.seed_thicknesses_for("a.cif_pets") == (400.0,)
+    assert cfg.sample.seed_thicknesses_for("b.cif_pets") == (800.0,)
+
+    with pytest.raises(ValidationError, match="keys must exactly match"):
+        ExperimentConfig.model_validate(
+            {
+                **base,
+                "sample": {"mean_thickness_by_dataset": {"a.cif_pets": 400.0}},
             }
         )
 

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -146,6 +146,29 @@ def test_dataset_config_digest_is_stable_and_value_sensitive() -> None:
     )
 
 
+def test_dataset_config_digest_scopes_per_dataset_mean_thickness() -> None:
+    cfg = load_config(LOCKED / "experiment.yaml")
+    raw = cfg.model_dump()
+    raw["inputs"] = {
+        "structure": cfg.inputs.structure,
+        "exp_data": [EXP_REF, "b.cif_pets"],
+        "multi_dataset": True,
+    }
+    raw["sample"]["mean_thickness_by_dataset"] = {EXP_REF: 400.0, "b.cif_pets": 800.0}
+    raw["refinement"]["thickness_nn"]["enabled"] = False
+    pooled = cfg.__class__.model_validate(raw)
+    changed_raw = pooled.model_dump()
+    changed_raw["sample"]["mean_thickness_by_dataset"]["b.cif_pets"] = 900.0
+    changed = cfg.__class__.model_validate(changed_raw)
+
+    assert dataset_config_digest(pooled, exp_data=EXP_REF) == dataset_config_digest(
+        changed, exp_data=EXP_REF
+    )
+    assert dataset_config_digest(pooled, exp_data="b.cif_pets") != dataset_config_digest(
+        changed, exp_data="b.cif_pets"
+    )
+
+
 def test_dataset_config_digest_scopes_to_plan_determining_config() -> None:
     """The digest keys only on what determines the settled per-dataset Plan."""
     cfg = load_config(LOCKED / "experiment.yaml")

--- a/tests/unit/test_multi_dataset.py
+++ b/tests/unit/test_multi_dataset.py
@@ -12,7 +12,7 @@ import pytest
 import yaml
 
 from diffBloch.app.program import _read_experimental_data, converge_experiment
-from diffBloch.config import input_lock_for, load_config
+from diffBloch.config import ExperimentConfig, input_lock_for, load_config
 from diffBloch.core.crystal import cell_matrix_from_parameters
 from diffBloch.io import read_experimental_data, read_structure
 from diffBloch.preprocess import setup_datasets
@@ -100,6 +100,30 @@ def test_setup_datasets_preserves_each_dataset_collection_geometry() -> None:
     _, datasets = setup_datasets(structure, (record, precession), config)
     assert datasets[0].integration.geometry == "continuous_rotation"
     assert datasets[1].integration.geometry == "precession"
+
+
+def test_setup_datasets_seeds_each_dataset_with_its_configured_mean_thickness() -> None:
+    structure, record, config = _quartz_inputs()
+    raw = config.model_dump(mode="python")
+    raw["inputs"] = {
+        **raw["inputs"],
+        "exp_data": ["a.cif_pets", "b.cif_pets"],
+        "multi_dataset": True,
+    }
+    raw["sample"] = {
+        **raw["sample"],
+        "mean_thickness_by_dataset": {
+            "a.cif_pets": 400.0,
+            "b.cif_pets": 800.0,
+        },
+    }
+    raw["refinement"]["thickness_nn"]["enabled"] = False
+    multi_config = ExperimentConfig.model_validate(raw)
+
+    _, datasets = setup_datasets(structure, (record, record), multi_config)
+
+    assert datasets[0].plan.orientations[0].thickness.tolist() == [400.0]
+    assert datasets[1].plan.orientations[0].thickness.tolist() == [800.0]
 
 
 def test_setup_datasets_translates_global_ignore_to_file_local_slices() -> None:

--- a/tests/unit/test_summary_logger.py
+++ b/tests/unit/test_summary_logger.py
@@ -58,7 +58,7 @@ def _experiment() -> ExperimentDeclared:
         structure="q.cif",
         experimental_data="q.cif_pets",
         optimizer="lbfgs",
-        seed_thicknesses=(820.0,),
+        seed_thicknesses_by_dataset=(("q.cif_pets", (820.0,)),),
         integration_semiangles=(1.0,),
         rocking_curve_sampling=42,
         dsg=0.0015,
@@ -94,6 +94,7 @@ def _step(**overrides: object) -> RefinementStep:
 def _run(
     tmp_path: Path,
     *,
+    experiment: ExperimentDeclared | None = None,
     steps: tuple[RefinementStep, ...] = (),
     rotations: tuple[RefinedRotationMetrics, ...] = (),
     profile: ThicknessProfile | None = None,
@@ -103,7 +104,7 @@ def _run(
     """Drive a SummaryLogger through one run's worth of events and return the written text."""
     structure = _structure(tmp_path)
     logger = SummaryLogger(tmp_path / "refinement_report.txt")
-    logger.report(_experiment())
+    logger.report(experiment if experiment is not None else _experiment())
     logger.report(
         manifest
         if manifest is not None
@@ -167,6 +168,35 @@ def test_summary_renders_every_section_from_events_alone(tmp_path: Path) -> None
     assert "5.00 [2/4]" in text  # best-epoch R_obs (%), 2 of 4
     assert "mean wR2   = 0.200000 [1/1]" in text
     assert "HKLs (Observed/total)" in text and "8 / 12" in text
+
+
+def test_summary_renders_dataset_labeled_seed_thicknesses(tmp_path: Path) -> None:
+    experiment = _experiment()
+    text = _run(
+        tmp_path,
+        experiment=ExperimentDeclared(
+            name=experiment.name,
+            structure=experiment.structure,
+            experimental_data="dataset_1.cif_pets, dataset_2.cif_pets",
+            optimizer=experiment.optimizer,
+            seed_thicknesses_by_dataset=(
+                ("dataset_1.cif_pets", (400.0,)),
+                ("dataset_2.cif_pets", (800.0,)),
+            ),
+            integration_semiangles=(1.0, 2.0),
+            rocking_curve_sampling=experiment.rocking_curve_sampling,
+            dsg=experiment.dsg,
+            rsg=experiment.rsg,
+            solve_g_max=experiment.solve_g_max,
+            sg_max=experiment.sg_max,
+            absorption=experiment.absorption,
+            steps=experiment.steps,
+            learning_rate=experiment.learning_rate,
+        ),
+    )
+
+    assert "dataset_1.cif_pets: 400" in text
+    assert "dataset_2.cif_pets: 800" in text
 
 
 def test_summary_selects_the_best_epoch_not_the_last(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add `sample.mean_thickness_by_dataset` for separate initial mean thicknesses in multi-dataset experiments
- validate exact dataset-key coverage and scope preprocess checkpoint identity to each dataset's effective seed
- seed each dataset's candidate plans from its configured value
- document the YAML shape and cover configuration, manifests, and runtime setup

## Verification

- `uv run ruff check src/diffBloch tests`
- `uv run mypy src/diffBloch`
- `uv run pytest -q` (686 passed, 2 skipped, 1 deselected)
- `uv run sphinx-build -W -b html docs /tmp/diffbloch-mean-thickness-docs`