### PR TITLE
docs: tighten mailing list copy

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ diffBloch performs the refinement as two complementary values: a crystal structu
 
 ### Command line
 
-The command-line interface (CLI) runs diffBloch from a terminal. This is the standard way to run a complete experiment. 
+The command-line interface (CLI) runs diffBloch from a terminal. This is the standard way to run a complete experiment.
 
 `uv` installs the required Python packages and runs diffBloch inside the
 project environment. Git LFS downloads the larger experimental-data files stored in the repository.
@@ -82,7 +82,7 @@ If diffBloch is used in research, please cite it as:
 ## Subscribe
 
 Subscribe to the diffBloch mailing list for occasional usage guides, release updates, and research
-papers that use diffBloch.
+papers.
 
 <form
   action="https://buttondown.com/api/emails/embed-subscribe/diffBloch"


### PR DESCRIPTION
## Summary

This PR tightens the home-page mailing-list copy by removing the redundant phrase "that use diffBloch" from the research-papers clause. It also includes the trailing-whitespace cleanup that the repository's commit hook enforced on the same Markdown file.

## What changed

`docs/index.md` now says the mailing list covers "occasional usage guides, release updates, and research papers." This keeps the sentence shorter and avoids repeating the project name immediately after the section and sentence have already named diffBloch.

The same file also drops a trailing space after the CLI quickstart sentence. This was applied by the pre-commit trailing-whitespace hook during commit creation and is unrelated to rendered content.

## Architecture & data flow

The change is content-only. It affects the authored Markdown source that Sphinx/MyST renders into the documentation site's home page.

```mermaid
flowchart LR
    A[docs/index.md] --> B[MyST parser]
    B --> C[Sphinx HTML build]
    C --> D[Rendered docsite home page]
```

## Design decisions & tradeoffs

**Decision**: Remove only "that use diffBloch" and leave the rest of the subscribe section unchanged.

**Alternatives considered**: Rewrite the whole subscribe paragraph or move the form to another page.

**Tradeoff**: This keeps the PR small and reviewable, but does not revisit the broader information architecture of the home page.

**Rationale**: The user-visible issue was a redundant clause, so a narrow copy edit is the correct scope.

## Honest assessment

1. **What**: No browser screenshot was captured after the copy change.
   **Where**: Rendered `docs/index.md` home page.
   **Why it's wrong**: For visual documentation changes, rendered verification can catch awkward wrapping or spacing that a source diff cannot.
   **What "right" looks like**: Capture a rendered home-page screenshot as part of docsite UI changes, especially when layout or form styling changes.
   **Severity**: Tech debt to track. This PR changes only text and passes the strict Sphinx build, so this should not block merge.

2. **What**: The commit includes trailing-whitespace cleanup adjacent to the requested change.
   **Where**: `docs/index.md`, the CLI quickstart sentence.
   **Why it's wrong**: It is not semantically related to the mailing-list copy edit.
   **What "right" looks like**: Ideally, trailing whitespace would already be absent on `main`, or cleanup would be separated when it spans more than the touched file.
   **Severity**: Tech debt to track. The cleanup is in the same file, enforced by the repo hook, and harmless.

## File-by-file changes

| File | Change |
|---|---|
| `docs/index.md` | Removes the redundant "that use diffBloch" phrase from subscribe copy and removes one trailing space enforced by the commit hook. |

## Testing

Ran:

```bash
uv run sphinx-build -W -b html docs site
```

The strict Sphinx build passed.
