### PR TITLE
Configure solvers independently by phase

### DIFF
--- a/docs/bloch_wave_simulation.md
+++ b/docs/bloch_wave_simulation.md
@@ -128,7 +128,8 @@ With boundary conditions {math}`\psi(0)` fixed at the entrance surface, the wave
 ```
 
 There are two mathematically equivalent ways to evaluate this, and diffBloch implements both as
-`blochwave.solver` choices (see [Hyperparameter selection](hyperparameter-selection.md)):
+`blochwave.solver.{preprocess,inference,refinement}` choices (see
+[Hyperparameter selection](hyperparameter-selection.md)):
 
 - **`bloch_eigen`** diagonalises {math}`A = C\,\mathrm{diag}(\gamma)\,C^{-1}` once and reads off
   {math}`\psi_{\mathbf{g}}(t) = \sum_i C_0^{(i)-1}C_{\mathbf{g}}^{(i)}\exp(2\pi i\gamma^{(i)}t)` —

--- a/docs/devices-and-scaling.md
+++ b/docs/devices-and-scaling.md
@@ -9,7 +9,7 @@ uv run diffbloch refine <experiment_dir> --device cpu
 ```
 
 Both devices perform the same calculation to the same accuracy; only speed differs. The fastest
-`coupling_mode` and `solver` are not the same on CPU as on GPU. The config defaults
+`coupling_mode` and the phase-specific `solver` choices are not the same on CPU as on GPU. The config defaults
 (`coupling_mode: union`) are tuned for GPU and are not optimal for CPU.
 
 ## CPU

--- a/docs/hyperparameter-selection.md
+++ b/docs/hyperparameter-selection.md
@@ -47,7 +47,9 @@ Bloch wave simulation hyperparameters (`BlochwaveConfig`).
 
 | Field | Default | What it does |
 |---|---|---|
-| `solver` | `"matrix_exp"` | Solver used for preprocessing, inference, and refinement. Use `matrix_exp` when absorption is enabled -- the alternative, `bloch_eigen`, isn't safe for the non-Hermitian absorptive structure matrix. |
+| `solver.preprocess` | `"matrix_exp"` | Solver used for orientation and thickness searches. |
+| `solver.inference` | `"matrix_exp"` | Solver used for settled-plan inference and scoring. |
+| `solver.refinement` | `"matrix_exp"` | Solver used for gradient refinement. Use `matrix_exp` when gradients or absorption are required. |
 | `absorption` | `false` | Include absorption as an imaginary structure-factor contribution. |
 | `rsg` | `0.66` | Relative excitation-error cutoff. See [`rsg` and `dsg`](#rsg-and-dsg). |
 | `dsg` | `0.0015` | Absolute excitation-error margin. See [`rsg` and `dsg`](#rsg-and-dsg). |

--- a/examples/Colmey_et_al_2026/data/borane-absorption/experiment.yaml
+++ b/examples/Colmey_et_al_2026/data/borane-absorption/experiment.yaml
@@ -9,7 +9,10 @@ sample:
   thicknesses: [1950.0]
 
 blochwave:
-  solver: matrix_exp
+  solver:
+    preprocess: matrix_exp
+    inference: matrix_exp
+    refinement: matrix_exp
   absorption: true
   coupling_mode: union
   g_max: 1.9

--- a/examples/Colmey_et_al_2026/data/borane-no-abs/experiment.yaml
+++ b/examples/Colmey_et_al_2026/data/borane-no-abs/experiment.yaml
@@ -9,7 +9,10 @@ sample:
   thicknesses: [1900.0]
 
 blochwave:
-  solver: matrix_exp
+  solver:
+    preprocess: matrix_exp
+    inference: matrix_exp
+    refinement: matrix_exp
   absorption: false
   coupling_mode: union
   g_max: 1.9

--- a/examples/Colmey_et_al_2026/data/cspbbr3-absorption/experiment.yaml
+++ b/examples/Colmey_et_al_2026/data/cspbbr3-absorption/experiment.yaml
@@ -9,7 +9,10 @@ sample:
   thicknesses: [460.0]
 
 blochwave:
-  solver: matrix_exp
+  solver:
+    preprocess: matrix_exp
+    inference: matrix_exp
+    refinement: matrix_exp
   absorption: true
   coupling_mode: union
   g_max: 2.3

--- a/examples/Colmey_et_al_2026/data/cspbbr3-no-abs/experiment.yaml
+++ b/examples/Colmey_et_al_2026/data/cspbbr3-no-abs/experiment.yaml
@@ -9,7 +9,10 @@ sample:
   thicknesses: [440.0]
 
 blochwave:
-  solver: matrix_exp
+  solver:
+    preprocess: matrix_exp
+    inference: matrix_exp
+    refinement: matrix_exp
   absorption: false
   coupling_mode: union
   g_max: 2.3

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -271,7 +271,7 @@ def converge_experiment(
             simulation,
             refinement,
             ConvergenceTolerance(),
-            method=cfg.blochwave.solver,
+            method=cfg.blochwave.solver.preprocess,
             logger=logger,
         )
         settled_states.append(settled)
@@ -409,7 +409,7 @@ def run_experiment(
     return run_inference(
         prepared,
         refinement,
-        method=cfg.blochwave.solver,
+        method=cfg.blochwave.solver.inference,
         device=device,
         max_batch=max_batch,
         logger=logger,
@@ -495,7 +495,7 @@ def refine_experiment(
         prepared,
         refinement,
         loss=cfg.loss_metrics.to_loss(),
-        method=cfg.blochwave.solver,
+        method=cfg.blochwave.solver.refinement,
         max_batch=max_batch,
         absorption=cfg.blochwave.to_absorption(),
         profile=profile,
@@ -522,7 +522,7 @@ def refine_experiment(
             replace(prepared, orientations=train_only),
             refinement,
             loss=cfg.loss_metrics.to_loss(),
-            method=cfg.blochwave.solver,
+            method=cfg.blochwave.solver.refinement,
             max_batch=max_batch,
             absorption=cfg.blochwave.to_absorption(),
             profile=profile,
@@ -532,7 +532,7 @@ def refine_experiment(
             replace(prepared, orientations=validation_only),
             refinement,
             loss=cfg.loss_metrics.to_loss(),
-            method=cfg.blochwave.solver,
+            method=cfg.blochwave.solver.refinement,
             max_batch=max_batch,
             absorption=cfg.blochwave.to_absorption(),
             profile=profile,
@@ -1016,7 +1016,7 @@ def _recipe_steps(
         return optimize_orientation(
             refinement,
             search,
-            method=cfg.blochwave.solver,
+            method=cfg.blochwave.solver.preprocess,
             coupling=coupling,
             validate=validate,
             device=device,
@@ -1032,7 +1032,7 @@ def _recipe_steps(
         return optimize_thickness(
             refinement,
             thickness_grid,
-            method=cfg.blochwave.solver,
+            method=cfg.blochwave.solver.preprocess,
             device=device,
             max_batch=max_batch,
             logger=logger,  # per-rotation thickness-fit progress (the memory-heavy tail phase)

--- a/src/diffBloch/config/__init__.py
+++ b/src/diffBloch/config/__init__.py
@@ -27,6 +27,7 @@ from diffBloch.config.schema import (
     LossMetricsConfig,
     OptimizerConfig,
     SampleConfig,
+    SolverConfig,
     load_config,
 )
 
@@ -43,6 +44,7 @@ __all__ = [
     "RecipeStep",
     "RefinementLock",
     "SampleConfig",
+    "SolverConfig",
     "artifact_hash_for",
     "code_version",
     "dataset_config_digest",

--- a/src/diffBloch/config/manifest.py
+++ b/src/diffBloch/config/manifest.py
@@ -193,6 +193,7 @@ def dataset_config_digest(config: ExperimentConfig, *, exp_data: str) -> str:
     """
     dump = config.model_dump(mode="json")
     blochwave = {k: v for k, v in dump["blochwave"].items() if k != "ignore_orientations"}
+    blochwave["solver"] = {"preprocess": dump["blochwave"]["solver"]["preprocess"]}
     preprocess = dict(dump["preprocess"])
     if not preprocess["optimize_orientation"]:
         preprocess.pop("orientation", None)
@@ -232,7 +233,11 @@ def refinement_config_digest(config: ExperimentConfig) -> str:
     solely to :func:`dataset_config_digest`.
     """
     dump = config.model_dump(mode="json")
-    canonical = json.dumps(dump["refinement"], sort_keys=True, separators=(",", ":"))
+    identity = {
+        "refinement": dump["refinement"],
+        "solver": dump["blochwave"]["solver"]["refinement"],
+    }
+    canonical = json.dumps(identity, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode()).hexdigest()
 
 

--- a/src/diffBloch/config/schema.py
+++ b/src/diffBloch/config/schema.py
@@ -64,6 +64,14 @@ class _StrictConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class SolverConfig(_StrictConfig):
+    """Dynamical solver selected independently for each application phase."""
+
+    preprocess: SolverMethod = "matrix_exp"
+    inference: SolverMethod = "matrix_exp"
+    refinement: SolverMethod = "matrix_exp"
+
+
 class BlochwaveConfig(_StrictConfig):
     """The beam-selection, coupling, and dynamical-solver settings for the Bloch-wave simulation.
 
@@ -80,10 +88,7 @@ class BlochwaveConfig(_StrictConfig):
     disables it.
     """
 
-    # One solver for every phase (preprocessing search, refinement, and inference/scoring) --
-    # typed as the solver's own SolverMethod literal (the single source of truth), so an unknown
-    # method fails fast at config load rather than deep in the forward model.
-    solver: SolverMethod = "matrix_exp"
+    solver: SolverConfig = Field(default_factory=SolverConfig)
     absorption: bool = False
     rsg: float = _BEAM_SELECTION_DEFAULTS.rsg
     dsg: float = _BEAM_SELECTION_DEFAULTS.dsg
@@ -138,7 +143,11 @@ class BlochwaveConfig(_StrictConfig):
         self.to_policy()
         self.to_orientation_selection()
         self.to_absorption()
-        if self.absorption and self.solver == "bloch_eigen":
+        if self.absorption and "bloch_eigen" in (
+            self.solver.preprocess,
+            self.solver.inference,
+            self.solver.refinement,
+        ):
             raise ValueError("absorption requires the non-Hermitian-safe 'matrix_exp' solver")
         return self
 

--- a/src/diffBloch/preprocess/steps/optimize_thickness.py
+++ b/src/diffBloch/preprocess/steps/optimize_thickness.py
@@ -129,7 +129,7 @@ def optimize_thickness(
             fitted.append(orientation)
         return replace(plan, orientations=tuple(fitted))
 
-    # method rides in the config digest (cfg.blochwave.solver); the grid is the step's own param.
+    # method rides in the config digest (cfg.blochwave.solver.preprocess); the grid is the step's own param.
     return as_step("optimize_thickness", {"grid": grid, "absorption": absorption}, run)
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -40,7 +40,9 @@ def test_minimal_config_validates_with_defaults() -> None:
     )
     assert cfg.name == "quartz"
     # defaults-as-code: the experiment file only needs inputs + overrides
-    assert cfg.blochwave.solver == "matrix_exp"
+    assert cfg.blochwave.solver.preprocess == "matrix_exp"
+    assert cfg.blochwave.solver.inference == "matrix_exp"
+    assert cfg.blochwave.solver.refinement == "matrix_exp"
     assert cfg.sample.thicknesses == (820.0,)
     assert cfg.refinement.trainable.positions == "all"
     assert cfg.refinement.trainable.adp == "all"
@@ -63,18 +65,26 @@ def test_solver_method_must_be_a_known_method() -> None:
     # config load rather than deep in the forward model.
     base = {"name": "bad", "inputs": {"structure": "q.cif", "exp_data": "q.cif_pets"}}
     with pytest.raises(ValidationError, match="Input should be"):
-        ExperimentConfig.model_validate({**base, "blochwave": {"solver": "nope"}})
+        ExperimentConfig.model_validate({**base, "blochwave": {"solver": {"preprocess": "nope"}}})
 
 
-def test_removed_nested_solver_config_is_rejected() -> None:
-    base = {"name": "bad", "inputs": {"structure": "q.cif", "exp_data": "q.cif_pets"}}
-    with pytest.raises(ValidationError, match="Input should be|Extra"):
-        ExperimentConfig.model_validate(
-            {
-                **base,
-                "blochwave": {"solver": {"refine": "matrix_exp", "inference": "matrix_exp"}},
-            }
-        )
+def test_solver_methods_are_independent_by_phase() -> None:
+    cfg = ExperimentConfig.model_validate(
+        {
+            "name": "split-solvers",
+            "inputs": {"structure": "q.cif", "exp_data": "q.cif_pets"},
+            "blochwave": {
+                "solver": {
+                    "preprocess": "bloch_eigen",
+                    "inference": "bloch_eigen",
+                    "refinement": "matrix_exp",
+                }
+            },
+        }
+    )
+    assert cfg.blochwave.solver.preprocess == "bloch_eigen"
+    assert cfg.blochwave.solver.inference == "bloch_eigen"
+    assert cfg.blochwave.solver.refinement == "matrix_exp"
 
 
 def test_absorption_config_is_typed_and_requires_matrix_exp() -> None:
@@ -87,7 +97,7 @@ def test_absorption_config_is_typed_and_requires_matrix_exp() -> None:
                 **base,
                 "blochwave": {
                     "absorption": True,
-                    "solver": "bloch_eigen",
+                    "solver": {"preprocess": "bloch_eigen"},
                 },
             }
         )

--- a/tests/unit/test_load_config.py
+++ b/tests/unit/test_load_config.py
@@ -18,7 +18,7 @@ def test_load_config_reads_yaml_and_applies_defaults() -> None:
     assert cfg.inputs.structure == "enantiomer_1.cif"
     assert cfg.inputs.exp_data == "exp_data.cif_pets"
     # defaults-as-code applied for everything the file omits
-    assert cfg.blochwave.solver == "matrix_exp"
+    assert cfg.blochwave.solver.refinement == "matrix_exp"
     assert cfg.blochwave.mosaicity is False
 
 

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -173,9 +173,15 @@ def test_dataset_config_digest_scopes_to_plan_determining_config() -> None:
     cfg = load_config(LOCKED / "experiment.yaml")
     base = dataset_config_digest(cfg, exp_data=EXP_REF)
 
-    def with_solver(method: str) -> object:
+    def with_preprocess_solver(method: str) -> object:
         return cfg.model_copy(
-            update={"blochwave": cfg.blochwave.model_copy(update={"solver": method})}
+            update={
+                "blochwave": cfg.blochwave.model_copy(
+                    update={
+                        "solver": cfg.blochwave.solver.model_copy(update={"preprocess": method})
+                    }
+                )
+            }
         )
 
     def with_refinement(**update: object) -> object:
@@ -204,7 +210,10 @@ def test_dataset_config_digest_scopes_to_plan_determining_config() -> None:
     )
     # included -- determine the settled Plan, so a change must restale
     assert (
-        dataset_config_digest(with_solver(_other_method(cfg.blochwave.solver)), exp_data=EXP_REF)
+        dataset_config_digest(
+            with_preprocess_solver(_other_method(cfg.blochwave.solver.preprocess)),
+            exp_data=EXP_REF,
+        )
         != base
     )
     # included -- objective drives optimize_orientation/optimize_thickness's search
@@ -376,6 +385,19 @@ def test_refinement_config_digest_is_the_complement_of_the_dataset_digest() -> N
         }
     )
     assert refinement_config_digest(bumped_split) != base
+
+    bumped_refinement_solver = cfg.model_copy(
+        update={
+            "blochwave": cfg.blochwave.model_copy(
+                update={
+                    "solver": cfg.blochwave.solver.model_copy(
+                        update={"refinement": _other_method(cfg.blochwave.solver.refinement)}
+                    )
+                }
+            )
+        }
+    )
+    assert refinement_config_digest(bumped_refinement_solver) != base
 
     # excluded -- objective is top-level (drives the preprocess search) and covered by
     # dataset_config_digest

--- a/tests/unit/test_refinement_model.py
+++ b/tests/unit/test_refinement_model.py
@@ -105,7 +105,7 @@ def test_quartz_refinement_model_path_matches_legacy_objective() -> None:
         plan,
         setup.refinement,
         loss=cfg.loss_metrics.to_loss(),
-        method=cfg.blochwave.solver,
+        method=cfg.blochwave.solver.refinement,
     )
     engine = dataclasses.replace(engine, orientations=engine.orientations[:1])
     params = setup.refinement.params


### PR DESCRIPTION
Adds separate solver selection for preprocessing, inference, and refinement while preserving matrix_exp as every default.

Example:

```yaml
blochwave:
  solver:
    preprocess: bloch_eigen
    inference: bloch_eigen
    refinement: matrix_exp
```

Absorption continues to reject bloch_eigen in every phase. Preprocess and refinement lock digests track only their relevant solver.

Validation:
- 714 tests passed
- ruff check and format passed
- mypy passed
- strict Sphinx build passed