### PR TITLE
Clear the open security advisories; make matplotlib a real dependency; watch deps with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# Dependabot version updates. Security updates are a separate repo setting ("Dependabot security
+# updates") and do not need an entry here -- they fire on any advisory regardless of the schedule
+# below. This file exists so routine bumps land continuously instead of accumulating into another
+# 20-alert backlog, and so the lockfile never drifts far enough that a security bump has to carry a
+# major upgrade with it.
+#
+# Grouping is deliberate: one PR per ecosystem for minor/patch versions keeps CI cost proportionate
+# (this repo runs unit tests, mypy, a strict docs build, and ~5-minute physics anchors on every PR),
+# while majors still arrive alone -- a torch or numpy major is a review, not a rubber stamp.
+version: 2
+
+updates:
+  - package-ecosystem: "uv" # reads pyproject.toml + uv.lock, including dependency-groups and extras
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: "github-actions" # the pinned action versions in .github/workflows/
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pydantic>=2.7",
     "pyyaml>=6.0",
     "scipy>=1.11",  # preprocess.steps.optimize_orientation: Nelder-Mead orientation search
-    "torch>=2.12.1",
+    "torch>=2.13.0",  # >=2.13.0: GHSA-rrmf-rvhw-rf47 (torch.jit.script memory corruption)
     # Scientific deps are added as their modules land:
     #   abtem -> core/scattering (electron form factors), wrapped behind a seam
 ]
@@ -24,6 +24,14 @@ dependencies = [
 wandb = ["wandb>=0.16"]
 comet = ["comet_ml>=3.0"]
 plot = ["matplotlib>=3.7"]
+
+[tool.uv]
+# Security floors for packages we do not depend on directly: wandb pulls gitpython, torch and
+# comet-ml pull setuptools. Pinned here so a future re-lock cannot drift back below the fix.
+constraint-dependencies = [
+    "gitpython>=3.1.58",  # 18 advisories through 3.1.57 (git option-injection / config-injection RCE)
+    "setuptools>=83.0.0",  # GHSA-h35f-9h28-mq5c (sdist MANIFEST.in exclusion bypass)
+]
 
 [project.scripts]
 diffbloch = "diffBloch.app.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,11 @@ license-files = ["LICENSE"]
 dependencies = [
     "diffpy.structure>=3.2",  # io/symmetry_setup: ADP (Uij) special-position constraints + oracle
     "gemmi>=0.7.5",
+    # Report plots are on by default (SummaryLogger.plot), so the renderer is not optional in
+    # practice: as an extra it left the default output silently degraded and its code untested in
+    # CI (`uv sync --dev` installs no extras). The wandb/comet SDKs below stay opt-in -- those are
+    # external services, not part of any default run.
+    "matplotlib>=3.7",
     "numpy>=2.5",
     "pydantic>=2.7",
     "pyyaml>=6.0",
@@ -23,7 +28,6 @@ dependencies = [
 # install the extra to use that backend. The core never imports these.
 wandb = ["wandb>=0.16"]
 comet = ["comet_ml>=3.0"]
-plot = ["matplotlib>=3.7"]
 
 [tool.uv]
 # Security floors for packages we do not depend on directly: wandb pulls gitpython, torch and

--- a/src/diffBloch/app/cli.py
+++ b/src/diffBloch/app/cli.py
@@ -103,8 +103,8 @@ def _add_stage_flags(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--plot-thickness",
         action="store_true",
-        help="save one wR2-vs-thickness PNG per rotation from the thickness grid search (requires "
-        "the 'diffBloch[plot]' extra); ORs with preprocess.thickness.plot in experiment.yaml, so "
+        help="save one wR2-vs-thickness PNG per rotation from the thickness grid search; ORs with "
+        "preprocess.thickness.plot in experiment.yaml, so "
         "either turns it on. Defaults to '<inputs.structure's directory>/thickness_optim', "
         "override with --plot-thickness-dir",
     )

--- a/src/diffBloch/app/loggers/plotting.py
+++ b/src/diffBloch/app/loggers/plotting.py
@@ -1,8 +1,9 @@
-"""Matplotlib plotting backend (the ``diffBloch[plot]`` extra).
+"""Matplotlib plotting backend.
 
-Confines the matplotlib dependency to this module, imported lazily on first use, mirroring
-``app.loggers.wandb``/``app.loggers.comet`` -- importing ``diffBloch.app.loggers`` never requires
-matplotlib to be installed.
+matplotlib is a core dependency (report plots are on by default), but it stays confined to this
+module and imported lazily on first use, as with ``app.loggers.wandb``/``app.loggers.comet``:
+importing ``diffBloch.app.loggers`` never pulls in a plotting stack, so a headless caller that
+attaches no plot sink pays nothing for it.
 """
 
 from __future__ import annotations

--- a/src/diffBloch/app/loggers/summary.py
+++ b/src/diffBloch/app/loggers/summary.py
@@ -384,10 +384,10 @@ class SummaryLogger:
                 lines.append("")
                 lines.append(f" plot: {plot_path.name}")
             except ModuleNotFoundError:
+                # matplotlib is a core dependency, so this only fires on a broken install -- the
+                # report still gets written rather than losing the run to a rendering import.
                 lines.append("")
-                lines.append(
-                    " plot: skipped (matplotlib not installed -- see the diffBloch[plot] extra)"
-                )
+                lines.append(" plot: skipped (matplotlib is not importable in this environment)")
 
     def _refined_structure(
         self, lines: list[str], rule: Callable[[str], None], structure_path: Path

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -1,22 +1,11 @@
-"""``ThicknessPlotLogger`` (the ``diffBloch[plot]`` matplotlib backend).
-
-Skipped whole-module when ``matplotlib`` isn't installed (the ``diffBloch[plot]`` extra is
-optional, exactly like the ``wandb``/``comet`` backends), rather than failing.
-"""
+"""``ThicknessPlotLogger`` and the report's thickness-NN shape plot (matplotlib backend)."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
-pytest.importorskip("matplotlib")
-
-from diffBloch.app.loggers.plotting import (  # noqa: E402
-    ThicknessPlotLogger,
-    plot_thickness_nn_shape,
-)
-from diffBloch.observability import OrientationOptimized, ThicknessOptimized  # noqa: E402
+from diffBloch.app.loggers.plotting import ThicknessPlotLogger, plot_thickness_nn_shape
+from diffBloch.observability import OrientationOptimized, ThicknessOptimized
 
 _EVENT = ThicknessOptimized(
     rotation_index=3,

--- a/tests/unit/test_summary_logger.py
+++ b/tests/unit/test_summary_logger.py
@@ -309,6 +309,29 @@ def test_summary_keeps_the_last_thickness_profile_reported_per_dataset(tmp_path:
     assert "430.25" not in text
 
 
+def test_summary_still_writes_when_the_plot_renderer_cannot_be_imported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """matplotlib is a core dependency, so this is broken-install insurance, not a supported mode.
+
+    The report is written on the run's terminal event, potentially hours in; a rendering import
+    that fails must cost the plot, not the whole report.
+    """
+
+    def unimportable(*args: object, **kwargs: object) -> None:
+        raise ModuleNotFoundError("No module named 'matplotlib'")
+
+    monkeypatch.setattr("diffBloch.app.loggers.plotting.plot_thickness_nn_shape", unimportable)
+
+    text = _run(tmp_path, rotations=(_rotation(0),), profiles=(_profile("q.cif_pets"),))
+
+    assert "plot: skipped (matplotlib is not importable in this environment)" in text
+    assert not (tmp_path / "thickness_nn_shape_q.png").exists()
+    # The section itself survives: the table is rendered from the event, not from the renderer.
+    assert "Thickness NN -- q.cif_pets" in text
+    assert "430.25" in text
+
+
 def test_thickness_profile_channel_names_its_dataset() -> None:
     assert _profile("sub/b.cif_pets").channel == "thickness_profile[sub/b.cif_pets]"
 

--- a/tests/unit/test_summary_logger.py
+++ b/tests/unit/test_summary_logger.py
@@ -271,7 +271,6 @@ def test_summary_reports_the_thickness_profile_when_one_was_trained(tmp_path: Pa
     assert "alpha (degrees)" in text
     assert "12.5000" in text and "430.25" in text
 
-    pytest.importorskip("matplotlib", reason="optional diffBloch[plot] extra")
     assert (tmp_path / "thickness_nn_shape_q.png").is_file()
     assert "plot: thickness_nn_shape_q.png" in text
 
@@ -290,7 +289,6 @@ def test_summary_reports_one_thickness_section_per_dataset(tmp_path: Path) -> No
     assert "Thickness NN -- sub/b.cif_pets" in text
     assert "430.25" in text and "210.00" in text
 
-    pytest.importorskip("matplotlib", reason="optional diffBloch[plot] extra")
     # Filenames use the dataset checkpoint stem: path separators fold to "__", suffix drops.
     assert (tmp_path / "thickness_nn_shape_a.png").is_file()
     assert (tmp_path / "thickness_nn_shape_sub__b.png").is_file()

--- a/uv.lock
+++ b/uv.lock
@@ -732,6 +732,7 @@ source = { editable = "." }
 dependencies = [
     { name = "diffpy-structure" },
     { name = "gemmi" },
+    { name = "matplotlib" },
     { name = "numpy" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -742,9 +743,6 @@ dependencies = [
 [package.optional-dependencies]
 comet = [
     { name = "comet-ml" },
-]
-plot = [
-    { name = "matplotlib" },
 ]
 wandb = [
     { name = "wandb" },
@@ -775,7 +773,7 @@ requires-dist = [
     { name = "comet-ml", marker = "extra == 'comet'", specifier = ">=3.0" },
     { name = "diffpy-structure", specifier = ">=3.2" },
     { name = "gemmi", specifier = ">=0.7.5" },
-    { name = "matplotlib", marker = "extra == 'plot'", specifier = ">=3.7" },
+    { name = "matplotlib", specifier = ">=3.7" },
     { name = "numpy", specifier = ">=2.5" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -783,7 +781,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.13.0" },
     { name = "wandb", marker = "extra == 'wandb'", specifier = ">=0.16" },
 ]
-provides-extras = ["comet", "plot", "wandb"]
+provides-extras = ["comet", "wandb"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,12 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
+[manifest]
+constraints = [
+    { name = "gitpython", specifier = ">=3.1.58" },
+    { name = "setuptools", specifier = ">=83.0.0" },
+]
+
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"
@@ -602,7 +608,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "python_full_version < '3.15'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351 },
@@ -625,42 +631,51 @@ wheels = [
 
 [[package]]
 name = "cuda-toolkit"
-version = "13.0.2"
+version = "13.0.3.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364 },
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512 },
 ]
 
 [package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 
 [[package]]
@@ -765,7 +780,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "scipy", specifier = ">=1.11" },
-    { name = "torch", specifier = ">=2.12.1" },
+    { name = "torch", specifier = ">=2.13.0" },
     { name = "wandb", marker = "extra == 'wandb'", specifier = ">=0.16" },
 ]
 provides-extras = ["comet", "plot", "wandb"]
@@ -1042,14 +1057,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.59"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798 }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507 },
+    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996 },
 ]
 
 [[package]]
@@ -3106,11 +3121,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "81.0.0"
+version = "84.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299 }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021 },
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216 },
 ]
 
 [[package]]
@@ -3457,42 +3472,41 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
     { name = "setuptools" },
     { name = "sympy" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/54/efb7ebca77970012b0cc21687a55d70eb2ba514b2c2b8e18d9fb1222f3be/torch-2.12.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:d2dd0f2c5f7ccbddaf34cade0deaf476808368f902b9cdb7f36a2ab42301bc0e", size = 87991951 },
-    { url = "https://files.pythonhosted.org/packages/1e/00/4210d76ca7424981f04033ebe7e48816ab83287a62538747a58825db770c/torch-2.12.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2de4e19b88a481482c6c75291f2d6a52eda3ce51f311b29aa9b68499c830c07c", size = 426382721 },
-    { url = "https://files.pythonhosted.org/packages/76/1f/bc9f5a5aa569307076365f25afcebacb22e9c754b1bcfbaaa146627c7fda/torch-2.12.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:649e4ced014ba646f76f8cb9c9726735a6323eb321b7919f942790a923f90921", size = 532261322 },
-    { url = "https://files.pythonhosted.org/packages/9e/49/c549461daa008159d006a76a991fbc2f26fa8bac27a4030c858463dcb20f/torch-2.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:e86550597877fb272ddc52db2f85b82cb601ea7bd932576a0340152cae2200b3", size = 122988095 },
-    { url = "https://files.pythonhosted.org/packages/ff/4a/0300261818e1560d72cc160ac826005507e8b7ca0a35788b591436d05b4a/torch-2.12.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:c75e93173c700bccd6bfcc4a9d19ce242ab6dacd1f1781483027a16239b9e650", size = 87992358 },
-    { url = "https://files.pythonhosted.org/packages/30/a7/874a5ca05e8f159211dca7921060f7057acc1adb26431e119fd150623efc/torch-2.12.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:fcb61ccd20784b62bdd78ec84238a5cfb383b4994902e03bac95505ab360884c", size = 426386134 },
-    { url = "https://files.pythonhosted.org/packages/e1/75/20bb8fe9c1ad6538cce8cd0391b51927ae5af0b17ed1eab44b8824465dc1/torch-2.12.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:f4afc8083dff08719edbea346644476e3cec0cf40ebe256be0ee5d5b7c7e8c0d", size = 532268019 },
-    { url = "https://files.pythonhosted.org/packages/d1/fa/824ddb662af55b2eabc0dbb7b57c7c0b1bcd93693754a2b8509ec4d16490/torch-2.12.1-cp313-cp313-win_amd64.whl", hash = "sha256:f92609e3b3ce72f25e2eb780d043ced2480c1a86c47c852604fc7a9108648386", size = 122987777 },
-    { url = "https://files.pythonhosted.org/packages/63/b7/1b49fe7086ea36839cc80abc43174c43d0ab6f676c0891c871c162f44fe3/torch-2.12.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e9b6f7d2dd66ea87a3ae620069d31335d594c06effb1a383bdd21cfe61e44ece", size = 88010025 },
-    { url = "https://files.pythonhosted.org/packages/d7/06/5b44063a6545036dcc680d2d303b137d9176cfb2cc1e1863e3ef94abeb52/torch-2.12.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:7973ccd3d2cd35c74449213f7bded199bec6c6247e705cbeda7407af79703d91", size = 426392891 },
-    { url = "https://files.pythonhosted.org/packages/f8/dd/c9ce9a4b0eb3c5bb92d9ea56766e2c22559f0b45171149188494edcce80f/torch-2.12.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c64ac4aac16be5e296dcd912305605804b203333c690bf98c55bc09494ee92ad", size = 532272494 },
-    { url = "https://files.pythonhosted.org/packages/21/7c/f3a601fc1b1f663ff269bfe553654e638651939aa6563e8daa7167c33098/torch-2.12.1-cp314-cp314-win_amd64.whl", hash = "sha256:f6dc4caf7eb4adb38a2d9f536b51db56310fdd1254e69a2d96767e1367c892b3", size = 122987254 },
-    { url = "https://files.pythonhosted.org/packages/e6/8c/b8087556cf81ddd808dbeb34afb8396d7ae7a1694ab489f08b1a0004e7d0/torch-2.12.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:2afbb2bdaa8a95040e733f05492ddf133c3967c9b7ce0abd218d704b6cab437d", size = 88303173 },
-    { url = "https://files.pythonhosted.org/packages/4a/07/fe09d1699fbed2afa10ebc692ff2b99d113f2605b6748cea633989e2789a/torch-2.12.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:97eba061fcb042fed191400b15568990073d67eaacaa6ee9b7ca01dd8b790fe9", size = 426404009 },
-    { url = "https://files.pythonhosted.org/packages/2e/f7/0ce4f6c1962c60ded7270e0a9eb560fb615c92b89d332cf9e3dff36d5ecc/torch-2.12.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3867b861391701012adb2df93360efb88494dca245a185e3bb7624495cfe3f33", size = 532184292 },
-    { url = "https://files.pythonhosted.org/packages/70/db/e384c12aba30320ca92aaaf557456cbcb26f04b4df307728bb8f019f5000/torch-2.12.1-cp314-cp314t-win_amd64.whl", hash = "sha256:dd15595f8fc764cffde8c6361a3beb6ef69a028c851b1b3e70e077f615980d4e", size = 123231142 },
+    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045 },
+    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998 },
+    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292 },
+    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313 },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743 },
+    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008 },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329 },
+    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920 },
+    { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066 },
+    { url = "https://files.pythonhosted.org/packages/e9/09/2c10e8cd0e00fa5d23c052df6ce467eaa7182399f5e0f824f1e4ff42ccae/torch-2.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a3893dc2da0a972a8ca5d698c85a9f967559ac5f8ee1797b77408aa8734d073c", size = 427226309 },
+    { url = "https://files.pythonhosted.org/packages/76/c6/22c2102bbef14ca6a6cb4c20e42f088e49c5f812be4e160ae57502e325f9/torch-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:49f1ea385c754e54919408a9bb3b5a72b0b755bbe2c916c1d6f70afbec4908a2", size = 526614507 },
+    { url = "https://files.pythonhosted.org/packages/2b/0c/7d1deb6bce5bc3e6042caf39100ac768eba3b9a098e1dddd16f75bd6489b/torch-2.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f8573e3ce9ebcd53fe922f01077a6085ccdfbe5f12fd215883a9d87d7a744fd", size = 122051871 },
+    { url = "https://files.pythonhosted.org/packages/f4/ce/aa8b7f9949d32e0f2f624f342bc3b48112c1b8a130288465938bc83bcbf9/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", size = 111537025 },
+    { url = "https://files.pythonhosted.org/packages/69/d1/491e3a0389430946145888b0203f2b6a759ce2a61481b96a85c2da4f2ced/torch-2.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:31061ff56ed8fbf26c749806905aeb749ebeb819810fd5d52508aa5afd90dddc", size = 427219769 },
+    { url = "https://files.pythonhosted.org/packages/9a/1d/38006e045bf0a1fc28ef01e757c554e59e59a8770c284bc4f47b14e60441/torch-2.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cc26eead4cf51d0b544e31e364dcf000846549c273bd148936fe9d24d29acb92", size = 526571320 },
+    { url = "https://files.pythonhosted.org/packages/56/94/655c91992a882bd5071aa0b5d22a07dbb130d801e872be97c0b627a7c693/torch-2.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a7de8a313090dc5c7d7ba4bfe5c3be222528f9a4dba1acc83bddb1157360c4b8", size = 122306773 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Clears every open Dependabot alert (15 high, 4 moderate, 1 low) and makes matplotlib a real dependency instead of an optional extra the default code path already assumed.

The Dependabot alert API returns nothing for this token (org OAuth filtering), so the vulnerable set was enumerated with `uv audit` -- which found 21 advisories whose severity split (15 high / 4 moderate / 1 low, once the one duplicate PYSEC entry is folded in) matches the push-time warning exactly.

## Security bumps (`345b488`)

Every alert came from a stale lock, not from anything this project does -- no code changes were needed:

| Package | Was | Now | Reached via | Advisories |
|---|---|---|---|---|
| `torch` | 2.12.1 | 2.13.0 | direct dependency | 1 low -- GHSA-rrmf-rvhw-rf47 (`torch.jit.script` memory corruption) |
| `gitpython` | 3.1.50 | 3.1.59 | `wandb` extra | 18 -- git option-injection / git-config injection leading to arbitrary command execution |
| `setuptools` | 81.0.0 | 84.0.0 | `torch`, `comet-ml` | 1 moderate -- GHSA-h35f-9h28-mq5c (sdist `MANIFEST.in` exclusion bypass) |

`torch`'s floor moves in `pyproject.toml`; the two transitive packages get `[tool.uv] constraint-dependencies` floors so a future re-lock cannot drift back below the fix. The lockfile format is unchanged (`revision = 1`) -- locking was done with the repo's own uv, not a newer one, so existing local toolchains keep reading `uv.lock`.

## matplotlib as a dependency (`860134d`)

The report writes thickness-NN shape PNGs by default (`SummaryLogger.plot` defaults `True`) and `--plot-thickness` is a first-class CLI flag, yet the renderer sat behind an optional `plot` extra. That had two costs:

- a plain install silently degraded its default output to a `plot: skipped` line;
- CI runs `uv sync --dev`, which installs **no extras**, so `tests/unit/test_plotting.py` skipped whole-module -- the plotting code shipped untested.

matplotlib becomes a core dependency and the `plot` extra goes away. It stays lazily imported inside `app.loggers.plotting`, so importing the logger package still pulls in no plotting stack; only the guarantee that the import succeeds is new. The `importorskip` guards go with the extra, so the PNG assertions now run everywhere. `wandb`/`comet` remain extras -- those are external services, not part of any default run.

## Keeping it fixed (`38864a5`)

Nothing was re-bumping these dependencies, which is how the backlog accumulated quietly enough that only a push warning surfaced it. Two changes:

- **Repo setting**: "Dependabot security updates" is now **enabled** (alerts were already on). Advisory-driven bumps will open their own PRs from here on.
- **`.github/dependabot.yml`**: weekly version updates for the two ecosystems this repo actually has -- `uv` (pyproject.toml + uv.lock, covering dependency groups and extras) and `github-actions` (the pinned action versions in the workflows). Minor/patch bumps are grouped into one PR per ecosystem so CI cost stays proportionate (every PR runs unit tests, mypy, a strict docs build, and the physics anchors); majors still arrive alone, since a torch or numpy major deserves a real review.

Note that Dependabot reads its config from the default branch, so the schedule only starts once this merges.

## Test plan

- [x] `uv audit` -- was 21 advisories across 3 packages, now **no known vulnerabilities** in 207 packages
- [x] `pytest tests/unit` -- 710 passed, 3 skipped (only the CUDA-gated ones; the two matplotlib skips are gone)
- [x] `pytest -m e2e` -- quartz physics anchor unchanged under the torch minor bump
- [x] `ruff check .` / `ruff format --check .` / `mypy src/diffBloch` -- clean
- [x] `sphinx-build -W` and `uv build` -- both succeed

## Note, not addressed here

`uv audit` also reports one adverse project status: `everett` (a `comet-ml` transitive dep) is archived upstream. Not a vulnerability and not actionable from this repo, so it is left alone.
