### PR TITLE
docs: update docsite links and subscription form

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,30 +1,73 @@
-/* Splits the sidebar brand title and a GitHub icon link onto one row, below the logo.
-   Pairs with the sidebar/brand.html template override. */
-.sidebar-brand-row {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.4rem;
-  padding: 0 var(--sidebar-item-spacing-horizontal) var(--sidebar-item-spacing-vertical);
-}
-
-.sidebar-brand-title-link {
-  color: var(--color-sidebar-brand-text);
+.sidebar-brand-github-text {
+  display: block;
+  margin: -0.4rem var(--sidebar-item-spacing-horizontal) var(--sidebar-item-spacing-vertical);
+  color: var(--color-sidebar-link-text);
+  font-size: 0.875rem;
+  text-align: left;
   text-decoration: none;
 }
 
-.sidebar-brand-title-link .sidebar-brand-text {
-  font-size: 1.5rem;
-  overflow-wrap: break-word;
+.sidebar-brand-github-text:hover {
+  color: var(--color-sidebar-link-text--top-level);
+  text-decoration: underline;
 }
 
-.sidebar-brand-github-link {
-  display: inline-flex;
-  color: var(--color-sidebar-link-text);
-  opacity: 0.75;
-  transition: opacity 0.1s ease-in-out;
+.embeddable-buttondown-form {
+  display: grid;
+  grid-template-columns: minmax(14rem, 1fr) auto;
+  gap: 0.75rem;
+  align-items: end;
+  margin: 1rem 0 2rem;
+  padding: 1rem;
+  border: 1px solid var(--color-background-border);
+  border-radius: 0.5rem;
+  background: var(--color-background-secondary);
 }
 
-.sidebar-brand-github-link:hover {
-  opacity: 1;
+.embeddable-buttondown-form label {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--color-foreground-muted);
+  font-weight: 600;
+}
+
+.embeddable-buttondown-form input[type="email"] {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 2.5rem;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--color-background-border);
+  border-radius: 0.25rem;
+  background: var(--color-background-primary);
+  color: var(--color-foreground-primary);
+  font: inherit;
+}
+
+.embeddable-buttondown-form input[type="email"]:focus {
+  border-color: var(--color-brand-primary);
+  outline: 2px solid var(--color-brand-primary);
+  outline-offset: 2px;
+}
+
+.embeddable-buttondown-form input[type="submit"] {
+  min-height: 2.5rem;
+  padding: 0.45rem 0.85rem;
+  border: 1px solid var(--color-brand-primary);
+  border-radius: 0.25rem;
+  background: var(--color-brand-primary);
+  color: var(--color-background-primary);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.embeddable-buttondown-form input[type="submit"]:hover {
+  background: var(--color-brand-content);
+  border-color: var(--color-brand-content);
+}
+
+@media (max-width: 40rem) {
+  .embeddable-buttondown-form {
+    grid-template-columns: 1fr;
+  }
 }

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,0 +1,73 @@
+{% extends "!page.html" %}
+
+{% block footer %}
+<div class="related-pages">
+  {% if next -%}
+    <a class="next-page" href="{{ next.link }}">
+      <div class="page-info">
+        <div class="context">
+          <span>{{ _("Next") }}</span>
+        </div>
+        <div class="title">{{ next.title }}</div>
+      </div>
+      <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
+    </a>
+  {%- endif %}
+  {% if prev -%}
+    <a class="prev-page" href="{{ prev.link }}">
+      <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
+      <div class="page-info">
+        <div class="context">
+          <span>{{ _("Previous") }}</span>
+        </div>
+        {% if prev.link == pathto(master_doc) %}
+        <div class="title">{{ _("Home") }}</div>
+        {% else %}
+        <div class="title">{{ prev.title }}</div>
+        {% endif %}
+      </div>
+    </a>
+  {%- endif %}
+</div>
+<div class="bottom-of-page">
+  <div class="left-details">
+    {%- if show_copyright %}
+    <div class="copyright">
+      {%- if hasdoc('copyright') %}
+        <a href="{{ pathto('copyright') }}">Copyright</a> &#169; 2026,
+        <a href="https://github.com/Differentiable-Electron-Crystallography/diffBloch" target="_blank" rel="noopener noreferrer">diffBloch contributors</a>
+      {%- else %}
+        Copyright &#169; 2026,
+        <a href="https://github.com/Differentiable-Electron-Crystallography/diffBloch" target="_blank" rel="noopener noreferrer">diffBloch contributors</a>
+      {%- endif %}
+    </div>
+    {%- endif %}
+    Docsite made with
+    {% if show_sphinx -%}
+    {% trans %}<a href="https://www.sphinx-doc.org/">Sphinx</a> and {% endtrans -%}
+    <a class="muted-link" href="https://pradyunsg.me">@pradyunsg</a>'s
+    {% endif -%}
+    {% trans %}
+    <a href="https://github.com/pradyunsg/furo">Furo</a>
+    {% endtrans %}
+    {%- if last_updated -%}
+    <div class="last-updated">
+      {% trans last_updated=last_updated|e -%}
+        Last updated on {{ last_updated }}
+      {%- endtrans -%}
+    </div>
+    {%- endif %}
+  </div>
+  <div class="right-details">
+    {% if theme_footer_icons -%}
+    <div class="icons">
+      {% for icon_dict in theme_footer_icons -%}
+      <a class="muted-link {{ icon_dict.class }}" href="{{ icon_dict.url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ icon_dict.name }}">
+        {{- icon_dict.html -}}
+      </a>
+      {% endfor %}
+    </div>
+    {%- endif %}
+  </div>
+</div>
+{% endblock footer %}

--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -1,33 +1,21 @@
-{#-
-Overrides furo's default sidebar/brand.html to place a GitHub icon link next to the project
-title, below the logo. The upstream template wraps logo+title in a single <a> to the home page;
-that can't also contain a second link to GitHub (nested <a> tags are invalid), so the title row
-is split out into its own flex row with two sibling links instead.
--#}
-{%- if logo_url %}
-<a class="sidebar-brand centered" href="{{ pathto(master_doc) }}">
+<a class="sidebar-brand{% if logo %} centered{% endif %}" href="{{ pathto(master_doc) }}">
+  {%- block brand_content %}
+  {%- if logo_url %}
   <div class="sidebar-logo-container">
     <img class="sidebar-logo" src="{{ logo_url }}" alt="Logo"/>
   </div>
-</a>
-{%- endif %}
-{%- if theme_light_logo and theme_dark_logo %}
-<a class="sidebar-brand centered" href="{{ pathto(master_doc) }}">
+  {%- endif %}
+  {%- if theme_light_logo and theme_dark_logo %}
   <div class="sidebar-logo-container">
     <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="Light Logo"/>
     <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="Dark Logo"/>
   </div>
+  {%- endif %}
+  {% if not theme_sidebar_hide_name %}
+  <span class="sidebar-brand-text">{{ docstitle if docstitle else project }}</span>
+  {%- endif %}
+  {% endblock brand_content %}
 </a>
-{%- endif %}
-{% if not theme_sidebar_hide_name %}
-<div class="sidebar-brand-row">
-  <a class="sidebar-brand-title-link" href="{{ pathto(master_doc) }}">
-    <span class="sidebar-brand-text">{{ docstitle if docstitle else project }}</span>
-  </a>
-  <a class="sidebar-brand-github-link" href="https://github.com/Differentiable-Electron-Crystallography/diffBloch" target="_blank" rel="noopener noreferrer" aria-label="View diffBloch on GitHub">
-    <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
-      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
-    </svg>
-  </a>
-</div>
-{%- endif %}
+<a class="sidebar-brand-github-text" href="https://github.com/Differentiable-Electron-Crystallography/diffBloch" target="_blank" rel="noopener noreferrer">
+  github
+</a>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,6 +126,19 @@ html_css_files = ["custom.css"]
 html_logo = "_static/logo.png"
 ogp_site_url = html_baseurl
 
-# templates/sidebar/brand.html overrides furo's default to add a GitHub icon link next to the
-# sidebar title.
+html_theme_options = {
+    "footer_icons": [
+        {
+            "name": "GitHub",
+            "url": _REPO_URL,
+            "html": """
+                <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
+                </svg>
+            """,
+            "class": "",
+        },
+    ],
+}
+
 templates_path = ["_templates"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,21 @@ If diffBloch is used in research, please cite it as:
 }
 ```
 
+## Subscribe
+
+Subscribe to the diffBloch mailing list for occasional usage guides, release updates, and research
+papers that use diffBloch.
+
+<form
+  action="https://buttondown.com/api/emails/embed-subscribe/diffBloch"
+  method="post"
+  class="embeddable-buttondown-form"
+>
+  <label for="bd-email">Enter your email</label>
+  <input type="email" name="email" id="bd-email" />
+  <input type="submit" value="Subscribe" />
+</form>
+
 ```{toctree}
 :hidden:
 :caption: Guides


### PR DESCRIPTION
## Summary

This PR updates the documentation site navigation and footer surfaces so repository links are easier to find and attribution text matches the desired site language. It also adds a Buttondown mailing-list form to the landing page after the citation block, styled with Furo theme variables so it works in light and dark modes.

## What changed

### Landing page subscription form

- Added a `Subscribe` section to `docs/index.md` immediately after the citation block.
- Used Buttondown's direct embeddable HTML form endpoint instead of an iframe.
- Omitted the Buttondown referral paragraph so the rendered form does not show "Powered by Buttondown."

### Sidebar repository link

- Reworked `docs/_templates/sidebar/brand.html` to keep Furo's logo/title home link while adding a plain text `github` link underneath the brand area.
- Removed the previous iconographic GitHub treatment next to the sidebar title.
- Styled the text link in `docs/_static/custom.css` with Furo sidebar color variables and left alignment.

### Footer repository and attribution links

- Added Furo `footer_icons` configuration in `docs/conf.py` so the GitHub icon link appears in the footer.
- Added `docs/_templates/page.html` to override Furo's footer block and change the footer wording from "Made with ..." to "Docsite made with ...".
- Made `diffBloch contributors` in the copyright line link to the GitHub repository and open in a new tab with `target="_blank"` and `rel="noopener noreferrer"`.

### Form styling

- Reused `docs/_static/custom.css` for the Buttondown form.
- Styled the form with Furo variables for background, borders, foreground text, focus state, and brand-colored submit button.
- Added a narrow-screen media rule so the email input and submit button stack cleanly.

## Architecture & data flow

```mermaid
flowchart TD
    A[docs/index.md] --> B[Sphinx / MyST]
    C[docs/conf.py] --> B
    D[docs/_templates/sidebar/brand.html] --> B
    E[docs/_templates/page.html] --> B
    F[docs/_static/custom.css] --> B
    B --> G[Rendered Furo HTML]
    G --> H[Sidebar github text link]
    G --> I[Footer GitHub icon and contributor link]
    G --> J[Buttondown subscribe form]
```

## Design decisions & tradeoffs

**Decision:** Use Buttondown's direct form markup rather than the iframe embed.

**Alternatives considered:** Keep the iframe and rely on Buttondown's embedded styling, or build a custom JavaScript integration against Buttondown's API.

**Tradeoff:** The direct form is simpler and removes unwanted referral text, but the form styling is now owned by the docs site and may need maintenance if Buttondown changes expected fields.

**Rationale:** The requested output was a visible native form without "Powered by Buttondown." Static HTML is enough for that and keeps the docs build simple.

**Decision:** Override Furo templates for sidebar brand and footer customization.

**Alternatives considered:** Use only `html_theme_options`, CSS-only manipulation, or post-process generated HTML.

**Tradeoff:** Template overrides are explicit and stable at build time, but they duplicate portions of Furo markup and can drift when Furo changes its upstream template structure.

**Rationale:** The requested footer text and contributor link are not exposed as narrow Furo configuration knobs, so an override is the cleanest Sphinx-native path.

**Decision:** Keep styling in `docs/_static/custom.css` and use Furo CSS variables.

**Alternatives considered:** Inline styles in Markdown or no styling beyond browser defaults.

**Tradeoff:** A stylesheet adds one more source file to maintain, but it keeps authored Markdown clean and lets the form adapt to Furo light/dark theme variables.

**Rationale:** The form should look like part of the docsite, not an unstyled third-party widget.

## Honest assessment

**What:** `docs/_templates/page.html` duplicates much of Furo's footer block.

**Where:** `docs/_templates/page.html`

**Why it's wrong:** This is vulnerable to upstream Furo template drift. If Furo changes related-page navigation, footer icon rendering, Read the Docs handling, or accessibility attributes, this local copy will not inherit those fixes automatically.

**What "right" looks like:** A narrower upstream-supported footer text option, a smaller override hook, or a custom Furo extension point that only replaces the attribution phrase and contributor markup.

**Severity:** Tech debt to track.

**What:** The Buttondown form posts directly to a third-party endpoint without local validation beyond `type="email"`.

**Where:** `docs/index.md`

**Why it's wrong:** Browser email validation is minimal, and failed submissions depend entirely on Buttondown's response page. There is no local UX for required fields, success state, or error state.

**What "right" looks like:** Add `required`, consider a minimal explanatory failure path, or use a small progressive-enhancement script if the docsite later wants inline success/error messaging.

**Severity:** Fix soon after if subscription conversion or UX matters; acceptable for a static docs form.

**What:** Repository URLs are hardcoded in templates and config.

**Where:** `docs/conf.py`, `docs/_templates/sidebar/brand.html`, `docs/_templates/page.html`

**Why it's wrong:** The same URL is repeated across multiple files, so future repository moves or organization renames require coordinated edits.

**What "right" looks like:** Expose a single `repo_url` template variable from `conf.py` and reference it from templates, or centralize these links in Furo theme options where possible.

**Severity:** Tech debt to track.

## File-by-file changes

| File | Change |
|---|---|
| `docs/index.md` | Adds the landing-page Subscribe section and Buttondown form after Citation. |
| `docs/conf.py` | Configures `custom.css`, Furo footer GitHub icon, and template override path. |
| `docs/_static/custom.css` | Replaces old sidebar icon-link styling with sidebar text-link styling and Buttondown form styles. |
| `docs/_templates/sidebar/brand.html` | Keeps the Furo brand home link and adds a plain text new-tab `github` link under the logo/title. |
| `docs/_templates/page.html` | Overrides the Furo footer to change attribution text and link GitHub surfaces to the repo with safe new-tab behavior. |

## Testing

Validated both documentation build outputs:

```bash
uv run sphinx-build -W -b html docs site
just docs
```

Both builds completed successfully with Sphinx warnings treated as errors.

## Migration & compatibility

No API, data, or runtime migration is required. This changes only the rendered documentation site.
