### PR TITLE
Default refinement optimizer to Adam

### DIFF
--- a/docs/hyperparameter-selection.md
+++ b/docs/hyperparameter-selection.md
@@ -175,7 +175,7 @@ Top-level, not nested under `refinement`, because it governs preprocessing too.
 | Field | Default | What it does |
 |---|---|---|
 | `steps` | `40` | Number of gradient-refinement epochs. |
-| `optimizer.name` | `"lbfgs"` | `"lbfgs"`, `"adam"`, or `"adamw"`. |
+| `optimizer.name` | `"adam"` | `"adam"`, `"adamw"`, or `"lbfgs"`. |
 | `optimizer.lr` | `1e-3` | Learning rate (Adam/AdamW; L-BFGS uses its own internal line search). |
 
 ### `refinement.trainable`

--- a/src/diffBloch/config/schema.py
+++ b/src/diffBloch/config/schema.py
@@ -237,7 +237,7 @@ class LossMetricsConfig(_StrictConfig):
 class OptimizerConfig(_StrictConfig):
     """Explicit optimizer backend for a refinement stage (matches ``OptimizerName``)."""
 
-    name: Literal["lbfgs", "adam", "adamw"] = "lbfgs"
+    name: Literal["lbfgs", "adam", "adamw"] = "adam"
     lr: float = 1e-3
 
 

--- a/src/diffBloch/engine/forward.py
+++ b/src/diffBloch/engine/forward.py
@@ -936,7 +936,7 @@ def run_refinement_model(
     *,
     trainable: TrainableSpec,
     steps: int,
-    optimizer: OptimizerName = "lbfgs",
+    optimizer: OptimizerName = "adam",
     lr: float = 1e-3,
     logger: Logger = NULL_LOGGER,
     verbose: bool = False,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -45,7 +45,7 @@ def test_minimal_config_validates_with_defaults() -> None:
     assert cfg.refinement.trainable.positions == "all"
     assert cfg.refinement.trainable.adp == "all"
     assert cfg.refinement.trainable.occupancy == "none"
-    assert cfg.refinement.optimizer.name == "lbfgs"
+    assert cfg.refinement.optimizer.name == "adam"
     assert cfg.loss_metrics.residual == "wr2"
     assert cfg.refinement.thickness_nn.to_spec() == ApparentThicknessNetwork()
     assert cfg.refinement.split.train_test is False


### PR DESCRIPTION
## Summary

This PR changes the default refinement optimizer from L-BFGS to Adam. It keeps L-BFGS available as an explicit `refinement.optimizer.name: lbfgs` choice, but makes omitted optimizer config follow the private baseline.

## What changed

Config:
- `OptimizerConfig.name` now defaults to `"adam"`.
- This changes the default app/CLI refinement path because `ExperimentConfig.refinement.optimizer` is constructed from that config value.

Engine API:
- `run_refinement_model(..., optimizer=...)` now defaults to `"adam"` so typed-Python callers see the same default as config-backed runs.
- The optimizer implementation itself is unchanged; this only changes the value selected when callers omit the argument.

Docs and tests:
- `docs/hyperparameter-selection.md` now documents Adam as the default optimizer.
- `test_minimal_config_validates_with_defaults` now locks the new default.

## Architecture & data flow

```mermaid
flowchart TD
    YAML[experiment.yaml omits refinement.optimizer.name]
    Config[OptimizerConfig.name default]
    App[app/program.py builds refinement run]
    Engine[run_refinement_model optimizer default]
    Builder[engine/refine optimizer builder]
    Adam[torch Adam optimizer]
    Explicit[explicit lbfgs/adamw still overrides]

    YAML --> Config
    Config --> App
    App --> Builder
    Engine --> Builder
    Explicit --> App
    Builder --> Adam
```

## Design decisions & tradeoffs

**Decision:** Make Adam the config default and the direct API default.

**Alternatives considered:** Change only `OptimizerConfig`, leaving `run_refinement_model` at L-BFGS.

**Tradeoff:** Updating both defaults is a broader behavioral change, but avoids two public paths disagreeing about what "default optimizer" means.

**Rationale:** The default should be one value across config-backed and typed-Python usage. The private baseline already uses Adam by default while retaining L-BFGS as an explicit option.

## Honest assessment

**What:** This is a global default change, not a local bug fix.

**Where:** `src/diffBloch/config/schema.py` and `src/diffBloch/engine/forward.py`.

**Why it's wrong/risky:** Any experiment that omitted `refinement.optimizer.name` will now run a different optimizer and can produce a different refinement trajectory.

**What right looks like:** Merge only if the project wants Adam as the new scientific default. Existing experiments that require L-BFGS should pin `refinement.optimizer.name: lbfgs`.

**Severity:** fix before merge only if the default policy is not settled.

## File-by-file changes

| File | Change |
|---|---|
| `src/diffBloch/config/schema.py` | Defaults `OptimizerConfig.name` to `"adam"`. |
| `src/diffBloch/engine/forward.py` | Defaults direct `run_refinement_model` calls to `"adam"`. |
| `docs/hyperparameter-selection.md` | Documents Adam as the default optimizer and keeps L-BFGS as an explicit option. |
| `tests/unit/test_config.py` | Updates the default-config assertion. |

## Testing

- `uv run pytest tests/unit/test_config.py -q`
- `uv run ruff format --check .`
- `uv run ruff check src/diffBloch tests`
- `uv run mypy src/diffBloch`
- `uv run pytest -q` (`698 passed, 3 skipped, 1 deselected`)

## Migration & compatibility

This is a behavior change for configs or API calls that omit the optimizer. To preserve previous behavior, set:

```yaml
refinement:
  optimizer:
    name: lbfgs
```
