### PR TITLE
Tolerate Jana2020/PETS2 CIF format quirks

### DIFF
--- a/src/diffBloch/app/loggers/__init__.py
+++ b/src/diffBloch/app/loggers/__init__.py
@@ -26,6 +26,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from diffBloch.io import ParseDiagnostic
 from diffBloch.observability import (
     NULL_LOGGER,
     ConvergencePassStarted,
@@ -197,6 +198,15 @@ class ConsoleLogger:
     def report(self, event: Event) -> None:
         if isinstance(event, DeviceSelected):
             _log.log(self.level, _format_device_selection(event))
+            return
+        if isinstance(event, ParseDiagnostic):
+            _log.log(
+                self.level,
+                "Input │ %s │ %s │ %s",
+                event.input_kind.replace("_", " "),
+                "" if event.source_path is None else str(event.source_path),
+                event.message,
+            )
             return
         if isinstance(event, ExperimentDeclared):
             _log.log(

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -69,7 +69,13 @@ from diffBloch.engine import (
     build_refinement_problem,
     run_refinement_model,
 )
-from diffBloch.io import ExperimentalRecord, read_experimental_data, read_structure
+from diffBloch.io import (
+    ExperimentalRecord,
+    StructureRecord,
+    read_experimental_data_with_diagnostics,
+    read_structure,
+    read_structure_with_diagnostics,
+)
 from diffBloch.observability import (
     NULL_LOGGER,
     DeviceSelected,
@@ -142,7 +148,19 @@ def _exp_data_refs(cfg: ExperimentConfig) -> tuple[str, ...]:
     return (cfg.inputs.exp_data,)
 
 
-def _read_experimental_data(root: Path, cfg: ExperimentConfig) -> tuple[ExperimentalRecord, ...]:
+def _read_structure(
+    root: Path, cfg: ExperimentConfig, *, logger: Logger = NULL_LOGGER
+) -> StructureRecord:
+    path = root / cfg.inputs.structure
+    parsed = read_structure_with_diagnostics(path, load_hydrogens=cfg.inputs.load_hydrogens)
+    for diagnostic in parsed.diagnostics:
+        logger.report(diagnostic)
+    return parsed.record
+
+
+def _read_experimental_data(
+    root: Path, cfg: ExperimentConfig, *, logger: Logger = NULL_LOGGER
+) -> tuple[ExperimentalRecord, ...]:
     """Read every ``inputs.exp_data`` file, single or pooled alike -- always a tuple.
 
     Order matches ``inputs.exp_data``, which is also the order
@@ -150,7 +168,13 @@ def _read_experimental_data(root: Path, cfg: ExperimentConfig) -> tuple[Experime
     :func:`~diffBloch.preprocess.pool` pools rotation indices in -- callers that need a flat array
     aligned to the pooled ``rotation_index`` space can rely on that order without recomputing it.
     """
-    return tuple(read_experimental_data(root / ref) for ref in _exp_data_refs(cfg))
+    records: list[ExperimentalRecord] = []
+    for ref in _exp_data_refs(cfg):
+        parsed = read_experimental_data_with_diagnostics(root / ref)
+        for diagnostic in parsed.diagnostics:
+            logger.report(diagnostic)
+        records.append(parsed.record)
+    return tuple(records)
 
 
 def _reproducibility_dir(root: Path) -> Path:
@@ -227,10 +251,8 @@ def converge_experiment(
     device = _select_device(device, logger=logger)
     cfg, _lock = load_experiment(root)
 
-    structure = read_structure(
-        root / cfg.inputs.structure, load_hydrogens=cfg.inputs.load_hydrogens
-    )
-    records = _read_experimental_data(root, cfg)
+    structure = _read_structure(root, cfg, logger=logger)
+    records = _read_experimental_data(root, cfg, logger=logger)
     refinement_setup, datasets = setup_datasets(structure, records, cfg)
     refinement = replace(refinement_setup, params=refinement_setup.params.to(device))
     if n_orientations < 1:
@@ -879,10 +901,8 @@ def _preprocess(
     only decide whether/where a PNG gets written, never the fitted ``Plan``) -- see
     :func:`~diffBloch.config.manifest.dataset_config_digest`.
     """
-    structure = read_structure(
-        root / cfg.inputs.structure, load_hydrogens=cfg.inputs.load_hydrogens
-    )
-    records = _read_experimental_data(root, cfg)
+    structure = _read_structure(root, cfg, logger=logger)
+    records = _read_experimental_data(root, cfg, logger=logger)
     refs = _exp_data_refs(cfg)
     refinement_setup, datasets = setup_datasets(structure, records, cfg)
     cell = records[0].cell_parameters

--- a/src/diffBloch/io/__init__.py
+++ b/src/diffBloch/io/__init__.py
@@ -1,19 +1,28 @@
 """Input readers and validated records for experiment boundaries."""
 
 from diffBloch.io._cifio import parse_cif_number
-from diffBloch.io.cif import parse_structure_block, read_structure
-from diffBloch.io.pets import parse_experimental_block, read_experimental_data
+from diffBloch.io.cif import parse_structure_block, read_structure, read_structure_with_diagnostics
+from diffBloch.io.diagnostics import ParseDiagnostic, ParsedInput
+from diffBloch.io.pets import (
+    parse_experimental_block,
+    read_experimental_data,
+    read_experimental_data_with_diagnostics,
+)
 from diffBloch.io.record import AdpRecord, ExperimentalRecord, StructureRecord
 from diffBloch.io.symmetry_setup import symmetry_constraints
 
 __all__ = [
     "AdpRecord",
     "ExperimentalRecord",
+    "ParsedInput",
+    "ParseDiagnostic",
     "StructureRecord",
     "parse_experimental_block",
     "parse_cif_number",
     "parse_structure_block",
     "read_experimental_data",
+    "read_experimental_data_with_diagnostics",
     "read_structure",
+    "read_structure_with_diagnostics",
     "symmetry_constraints",
 ]

--- a/src/diffBloch/io/_cifio.py
+++ b/src/diffBloch/io/_cifio.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import re
+from collections import Counter
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -11,6 +13,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from diffBloch.core.crystal import cell_matrix_from_parameters
+from diffBloch.io.diagnostics import InputKind, ParseDetail, ParseDiagnostic
 
 _TOP_LEVEL_TAG = re.compile(r"^(_\S+)(\s+\S.*)?$")
 
@@ -33,8 +36,48 @@ def read_document(path: str | Path) -> gemmi.cif.Document:
     return gemmi.cif.read_string(_drop_duplicate_scalar_tags(text))
 
 
+def read_document_with_diagnostics(
+    path: str | Path, *, input_kind: InputKind
+) -> tuple[gemmi.cif.Document, tuple[ParseDiagnostic, ...]]:
+    """Read a CIF-like file and report non-fatal tolerance decisions made before parsing."""
+    source = Path(path)
+    text, dropped, kept_values = _drop_duplicate_scalar_tags_with_counts(source.read_text())
+    diagnostics: list[ParseDiagnostic] = []
+    for tag, count in sorted(dropped.items()):
+        kept_value = kept_values.get(tag)
+        if kept_value:
+            message = f"dropped duplicate scalar CIF tag {tag}, kept first value {kept_value!r}"
+            details: Mapping[str, ParseDetail] = {
+                "tag": tag,
+                "count": count,
+                "kept_value": kept_value,
+            }
+        else:
+            message = f"dropped duplicate scalar CIF tag {tag}, kept first value"
+            details = {"tag": tag, "count": count}
+        diagnostics.append(
+            ParseDiagnostic(
+                code="duplicate_scalar_tag_dropped",
+                input_kind=input_kind,
+                source_path=source,
+                message=message,
+                details=details,
+            )
+        )
+    return gemmi.cif.read_string(text), tuple(diagnostics)
+
+
 def _drop_duplicate_scalar_tags(text: str) -> str:
+    return _drop_duplicate_scalar_tags_with_counts(text)[0]
+
+
+def _drop_duplicate_scalar_tags_with_counts(
+    text: str,
+) -> tuple[str, Counter[str], dict[str, str]]:
     seen: set[str] = set()
+    dropped: Counter[str] = Counter()
+    kept_values: dict[str, str] = {}
+    pending_kept_value_tag: str | None = None
     in_text_field = False
     in_loop_header = False
     skipping_duplicate_text_field = False
@@ -53,6 +96,13 @@ def _drop_duplicate_scalar_tags(text: str) -> str:
             elif stripped and not stripped.startswith("#"):
                 skip_duplicate_value = False
             continue
+        if pending_kept_value_tag is not None:
+            if stripped.startswith(";"):
+                kept_values.setdefault(pending_kept_value_tag, "<text field>")
+                pending_kept_value_tag = None
+            elif stripped and not stripped.startswith("#"):
+                kept_values.setdefault(pending_kept_value_tag, stripped)
+                pending_kept_value_tag = None
         if stripped.startswith(";"):
             in_text_field = not in_text_field
             out.append(line)
@@ -62,6 +112,7 @@ def _drop_duplicate_scalar_tags(text: str) -> str:
             continue
         if stripped.startswith("data_"):
             seen = set()
+            pending_kept_value_tag = None
             in_loop_header = False
             out.append(line)
             continue
@@ -78,12 +129,17 @@ def _drop_duplicate_scalar_tags(text: str) -> str:
         if match:
             tag = match.group(1)
             if tag in seen:
+                dropped[tag] += 1
                 if match.group(2) is None:
                     skip_duplicate_value = True
                 continue
             seen.add(tag)
+            if match.group(2) is not None:
+                kept_values.setdefault(tag, match.group(2).strip())
+            else:
+                pending_kept_value_tag = tag
         out.append(line)
-    return "\n".join(out)
+    return "\n".join(out), dropped, kept_values
 
 
 def select_block(doc: gemmi.cif.Document, *, required_loop_tag: str) -> gemmi.cif.Block:
@@ -103,6 +159,35 @@ def select_block(doc: gemmi.cif.Document, *, required_loop_tag: str) -> gemmi.ci
     raise ValueError(
         f"expected exactly one CIF block containing {required_loop_tag}, found "
         f"{len(candidates)} among {len(doc)} blocks ({names})"
+    )
+
+
+def select_block_with_diagnostics(
+    doc: gemmi.cif.Document,
+    *,
+    required_loop_tag: str,
+    source_path: str | Path | None,
+    input_kind: InputKind,
+) -> tuple[gemmi.cif.Block, tuple[ParseDiagnostic, ...]]:
+    """Select a block and report when a data-bearing block is chosen from a multi-block CIF."""
+    block = select_block(doc, required_loop_tag=required_loop_tag)
+    if len(doc) == 1:
+        return block, ()
+    return block, (
+        ParseDiagnostic(
+            code="cif_block_selected",
+            input_kind=input_kind,
+            source_path=None if source_path is None else Path(source_path),
+            message=(
+                f"found {len(doc)} CIF blocks; using structure block {block.name!r} "
+                f"(the only block with {required_loop_tag})"
+            ),
+            details={
+                "block": block.name,
+                "required_loop_tag": required_loop_tag,
+                "n_blocks": len(doc),
+            },
+        ),
     )
 
 

--- a/src/diffBloch/io/_cifio.py
+++ b/src/diffBloch/io/_cifio.py
@@ -37,9 +37,22 @@ def _drop_duplicate_scalar_tags(text: str) -> str:
     seen: set[str] = set()
     in_text_field = False
     in_loop_header = False
+    skipping_duplicate_text_field = False
+    skip_duplicate_value = False
     out: list[str] = []
     for line in text.splitlines():
         stripped = line.strip()
+        if skipping_duplicate_text_field:
+            if stripped.startswith(";"):
+                skipping_duplicate_text_field = False
+            continue
+        if skip_duplicate_value:
+            if stripped.startswith(";"):
+                skipping_duplicate_text_field = True
+                skip_duplicate_value = False
+            elif stripped and not stripped.startswith("#"):
+                skip_duplicate_value = False
+            continue
         if stripped.startswith(";"):
             in_text_field = not in_text_field
             out.append(line)
@@ -65,6 +78,8 @@ def _drop_duplicate_scalar_tags(text: str) -> str:
         if match:
             tag = match.group(1)
             if tag in seen:
+                if match.group(2) is None:
+                    skip_duplicate_value = True
                 continue
             seen.add(tag)
         out.append(line)

--- a/src/diffBloch/io/_cifio.py
+++ b/src/diffBloch/io/_cifio.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import Any, NamedTuple
 
 import gemmi
@@ -11,10 +12,83 @@ from numpy.typing import NDArray
 
 from diffBloch.core.crystal import cell_matrix_from_parameters
 
+_TOP_LEVEL_TAG = re.compile(r"^(_\S+)(\s+\S.*)?$")
+
 _NUMERIC_WITH_SU = re.compile(
     r"^(?P<nominal>[+-]?(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:[eE][+-]?\d+)?)"
     r"(?:\((?P<su>\d+)\))?$"
 )
+
+
+def read_document(path: str | Path) -> gemmi.cif.Document:
+    """Read a CIF-like file into a :class:`gemmi.cif.Document`, tolerating duplicate scalar tags.
+
+    Some PETS2 builds append a second, CIF-compliance-only section that restates a tag (e.g.
+    ``_diffrn_radiation_wavelength``) already given earlier in the same block. That violates the
+    CIF spec -- a data name may appear at most once per block -- so gemmi's strict parser rejects
+    it outright. Drop later duplicates (keeping the first, higher-precision occurrence) before
+    parsing.
+    """
+    text = Path(path).read_text()
+    return gemmi.cif.read_string(_drop_duplicate_scalar_tags(text))
+
+
+def _drop_duplicate_scalar_tags(text: str) -> str:
+    seen: set[str] = set()
+    in_text_field = False
+    in_loop_header = False
+    out: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(";"):
+            in_text_field = not in_text_field
+            out.append(line)
+            continue
+        if in_text_field:
+            out.append(line)
+            continue
+        if stripped.startswith("data_"):
+            seen = set()
+            in_loop_header = False
+            out.append(line)
+            continue
+        if stripped == "loop_":
+            in_loop_header = True
+            out.append(line)
+            continue
+        match = _TOP_LEVEL_TAG.match(stripped)
+        if in_loop_header:
+            if not match:
+                in_loop_header = False
+            out.append(line)
+            continue
+        if match:
+            tag = match.group(1)
+            if tag in seen:
+                continue
+            seen.add(tag)
+        out.append(line)
+    return "\n".join(out)
+
+
+def select_block(doc: gemmi.cif.Document, *, required_loop_tag: str) -> gemmi.cif.Block:
+    """Return the sole block, or the one block carrying ``required_loop_tag`` among several.
+
+    Software such as Jana2020 exports structure CIFs with a leading ``data_global`` block of blank
+    journal-submission boilerplate ahead of the actual ``data_<name>`` block with the refined
+    structure. ``gemmi``'s ``sole_block()`` rejects any file with more than one block, so pick the
+    block that actually carries the data this reader needs instead.
+    """
+    if len(doc) == 1:
+        return doc.sole_block()
+    candidates = [block for block in doc if block.find_loop(required_loop_tag)]
+    if len(candidates) == 1:
+        return candidates[0]
+    names = ", ".join(block.name for block in doc)
+    raise ValueError(
+        f"expected exactly one CIF block containing {required_loop_tag}, found "
+        f"{len(candidates)} among {len(doc)} blocks ({names})"
+    )
 
 
 class CifNumber(NamedTuple):

--- a/src/diffBloch/io/cif.py
+++ b/src/diffBloch/io/cif.py
@@ -15,13 +15,14 @@ from diffBloch.io._cifio import (
     loop_rows,
     optional_int,
     parse_cif_number,
-    read_document,
-    select_block,
+    read_document_with_diagnostics,
+    select_block_with_diagnostics,
     unquote,
 )
 from diffBloch.io._cifio import (
     cell_parameters as parse_cell_parameters,
 )
+from diffBloch.io.diagnostics import ParseDiagnostic, ParsedInput
 from diffBloch.io.record import AdpRecord, StructureRecord
 
 ANISO_TAGS = (
@@ -50,6 +51,13 @@ class _AtomSites(NamedTuple):
     occupancies: NDArray[np.float64]
     occupancies_su: NDArray[np.float64]
     adp: AdpRecord
+    n_hydrogens_filtered: int
+
+
+class _Symops(NamedTuple):
+    rotations: NDArray[np.float64]
+    translations: NDArray[np.float64]
+    source: Literal["loop", "spacegroup"]
 
 
 def read_structure(path: str | Path, *, load_hydrogens: bool = False) -> StructureRecord:
@@ -60,9 +68,28 @@ def read_structure(path: str | Path, *, load_hydrogens: bool = False) -> Structu
         load_hydrogens: Include hydrogen atom sites when present. The default mirrors electron
             diffraction refinement practice where H sites are usually excluded from this boundary.
     """
+    return read_structure_with_diagnostics(path, load_hydrogens=load_hydrogens).record
+
+
+def read_structure_with_diagnostics(
+    path: str | Path, *, load_hydrogens: bool = False
+) -> ParsedInput[StructureRecord]:
+    """Read a structure CIF and report non-fatal parser decisions."""
     source = Path(path)
-    block = select_block(read_document(source), required_loop_tag="_atom_site_label")
-    return parse_structure_block(block, source_path=source, load_hydrogens=load_hydrogens)
+    doc, diagnostics = read_document_with_diagnostics(source, input_kind="structure")
+    block, block_diagnostics = select_block_with_diagnostics(
+        doc,
+        required_loop_tag="_atom_site_label",
+        source_path=source,
+        input_kind="structure",
+    )
+    parsed = _parse_structure_block_with_diagnostics(
+        block, source_path=source, load_hydrogens=load_hydrogens
+    )
+    return ParsedInput(
+        parsed.record,
+        diagnostics + block_diagnostics + parsed.diagnostics,
+    )
 
 
 def parse_structure_block(
@@ -79,11 +106,23 @@ def parse_structure_block(
         load_hydrogens: Include hydrogen atom sites when present. The default mirrors electron
             diffraction refinement practice where H sites are usually excluded from this boundary.
     """
+    return _parse_structure_block_with_diagnostics(
+        block, source_path=source_path, load_hydrogens=load_hydrogens
+    ).record
+
+
+def _parse_structure_block_with_diagnostics(
+    block: gemmi.cif.Block,
+    *,
+    source_path: str | Path | None,
+    load_hydrogens: bool,
+) -> ParsedInput[StructureRecord]:
     atom_sites = _read_atom_sites(block, load_hydrogens=load_hydrogens)
-    symops_R, symops_t = _read_symops(block)
+    symops = _read_symops(block)
     cell_parameters, cell_parameters_su = parse_cell_parameters(block)
-    return StructureRecord(
-        source_path=Path(source_path) if source_path is not None else None,
+    source = Path(source_path) if source_path is not None else None
+    record = StructureRecord(
+        source_path=source,
         unit_cell=cell_matrix_from_parameters(cell_parameters),
         cell_parameters=cell_parameters,
         cell_parameters_su=cell_parameters_su,
@@ -96,8 +135,8 @@ def parse_structure_block(
             block.find_value("_symmetry_Int_Tables_number")
             or block.find_value("_space_group_IT_number")
         ),
-        symops_R=symops_R,
-        symops_t=symops_t,
+        symops_R=symops.rotations,
+        symops_t=symops.translations,
         labels=atom_sites.labels,
         numbers=atom_sites.numbers,
         frac_positions=atom_sites.frac_positions,
@@ -106,6 +145,31 @@ def parse_structure_block(
         occupancies_su=atom_sites.occupancies_su,
         adp=atom_sites.adp,
     )
+    diagnostics: list[ParseDiagnostic] = []
+    if atom_sites.n_hydrogens_filtered:
+        diagnostics.append(
+            ParseDiagnostic(
+                code="hydrogen_sites_filtered",
+                input_kind="structure",
+                source_path=source,
+                message=(
+                    f"filtered {atom_sites.n_hydrogens_filtered} hydrogen atom site(s); "
+                    "set load_hydrogens to include them"
+                ),
+                details={"count": atom_sites.n_hydrogens_filtered},
+            )
+        )
+    if symops.source == "spacegroup":
+        diagnostics.append(
+            ParseDiagnostic(
+                code="symmetry_from_spacegroup",
+                input_kind="structure",
+                source_path=source,
+                message="derived symmetry operations from space-group symbol or number",
+                details={"n_symops": record.n_symops},
+            )
+        )
+    return ParsedInput(record, tuple(diagnostics))
 
 
 def _read_atom_sites(block: gemmi.cif.Block, *, load_hydrogens: bool) -> _AtomSites:
@@ -126,10 +190,12 @@ def _read_atom_sites(block: gemmi.cif.Block, *, load_hydrogens: bool) -> _AtomSi
     u_iso_su: list[float] = []
     uij_cif: list[NDArray[np.float64]] = []
     uij_cif_su: list[NDArray[np.float64]] = []
+    n_hydrogens_filtered = 0
 
     for row in atom_rows:
         element = gemmi.Element(str(row["_atom_site_type_symbol"]))
         if not load_hydrogens and element.atomic_number == 1:
+            n_hydrogens_filtered += 1
             continue
         label = str(row["_atom_site_label"])
         labels.append(label)
@@ -172,10 +238,11 @@ def _read_atom_sites(block: gemmi.cif.Block, *, load_hydrogens: bool) -> _AtomSi
             uij_cif=np.asarray(uij_cif, dtype=np.float64),
             uij_cif_su=np.asarray(uij_cif_su, dtype=np.float64),
         ),
+        n_hydrogens_filtered=n_hydrogens_filtered,
     )
 
 
-def _read_symops(block: gemmi.cif.Block) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+def _read_symops(block: gemmi.cif.Block) -> _Symops:
     rows = loop_rows(block, "_symmetry_equiv_pos_as_xyz") or loop_rows(
         block, "_space_group_symop_operation_xyz"
     )
@@ -185,11 +252,13 @@ def _read_symops(block: gemmi.cif.Block) -> tuple[NDArray[np.float64], NDArray[n
         )
         for row in rows
     ]
+    source: Literal["loop", "spacegroup"] = "loop"
     if not symops:
         spacegroup = _spacegroup_for_block(block)
         if spacegroup is None:
             raise ValueError("CIF must provide symmetry operations or a space-group symbol/number")
         symops = [op.triplet() for op in spacegroup.operations()]
+        source = "spacegroup"
 
     rotations: list[list[list[float]]] = []
     translations: list[list[float]] = []
@@ -197,7 +266,11 @@ def _read_symops(block: gemmi.cif.Block) -> tuple[NDArray[np.float64], NDArray[n
         op = gemmi.Op(operation)
         rotations.append([[float(op.rot[i][j]) / op.DEN for j in range(3)] for i in range(3)])
         translations.append([float(op.tran[i]) / op.DEN for i in range(3)])
-    return np.asarray(rotations, dtype=np.float64), np.asarray(translations, dtype=np.float64)
+    return _Symops(
+        rotations=np.asarray(rotations, dtype=np.float64),
+        translations=np.asarray(translations, dtype=np.float64),
+        source=source,
+    )
 
 
 def _spacegroup_for_block(block: gemmi.cif.Block) -> gemmi.SpaceGroup | None:

--- a/src/diffBloch/io/cif.py
+++ b/src/diffBloch/io/cif.py
@@ -15,6 +15,8 @@ from diffBloch.io._cifio import (
     loop_rows,
     optional_int,
     parse_cif_number,
+    read_document,
+    select_block,
     unquote,
 )
 from diffBloch.io._cifio import (
@@ -59,7 +61,7 @@ def read_structure(path: str | Path, *, load_hydrogens: bool = False) -> Structu
             diffraction refinement practice where H sites are usually excluded from this boundary.
     """
     source = Path(path)
-    block = gemmi.cif.read_file(str(source)).sole_block()
+    block = select_block(read_document(source), required_loop_tag="_atom_site_label")
     return parse_structure_block(block, source_path=source, load_hydrogens=load_hydrogens)
 
 

--- a/src/diffBloch/io/diagnostics.py
+++ b/src/diffBloch/io/diagnostics.py
@@ -1,0 +1,54 @@
+"""Parse diagnostics for input-file tolerance and fallback decisions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import ClassVar, Literal
+
+type ParseDetail = str | int | float | bool
+type InputKind = Literal["structure", "experimental_data"]
+type ParseDiagnosticCode = Literal[
+    "cif_block_selected",
+    "duplicate_scalar_tag_dropped",
+    "hydrogen_sites_filtered",
+    "pets_geometry_defaulted",
+    "pets_optional_metadata_absent",
+    "pets_summary_tag_used",
+    "symmetry_from_spacegroup",
+]
+
+
+@dataclass(frozen=True)
+class ParseDiagnostic:
+    """A non-fatal input parse decision worth surfacing at the app boundary."""
+
+    channel: ClassVar[str] = "input parse"
+    code: ParseDiagnosticCode
+    input_kind: InputKind
+    source_path: Path | None
+    message: str
+    details: Mapping[str, ParseDetail] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        source = None if self.source_path is None else Path(self.source_path)
+        object.__setattr__(self, "source_path", source)
+        object.__setattr__(self, "details", MappingProxyType(dict(self.details)))
+
+    @property
+    def step(self) -> int | None:
+        return None
+
+    @property
+    def measurements(self) -> Mapping[str, float]:
+        return {}
+
+
+@dataclass(frozen=True)
+class ParsedInput[T]:
+    """An IO record plus non-fatal diagnostics collected while parsing it."""
+
+    record: T
+    diagnostics: tuple[ParseDiagnostic, ...] = ()

--- a/src/diffBloch/io/pets.py
+++ b/src/diffBloch/io/pets.py
@@ -4,14 +4,21 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Literal
+from typing import Literal, NamedTuple
 
 import gemmi
 import numpy as np
 from numpy.typing import NDArray
 
 from diffBloch.core.crystal import cell_matrix_from_parameters
-from diffBloch.io._cifio import as_float, cell_parameters, loop_rows, read_document, required_float
+from diffBloch.io._cifio import (
+    as_float,
+    cell_parameters,
+    loop_rows,
+    read_document_with_diagnostics,
+    required_float,
+)
+from diffBloch.io.diagnostics import ParseDiagnostic, ParsedInput
 from diffBloch.io.record import ExperimentalRecord
 
 _DSTAR_MAX = re.compile(r"dstarmax:\s*([\d.]+)", re.IGNORECASE)
@@ -26,11 +33,26 @@ _DATA_COLLECTION_GEOMETRY = re.compile(
 _MEASUREMENT_DETAILS_TAGS = ("_diffrn_measurement_details", "_diffrn_reflns_reduction_process")
 
 
+class _MeasurementDetails(NamedTuple):
+    text: str
+    tag: str
+
+
 def read_experimental_data(path: str | Path) -> ExperimentalRecord:
     """Read a PETS ``.cif_pets`` file into a validated :class:`ExperimentalRecord`."""
+    return read_experimental_data_with_diagnostics(path).record
+
+
+def read_experimental_data_with_diagnostics(path: str | Path) -> ParsedInput[ExperimentalRecord]:
+    """Read a PETS ``.cif_pets`` file and report non-fatal parser decisions."""
     source = Path(path)
-    block = read_document(source).sole_block()
-    return parse_experimental_block(block, source_path=source)
+    doc, diagnostics = read_document_with_diagnostics(source, input_kind="experimental_data")
+    block = doc.sole_block()
+    record = parse_experimental_block(block, source_path=source)
+    return ParsedInput(
+        record,
+        diagnostics + _experimental_parse_diagnostics(block, source_path=source),
+    )
 
 
 def parse_experimental_block(
@@ -108,12 +130,14 @@ def parse_experimental_block(
     )
 
 
-def _measurement_details(block: gemmi.cif.Block, pattern: re.Pattern[str]) -> str | None:
+def _measurement_details(
+    block: gemmi.cif.Block, pattern: re.Pattern[str]
+) -> _MeasurementDetails | None:
     """Return the PETS2 summary text field containing ``pattern``, wherever it was written."""
     for tag in _MEASUREMENT_DETAILS_TAGS:
         text = block.find_value(tag)
         if text is not None and pattern.search(str(text)):
-            return str(text)
+            return _MeasurementDetails(str(text), tag)
     return None
 
 
@@ -125,19 +149,19 @@ def _dstar_max(block: gemmi.cif.Block) -> float | None:
     Returns ``None`` when the tag is absent or a PETS version that doesn't record ``dstarmax``
     wrote the file.
     """
-    text = _measurement_details(block, _DSTAR_MAX)
-    if text is None:
+    details = _measurement_details(block, _DSTAR_MAX)
+    if details is None:
         return None
-    match = _DSTAR_MAX.search(text)
+    match = _DSTAR_MAX.search(details.text)
     return float(match.group(1)) if match else None
 
 
 def _mosaicity(block: gemmi.cif.Block) -> float | None:
     """PETS2 apparent mosaicity in degrees from measurement details."""
-    text = _measurement_details(block, _MOSAICITY)
-    if text is None:
+    details = _measurement_details(block, _MOSAICITY)
+    if details is None:
         return None
-    match = _MOSAICITY.search(text)
+    match = _MOSAICITY.search(details.text)
     return float(match.group(1)) if match else None
 
 
@@ -151,10 +175,10 @@ def _data_collection_geometry(
     continuous-rotation default. An explicit unknown value fails at the I/O boundary rather than
     silently selecting scientifically different integration geometry.
     """
-    text = _measurement_details(block, _DATA_COLLECTION_GEOMETRY)
-    if text is None:
+    details = _measurement_details(block, _DATA_COLLECTION_GEOMETRY)
+    if details is None:
         return "continuous_rotation"
-    match = _DATA_COLLECTION_GEOMETRY.search(text)
+    match = _DATA_COLLECTION_GEOMETRY.search(details.text)
     if match is None:
         return "continuous_rotation"
     value = re.sub(r"[\s_-]+", "_", match.group(1).strip().lower())
@@ -166,6 +190,60 @@ def _data_collection_geometry(
         "PETS data collection geometry must be 'continuous rotation' or 'precession'; "
         f"got {match.group(1).strip()!r}"
     )
+
+
+def _experimental_parse_diagnostics(
+    block: gemmi.cif.Block, *, source_path: Path
+) -> tuple[ParseDiagnostic, ...]:
+    diagnostics: list[ParseDiagnostic] = []
+    summary_fields = (
+        ("data_collection_geometry", _DATA_COLLECTION_GEOMETRY),
+        ("dstarmax", _DSTAR_MAX),
+        ("mosaicity", _MOSAICITY),
+    )
+    used_by_tag: dict[str, list[str]] = {}
+    absent_optional: list[str] = []
+    for field, pattern in summary_fields:
+        details = _measurement_details(block, pattern)
+        if details is None:
+            if field == "data_collection_geometry":
+                diagnostics.append(
+                    ParseDiagnostic(
+                        code="pets_geometry_defaulted",
+                        input_kind="experimental_data",
+                        source_path=source_path,
+                        message=(
+                            "PETS data collection geometry absent; defaulted to continuous_rotation"
+                        ),
+                        details={"field": field, "default": "continuous_rotation"},
+                    )
+                )
+            else:
+                absent_optional.append(field)
+            continue
+        used_by_tag.setdefault(details.tag, []).append(field)
+
+    for tag, fields in sorted(used_by_tag.items()):
+        diagnostics.append(
+            ParseDiagnostic(
+                code="pets_summary_tag_used",
+                input_kind="experimental_data",
+                source_path=source_path,
+                message=f"read PETS summary field(s) {', '.join(fields)} from {tag}",
+                details={"tag": tag, "fields": ", ".join(fields)},
+            )
+        )
+    if absent_optional:
+        diagnostics.append(
+            ParseDiagnostic(
+                code="pets_optional_metadata_absent",
+                input_kind="experimental_data",
+                source_path=source_path,
+                message=f"PETS optional metadata absent: {', '.join(absent_optional)}",
+                details={"fields": ", ".join(absent_optional)},
+            )
+        )
+    return tuple(diagnostics)
 
 
 def _ub_matrix(block: gemmi.cif.Block) -> NDArray[np.float64]:

--- a/src/diffBloch/io/pets.py
+++ b/src/diffBloch/io/pets.py
@@ -22,7 +22,7 @@ _DATA_COLLECTION_GEOMETRY = re.compile(
 )
 # PETS2 writes its informal `key: value` processing summary (data collection geometry, dstarmax,
 # mosaicity, ...) as a semicolon-delimited text field, but different builds attach it to different
-# CIF tags -- try each in order and use the first one present.
+# CIF tags. For each key, try the tags in order and use the first text field containing that key.
 _MEASUREMENT_DETAILS_TAGS = ("_diffrn_measurement_details", "_diffrn_reflns_reduction_process")
 
 
@@ -108,11 +108,11 @@ def parse_experimental_block(
     )
 
 
-def _measurement_details(block: gemmi.cif.Block) -> str | None:
-    """Return PETS2's informal ``key: value`` processing summary text, wherever it was written."""
+def _measurement_details(block: gemmi.cif.Block, pattern: re.Pattern[str]) -> str | None:
+    """Return the PETS2 summary text field containing ``pattern``, wherever it was written."""
     for tag in _MEASUREMENT_DETAILS_TAGS:
         text = block.find_value(tag)
-        if text is not None:
+        if text is not None and pattern.search(str(text)):
             return str(text)
     return None
 
@@ -125,7 +125,7 @@ def _dstar_max(block: gemmi.cif.Block) -> float | None:
     Returns ``None`` when the tag is absent or a PETS version that doesn't record ``dstarmax``
     wrote the file.
     """
-    text = _measurement_details(block)
+    text = _measurement_details(block, _DSTAR_MAX)
     if text is None:
         return None
     match = _DSTAR_MAX.search(text)
@@ -134,7 +134,7 @@ def _dstar_max(block: gemmi.cif.Block) -> float | None:
 
 def _mosaicity(block: gemmi.cif.Block) -> float | None:
     """PETS2 apparent mosaicity in degrees from measurement details."""
-    text = _measurement_details(block)
+    text = _measurement_details(block, _MOSAICITY)
     if text is None:
         return None
     match = _MOSAICITY.search(text)
@@ -151,7 +151,7 @@ def _data_collection_geometry(
     continuous-rotation default. An explicit unknown value fails at the I/O boundary rather than
     silently selecting scientifically different integration geometry.
     """
-    text = _measurement_details(block)
+    text = _measurement_details(block, _DATA_COLLECTION_GEOMETRY)
     if text is None:
         return "continuous_rotation"
     match = _DATA_COLLECTION_GEOMETRY.search(text)

--- a/src/diffBloch/io/pets.py
+++ b/src/diffBloch/io/pets.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from diffBloch.core.crystal import cell_matrix_from_parameters
-from diffBloch.io._cifio import as_float, cell_parameters, loop_rows, required_float
+from diffBloch.io._cifio import as_float, cell_parameters, loop_rows, read_document, required_float
 from diffBloch.io.record import ExperimentalRecord
 
 _DSTAR_MAX = re.compile(r"dstarmax:\s*([\d.]+)", re.IGNORECASE)
@@ -20,12 +20,16 @@ _MOSAICITY = re.compile(rf"mosaicity:\s*({_FLOAT_TEXT})", re.IGNORECASE)
 _DATA_COLLECTION_GEOMETRY = re.compile(
     r"data\s+collection\s+geometry\s*:\s*([^\r\n;]+)", re.IGNORECASE
 )
+# PETS2 writes its informal `key: value` processing summary (data collection geometry, dstarmax,
+# mosaicity, ...) as a semicolon-delimited text field, but different builds attach it to different
+# CIF tags -- try each in order and use the first one present.
+_MEASUREMENT_DETAILS_TAGS = ("_diffrn_measurement_details", "_diffrn_reflns_reduction_process")
 
 
 def read_experimental_data(path: str | Path) -> ExperimentalRecord:
     """Read a PETS ``.cif_pets`` file into a validated :class:`ExperimentalRecord`."""
     source = Path(path)
-    block = gemmi.cif.read_file(str(source)).sole_block()
+    block = read_document(source).sole_block()
     return parse_experimental_block(block, source_path=source)
 
 
@@ -104,27 +108,36 @@ def parse_experimental_block(
     )
 
 
-def _dstar_max(block: gemmi.cif.Block) -> float | None:
-    """PETS2's processing-resolution cutoff (Å⁻¹) from the free-text ``_diffrn_measurement_details``.
+def _measurement_details(block: gemmi.cif.Block) -> str | None:
+    """Return PETS2's informal ``key: value`` processing summary text, wherever it was written."""
+    for tag in _MEASUREMENT_DETAILS_TAGS:
+        text = block.find_value(tag)
+        if text is not None:
+            return str(text)
+    return None
 
-    That tag is PETS2's own semicolon-delimited text block (``dstarmax:  1.800`` among other
-    informal ``key: value`` lines), not a structured CIF field, so this greps rather than parses it
-    as CIF. Returns ``None`` when the tag is absent or a PETS version that doesn't record
-    ``dstarmax`` wrote the file.
+
+def _dstar_max(block: gemmi.cif.Block) -> float | None:
+    """PETS2's processing-resolution cutoff (Å⁻¹) from the free-text measurement-details block.
+
+    That text is PETS2's own semicolon-delimited block (``dstarmax:  1.800`` among other informal
+    ``key: value`` lines), not a structured CIF field, so this greps rather than parses it as CIF.
+    Returns ``None`` when the tag is absent or a PETS version that doesn't record ``dstarmax``
+    wrote the file.
     """
-    text = block.find_value("_diffrn_measurement_details")
+    text = _measurement_details(block)
     if text is None:
         return None
-    match = _DSTAR_MAX.search(str(text))
+    match = _DSTAR_MAX.search(text)
     return float(match.group(1)) if match else None
 
 
 def _mosaicity(block: gemmi.cif.Block) -> float | None:
     """PETS2 apparent mosaicity in degrees from measurement details."""
-    text = block.find_value("_diffrn_measurement_details")
+    text = _measurement_details(block)
     if text is None:
         return None
-    match = _MOSAICITY.search(str(text))
+    match = _MOSAICITY.search(text)
     return float(match.group(1)) if match else None
 
 
@@ -133,15 +146,15 @@ def _data_collection_geometry(
 ) -> Literal["continuous_rotation", "precession"]:
     """Return PETS2's acquisition geometry in the package's canonical spelling.
 
-    PETS2 writes this value into the informal ``_diffrn_measurement_details`` text block rather
-    than a structured CIF tag. Older files may omit it; those retain diffBloch's historical
+    PETS2 writes this value into an informal measurement-details text block rather than a
+    structured CIF tag. Older files may omit it; those retain diffBloch's historical
     continuous-rotation default. An explicit unknown value fails at the I/O boundary rather than
     silently selecting scientifically different integration geometry.
     """
-    text = block.find_value("_diffrn_measurement_details")
+    text = _measurement_details(block)
     if text is None:
         return "continuous_rotation"
-    match = _DATA_COLLECTION_GEOMETRY.search(str(text))
+    match = _DATA_COLLECTION_GEOMETRY.search(text)
     if match is None:
         return "continuous_rotation"
     value = re.sub(r"[\s_-]+", "_", match.group(1).strip().lower())

--- a/tests/unit/test_io_quartz.py
+++ b/tests/unit/test_io_quartz.py
@@ -12,6 +12,7 @@ from diffBloch.io import (
     read_structure,
     symmetry_constraints,
 )
+from diffBloch.io._cifio import read_document
 
 FIXTURE_ROOT = Path(__file__).parent.parent / "fixtures" / "quartz_anchor"
 
@@ -38,6 +39,56 @@ def test_read_quartz_structure_fixture() -> None:
     constraints = symmetry_constraints(record)
     assert constraints.n_asymmetric_sites == 2
     assert constraints.n_symops == 6
+
+
+def test_read_structure_selects_atom_site_block_from_multiblock_cif(tmp_path: Path) -> None:
+    source = tmp_path / "jana2020_multiblock.cif"
+    source.write_text(
+        """data_global
+_journal_name_full .
+
+data_structure
+_cell_length_a 5.0
+_cell_length_b 6.0
+_cell_length_c 7.0
+_cell_angle_alpha 90
+_cell_angle_beta 100
+_cell_angle_gamma 90
+_symmetry_space_group_name_H-M 'P 1'
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+C1 C 0.10 0.20 0.30
+"""
+    )
+
+    record = read_structure(source)
+
+    assert record.labels == ("C1",)
+    assert record.cell_parameters.tolist() == pytest.approx([5.0, 6.0, 7.0, 90.0, 100.0, 90.0])
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("data_x\n_tag 1\n_tag 2\n_other 3\n", "1"),
+        ("data_x\n_tag\n1\n_tag\n2\n_other 3\n", "1"),
+        ("data_x\n_tag\n;\nfirst\n;\n_tag\n;\nsecond\n;\n_other 3\n", "first"),
+    ],
+)
+def test_read_document_drops_duplicate_scalar_tag_with_its_value(
+    tmp_path: Path, text: str, expected: str
+) -> None:
+    source = tmp_path / "duplicate.cif"
+    source.write_text(text)
+
+    block = read_document(source).sole_block()
+
+    assert expected in str(block.find_value("_tag"))
+    assert block.find_value("_other") == "3"
 
 
 def test_read_quartz_pets_fixture() -> None:
@@ -212,3 +263,121 @@ _refln_zone_axis_id
     assert record.sigmas.tolist() == [0.7]
     assert record.data_collection_geometry == "precession"
     assert record.dstar_max is None
+
+
+def test_parse_pets_summary_from_reduction_process_when_measurement_details_lacks_keys() -> None:
+    block = gemmi.cif.read_string(
+        """data_pets
+_cell_length_a 5.0
+_cell_length_b 6.0
+_cell_length_c 7.0
+_cell_angle_alpha 90
+_cell_angle_beta 100
+_cell_angle_gamma 90
+_diffrn_radiation_wavelength 0.0251
+_diffrn_orient_matrix_UB_11 1
+_diffrn_orient_matrix_UB_12 0
+_diffrn_orient_matrix_UB_13 0
+_diffrn_orient_matrix_UB_21 0
+_diffrn_orient_matrix_UB_22 1
+_diffrn_orient_matrix_UB_23 0
+_diffrn_orient_matrix_UB_31 0
+_diffrn_orient_matrix_UB_32 0
+_diffrn_orient_matrix_UB_33 1
+_diffrn_measurement_details
+;
+operator note only
+;
+_diffrn_reflns_reduction_process
+;
+data collection geometry: precession
+dstarmax:  1.400
+mosaicity:  0.100
+;
+loop_
+_diffrn_zone_axis_id
+_diffrn_zone_axis_u
+_diffrn_zone_axis_v
+_diffrn_zone_axis_w
+_diffrn_zone_axis_precession_angle
+_diffrn_zone_axis_alpha
+_diffrn_zone_axis_beta
+_diffrn_zone_axis_omega
+_diffrn_zone_axis_scale
+1 0 0 1 0.5 10 20 30 1
+loop_
+_refln_index_h
+_refln_index_k
+_refln_index_l
+_refln_intensity_meas
+_refln_intensity_sigma
+_refln_zone_axis_id
+1 0 0 12.5 0.7 1
+"""
+    ).sole_block()
+
+    record = parse_experimental_block(block)
+
+    assert record.data_collection_geometry == "precession"
+    assert record.dstar_max == pytest.approx(1.4)
+    assert record.mosaicity_degrees == pytest.approx(0.1)
+
+
+def test_parse_pets_summary_prefers_measurement_details_when_both_tags_have_keys() -> None:
+    block = gemmi.cif.read_string(
+        """data_pets
+_cell_length_a 5.0
+_cell_length_b 6.0
+_cell_length_c 7.0
+_cell_angle_alpha 90
+_cell_angle_beta 100
+_cell_angle_gamma 90
+_diffrn_radiation_wavelength 0.0251
+_diffrn_orient_matrix_UB_11 1
+_diffrn_orient_matrix_UB_12 0
+_diffrn_orient_matrix_UB_13 0
+_diffrn_orient_matrix_UB_21 0
+_diffrn_orient_matrix_UB_22 1
+_diffrn_orient_matrix_UB_23 0
+_diffrn_orient_matrix_UB_31 0
+_diffrn_orient_matrix_UB_32 0
+_diffrn_orient_matrix_UB_33 1
+_diffrn_measurement_details
+;
+data collection geometry: continuous rotation
+dstarmax:  1.800
+mosaicity:  0.050
+;
+_diffrn_reflns_reduction_process
+;
+data collection geometry: precession
+dstarmax:  1.400
+mosaicity:  0.100
+;
+loop_
+_diffrn_zone_axis_id
+_diffrn_zone_axis_u
+_diffrn_zone_axis_v
+_diffrn_zone_axis_w
+_diffrn_zone_axis_precession_angle
+_diffrn_zone_axis_alpha
+_diffrn_zone_axis_beta
+_diffrn_zone_axis_omega
+_diffrn_zone_axis_scale
+1 0 0 1 0.5 10 20 30 1
+loop_
+_refln_index_h
+_refln_index_k
+_refln_index_l
+_refln_intensity_meas
+_refln_intensity_sigma
+_refln_zone_axis_id
+1 0 0 12.5 0.7 1
+"""
+    ).sole_block()
+
+    record = parse_experimental_block(block)
+
+    assert record.data_collection_geometry == "continuous_rotation"
+    assert record.dstar_max == pytest.approx(1.8)
+    assert record.mosaicity_degrees == pytest.approx(0.05)

--- a/tests/unit/test_io_quartz.py
+++ b/tests/unit/test_io_quartz.py
@@ -9,10 +9,12 @@ from diffBloch.io import (
     parse_experimental_block,
     parse_structure_block,
     read_experimental_data,
+    read_experimental_data_with_diagnostics,
     read_structure,
+    read_structure_with_diagnostics,
     symmetry_constraints,
 )
-from diffBloch.io._cifio import read_document
+from diffBloch.io._cifio import read_document, read_document_with_diagnostics
 
 FIXTURE_ROOT = Path(__file__).parent.parent / "fixtures" / "quartz_anchor"
 
@@ -62,13 +64,23 @@ _atom_site_fract_x
 _atom_site_fract_y
 _atom_site_fract_z
 C1 C 0.10 0.20 0.30
+H1 H 0.40 0.50 0.60
 """
     )
 
-    record = read_structure(source)
+    parsed = read_structure_with_diagnostics(source)
+    record = parsed.record
 
     assert record.labels == ("C1",)
     assert record.cell_parameters.tolist() == pytest.approx([5.0, 6.0, 7.0, 90.0, 100.0, 90.0])
+    diagnostics = {diagnostic.code: diagnostic for diagnostic in parsed.diagnostics}
+    assert diagnostics["cif_block_selected"].message == (
+        "found 2 CIF blocks; using structure block 'structure' "
+        "(the only block with _atom_site_label)"
+    )
+    assert diagnostics["cif_block_selected"].details["block"] == "structure"
+    assert diagnostics["hydrogen_sites_filtered"].details["count"] == 1
+    assert diagnostics["symmetry_from_spacegroup"].details["n_symops"] == 1
 
 
 @pytest.mark.parametrize(
@@ -89,6 +101,23 @@ def test_read_document_drops_duplicate_scalar_tag_with_its_value(
 
     assert expected in str(block.find_value("_tag"))
     assert block.find_value("_other") == "3"
+
+
+def test_read_document_reports_kept_duplicate_scalar_value(tmp_path: Path) -> None:
+    source = tmp_path / "duplicate.cif"
+    source.write_text("data_x\n_tag 1.234\n_tag 2.0\n")
+
+    _document, diagnostics = read_document_with_diagnostics(source, input_kind="experimental_data")
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].message == (
+        "dropped duplicate scalar CIF tag _tag, kept first value '1.234'"
+    )
+    assert diagnostics[0].details == {
+        "tag": "_tag",
+        "count": 1,
+        "kept_value": "1.234",
+    }
 
 
 def test_read_quartz_pets_fixture() -> None:
@@ -266,7 +295,65 @@ _refln_zone_axis_id
 
 
 def test_parse_pets_summary_from_reduction_process_when_measurement_details_lacks_keys() -> None:
-    block = gemmi.cif.read_string(
+    text = """data_pets
+_cell_length_a 5.0
+_cell_length_b 6.0
+_cell_length_c 7.0
+_cell_angle_alpha 90
+_cell_angle_beta 100
+_cell_angle_gamma 90
+_diffrn_radiation_wavelength 0.0251
+_diffrn_orient_matrix_UB_11 1
+_diffrn_orient_matrix_UB_12 0
+_diffrn_orient_matrix_UB_13 0
+_diffrn_orient_matrix_UB_21 0
+_diffrn_orient_matrix_UB_22 1
+_diffrn_orient_matrix_UB_23 0
+_diffrn_orient_matrix_UB_31 0
+_diffrn_orient_matrix_UB_32 0
+_diffrn_orient_matrix_UB_33 1
+_diffrn_measurement_details
+;
+operator note only
+;
+_diffrn_reflns_reduction_process
+;
+data collection geometry: precession
+dstarmax:  1.400
+mosaicity:  0.100
+;
+loop_
+_diffrn_zone_axis_id
+_diffrn_zone_axis_u
+_diffrn_zone_axis_v
+_diffrn_zone_axis_w
+_diffrn_zone_axis_precession_angle
+_diffrn_zone_axis_alpha
+_diffrn_zone_axis_beta
+_diffrn_zone_axis_omega
+_diffrn_zone_axis_scale
+1 0 0 1 0.5 10 20 30 1
+loop_
+_refln_index_h
+_refln_index_k
+_refln_index_l
+_refln_intensity_meas
+_refln_intensity_sigma
+_refln_zone_axis_id
+1 0 0 12.5 0.7 1
+"""
+    block = gemmi.cif.read_string(text).sole_block()
+
+    record = parse_experimental_block(block)
+
+    assert record.data_collection_geometry == "precession"
+    assert record.dstar_max == pytest.approx(1.4)
+    assert record.mosaicity_degrees == pytest.approx(0.1)
+
+
+def test_read_pets_reports_summary_source_diagnostics(tmp_path: Path) -> None:
+    source = tmp_path / "fallback_summary.cif_pets"
+    source.write_text(
         """data_pets
 _cell_length_a 5.0
 _cell_length_b 6.0
@@ -314,13 +401,21 @@ _refln_intensity_sigma
 _refln_zone_axis_id
 1 0 0 12.5 0.7 1
 """
-    ).sole_block()
+    )
 
-    record = parse_experimental_block(block)
+    parsed = read_experimental_data_with_diagnostics(source)
 
-    assert record.data_collection_geometry == "precession"
-    assert record.dstar_max == pytest.approx(1.4)
-    assert record.mosaicity_degrees == pytest.approx(0.1)
+    assert parsed.record.data_collection_geometry == "precession"
+    summary = [
+        diagnostic
+        for diagnostic in parsed.diagnostics
+        if diagnostic.code == "pets_summary_tag_used"
+    ]
+    assert len(summary) == 1
+    assert summary[0].details == {
+        "tag": "_diffrn_reflns_reduction_process",
+        "fields": "data_collection_geometry, dstarmax, mosaicity",
+    }
 
 
 def test_parse_pets_summary_prefers_measurement_details_when_both_tags_have_keys() -> None:

--- a/tests/unit/test_multi_dataset.py
+++ b/tests/unit/test_multi_dataset.py
@@ -14,7 +14,12 @@ import yaml
 from diffBloch.app.program import _read_experimental_data, converge_experiment
 from diffBloch.config import ExperimentConfig, input_lock_for, load_config
 from diffBloch.core.crystal import cell_matrix_from_parameters
-from diffBloch.io import read_experimental_data, read_structure
+from diffBloch.io import (
+    ParsedInput,
+    read_experimental_data,
+    read_experimental_data_with_diagnostics,
+    read_structure,
+)
 from diffBloch.preprocess import setup_datasets
 from diffBloch.preprocess.driver import ConvergenceState
 from diffBloch.preprocess.experiment import _mean_inner_potential
@@ -282,14 +287,20 @@ def test_converge_starting_g_max_falls_back_per_dataset_when_dstar_max_is_missin
     exp = _multi_experiment(tmp_path)
     cfg = load_config(exp / "experiment.yaml")
 
-    real_read = read_experimental_data
+    real_read = read_experimental_data_with_diagnostics
 
     def read_with_mixed_dstar_max(path):
-        record = real_read(path)
+        parsed = real_read(path)
         dstar = 1.4 if Path(path).name == "a.cif_pets" else None
-        return record.model_copy(update={"dstar_max": dstar})
+        return ParsedInput(
+            parsed.record.model_copy(update={"dstar_max": dstar}),
+            parsed.diagnostics,
+        )
 
-    monkeypatch.setattr("diffBloch.app.program.read_experimental_data", read_with_mixed_dstar_max)
+    monkeypatch.setattr(
+        "diffBloch.app.program.read_experimental_data_with_diagnostics",
+        read_with_mixed_dstar_max,
+    )
 
     starting: list[ConvergenceState] = []
 

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -25,6 +25,7 @@ from diffBloch.app.loggers import (
 )
 from diffBloch.app.loggers.comet import CometLogger
 from diffBloch.app.loggers.wandb import WandbLogger
+from diffBloch.io import ParseDiagnostic
 from diffBloch.observability import (
     ConvergencePassStarted,
     ConvergenceTrial,
@@ -276,6 +277,26 @@ def test_console_logger_formats_device_selection(caplog: pytest.LogCaptureFixtur
 
     assert caplog.records[-1].getMessage() == (
         "No CUDA detected, using CPU, diffBloch is optimized for CUDA"
+    )
+
+
+def test_console_logger_formats_input_parse_diagnostic(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger = ConsoleLogger(level=logging.INFO)
+    with caplog.at_level(logging.INFO, logger="diffBloch.loggers"):
+        logger.report(
+            ParseDiagnostic(
+                input_kind="experimental_data",
+                source_path=Path("exp_data.cif_pets"),
+                code="pets_summary_tag_used",
+                message="read PETS summary field(s) dstarmax from _diffrn_measurement_details",
+            )
+        )
+
+    assert caplog.records[-1].getMessage() == (
+        "Input │ experimental data │ exp_data.cif_pets │ "
+        "read PETS summary field(s) dstarmax from _diffrn_measurement_details"
     )
 
 


### PR DESCRIPTION
## Summary
- Structure CIF reader now picks the block with atom-site data instead of assuming a single block (Jana2020 exports add a boilerplate data_global block).
- Both readers now drop duplicate scalar tags within a block (some PETS2 builds restate _diffrn_radiation_wavelength), keeping the first value.
- PETS summary (dstarmax/mosaicity/geometry) is now read from either _diffrn_measurement_details or _diffrn_reflns_reduction_process.

## Test plan
- [x] pytest tests/unit — 714 passed
- [x] All example .cif/.cif_pets files parse correctly, values unchanged