### PR TITLE
Restore GitHub sidebar link

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,30 @@
+/* Splits the sidebar brand title and a GitHub icon link onto one row, below the logo.
+   Pairs with the sidebar/brand.html template override. */
+.sidebar-brand-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0 var(--sidebar-item-spacing-horizontal) var(--sidebar-item-spacing-vertical);
+}
+
+.sidebar-brand-title-link {
+  color: var(--color-sidebar-brand-text);
+  text-decoration: none;
+}
+
+.sidebar-brand-title-link .sidebar-brand-text {
+  font-size: 1.5rem;
+  overflow-wrap: break-word;
+}
+
+.sidebar-brand-github-link {
+  display: inline-flex;
+  color: var(--color-sidebar-link-text);
+  opacity: 0.75;
+  transition: opacity 0.1s ease-in-out;
+}
+
+.sidebar-brand-github-link:hover {
+  opacity: 1;
+}

--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -1,0 +1,33 @@
+{#-
+Overrides furo's default sidebar/brand.html to place a GitHub icon link next to the project
+title, below the logo. The upstream template wraps logo+title in a single <a> to the home page;
+that can't also contain a second link to GitHub (nested <a> tags are invalid), so the title row
+is split out into its own flex row with two sibling links instead.
+-#}
+{%- if logo_url %}
+<a class="sidebar-brand centered" href="{{ pathto(master_doc) }}">
+  <div class="sidebar-logo-container">
+    <img class="sidebar-logo" src="{{ logo_url }}" alt="Logo"/>
+  </div>
+</a>
+{%- endif %}
+{%- if theme_light_logo and theme_dark_logo %}
+<a class="sidebar-brand centered" href="{{ pathto(master_doc) }}">
+  <div class="sidebar-logo-container">
+    <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="Light Logo"/>
+    <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="Dark Logo"/>
+  </div>
+</a>
+{%- endif %}
+{% if not theme_sidebar_hide_name %}
+<div class="sidebar-brand-row">
+  <a class="sidebar-brand-title-link" href="{{ pathto(master_doc) }}">
+    <span class="sidebar-brand-text">{{ docstitle if docstitle else project }}</span>
+  </a>
+  <a class="sidebar-brand-github-link" href="https://github.com/Differentiable-Electron-Crystallography/diffBloch" target="_blank" rel="noopener noreferrer" aria-label="View diffBloch on GitHub">
+    <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
+    </svg>
+  </a>
+</div>
+{%- endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,5 +122,10 @@ html_theme = "furo"
 html_title = "diffBloch"
 html_baseurl = "https://differentiable-electron-crystallography.github.io/diffBloch/"
 html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 html_logo = "_static/logo.png"
 ogp_site_url = html_baseurl
+
+# templates/sidebar/brand.html overrides furo's default to add a GitHub icon link next to the
+# sidebar title.
+templates_path = ["_templates"]


### PR DESCRIPTION
Restores the GitHub icon link beside the documentation sidebar title, including its template and CSS configuration.