### PR TITLE
Add diffbloch lock command and auto-create missing experiment.lock

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -85,9 +85,11 @@ Running preprocessing or refinement adds results to the experiment directory:
 | `reproducibility/refined_parameters.npz` | Refined parameter values. |
 | `reproducibility/refinement.lock` | Inputs and settings used for the refinement. |
 
-`reproducibility/experiment.lock` is not one of these -- it identifies the input files, not a
-calculation result. It is created automatically the first time any command runs against the
-experiment directory; see [Reproducibility](reproducibility.md#input-files).
+`reproducibility/experiment.lock` is not one of these calculation outputs. It identifies the raw
+input files accepted for the experiment and is created automatically the first time any command runs
+against the experiment directory. See [Reproducibility](reproducibility.md#input-files) for the
+create-only `lock-experiment` command and the warning about invalidating plan and refinement locks
+after input changes.
 
 See [Refinement](refinement.md#refinement-outputs) for the refinement report and
 [Reproducibility](reproducibility.md) for the lock files.

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -80,11 +80,14 @@ Running preprocessing or refinement adds results to the experiment directory:
 | `refinement_report.txt` | Final residuals, reflection counts, and refinement summary. |
 | `thickness_optim/` | Thickness-search plots when plotting is enabled. |
 | `thickness_nn_shape_<stem>.png` | Learned thickness curve per `.cif_pets` dataset, when the thickness network and plotting are enabled. |
-| `reproducibility/experiment.lock` | Record of the input files. |
 | `reproducibility/plan.<stem>.npz` | Saved preprocessing for each `.cif_pets` dataset. |
 | `reproducibility/plan.<stem>.lock` | Inputs and settings used for the saved preprocessing. |
 | `reproducibility/refined_parameters.npz` | Refined parameter values. |
 | `reproducibility/refinement.lock` | Inputs and settings used for the refinement. |
+
+`reproducibility/experiment.lock` is not one of these -- it identifies the input files, not a
+calculation result. It is created automatically the first time any command runs against the
+experiment directory; see [Reproducibility](reproducibility.md#input-files).
 
 See [Refinement](refinement.md#refinement-outputs) for the refinement report and
 [Reproducibility](reproducibility.md) for the lock files.

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -16,15 +16,28 @@ are stored in the experiment directory under `reproducibility/`.
 file change. This prevents a calculation from using input files that differ from those recorded for
 the experiment.
 
-`experiment.lock` is created automatically, from the current input files, the first time any command
-(`converge`, `preprocess`, `infer`, `refine`) runs against an experiment directory that doesn't have
-one yet. After that, if an input file's contents change, the lock is *not* rewritten automatically --
-the mismatch is exactly the drift this file exists to catch, so the command fails instead. Rewrite it
-explicitly once the change is intentional:
+`experiment.lock` is a raw-input blessing gate. It is created automatically, from the current input
+files, the first time any command (`converge`, `preprocess`, `infer`, `refine`) runs against an
+experiment directory that doesn't have one yet. After that, if an input file's contents change, the
+lock is not rewritten automatically. The mismatch is exactly the drift this file exists to catch, so
+the command fails instead.
+
+To create the lock explicitly for a new experiment, run:
 
 ```bash
-uv run diffbloch lock <experiment_dir>
+uv run diffbloch lock-experiment <experiment_dir>
 ```
+
+This command fails if `reproducibility/experiment.lock` already exists. When a CIF or `.cif_pets`
+input change is intentional, either delete `experiment.lock` and rerun, or force a rewrite:
+
+```bash
+uv run diffbloch lock-experiment --force <experiment_dir>
+```
+
+Warning: accepting changed input bytes invalidates existing `plan.<stem>.lock` files and any
+`refinement.lock` chained to them. The next checkpointed preprocessing run will regenerate stale
+plan checkpoints; refinement outputs must be regenerated against the new plans.
 
 ## Preprocessing
 

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -16,6 +16,16 @@ are stored in the experiment directory under `reproducibility/`.
 file change. This prevents a calculation from using input files that differ from those recorded for
 the experiment.
 
+`experiment.lock` is created automatically, from the current input files, the first time any command
+(`converge`, `preprocess`, `infer`, `refine`) runs against an experiment directory that doesn't have
+one yet. After that, if an input file's contents change, the lock is *not* rewritten automatically --
+the mismatch is exactly the drift this file exists to catch, so the command fails instead. Rewrite it
+explicitly once the change is intentional:
+
+```bash
+uv run diffbloch lock <experiment_dir>
+```
+
 ## Preprocessing
 
 Preprocessing results are saved under `reproducibility/` so they can be reused. Combined experiments

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -51,6 +51,16 @@ output is one calculated diffraction pattern for each experimental rotation.
 
 For more information, see [Inputs and outputs](inputs.md).
 
+Every command below verifies the structure CIF and `.cif_pets` file(s) against a checksum recorded in
+`reproducibility/experiment.lock`, creating that lock automatically the first time it runs. If those
+input files intentionally change afterward, refresh the lock explicitly:
+
+```bash
+uv run diffbloch lock <experiment_dir>
+```
+
+See [Reproducibility](reproducibility.md#input-files).
+
 ## Convergence testing
 
 The convergence test determines suitable values for the main simulation hyperparameters:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -52,12 +52,23 @@ output is one calculated diffraction pattern for each experimental rotation.
 For more information, see [Inputs and outputs](inputs.md).
 
 Every command below verifies the structure CIF and `.cif_pets` file(s) against a checksum recorded in
-`reproducibility/experiment.lock`, creating that lock automatically the first time it runs. If those
-input files intentionally change afterward, refresh the lock explicitly:
+`reproducibility/experiment.lock`, creating that lock automatically the first time it runs. This file
+is a raw-input blessing gate: if those input bytes change later, the command fails instead of
+rewriting the lock. For a new experiment, the lock can also be created explicitly:
 
 ```bash
-uv run diffbloch lock <experiment_dir>
+uv run diffbloch lock-experiment <experiment_dir>
 ```
+
+That command refuses to overwrite an existing lock. After an intentional CIF or `.cif_pets` change,
+delete `experiment.lock` and rerun, or force a rewrite:
+
+```bash
+uv run diffbloch lock-experiment --force <experiment_dir>
+```
+
+Warning: accepting changed input bytes invalidates existing plan and refinement locks, so
+preprocessing and refinement outputs must be regenerated.
 
 See [Reproducibility](reproducibility.md#input-files).
 

--- a/src/diffBloch/app/cli.py
+++ b/src/diffBloch/app/cli.py
@@ -25,7 +25,7 @@ from diffBloch.app.program import (
     refine_experiment,
     run_experiment,
 )
-from diffBloch.config import load_config
+from diffBloch.config import load_config, write_experiment_lock
 from diffBloch.engine.plan import OrientationPlanLike
 from diffBloch.observability import (
     NULL_LOGGER,
@@ -130,7 +130,9 @@ def main(argv: list[str] | None = None) -> int:
             "  diffbloch preprocess experiment/\n"
             "  diffbloch refine experiment/\n"
             "\n"
-            "Each command has its own flags; see e.g. 'diffbloch refine --help'."
+            "Each command has its own flags; see e.g. 'diffbloch refine --help'. "
+            "reproducibility/experiment.lock is created automatically on first run; "
+            "use 'diffbloch lock experiment/' to refresh it after inputs intentionally change."
         ),
     )
     parser.add_argument("--version", action="version", version=f"diffbloch {__version__}")
@@ -140,6 +142,14 @@ def main(argv: list[str] | None = None) -> int:
     # Registered in typical workflow order so the --help listing reads as the pipeline.
     p_validate = sub.add_parser("validate", help="Validate an experiment.yaml and report")
     p_validate.add_argument("config", help="Path to experiment.yaml")
+
+    p_lock = sub.add_parser(
+        "lock",
+        help="Rewrite reproducibility/experiment.lock from the current input files (other "
+        "commands create it automatically on first run; use this after inputs intentionally "
+        "change)",
+    )
+    p_lock.add_argument("experiment_directory", help="Path to the experiment directory")
 
     p_converge = sub.add_parser(
         "converge", help="Test convergence of g_max, sg_max, and rocking-curve tilt steps"
@@ -210,6 +220,28 @@ def main(argv: list[str] | None = None) -> int:
             print(f"error: {args.config}: {exc}", file=sys.stderr)
             return 1
         print(f"OK: experiment '{cfg.name}' validated.")
+        return 0
+
+    if args.command == "lock":
+        try:
+            experiment_lock = write_experiment_lock(args.experiment_directory)
+        except (FileNotFoundError, ValidationError, yaml.YAMLError) as exc:
+            if args.debug:
+                raise
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        lock_path = (
+            Path(args.experiment_directory) / "reproducibility" / "experiment.lock"
+        ).resolve()
+        refs = (
+            [entry.ref for entry in experiment_lock.experimental_data]
+            if isinstance(experiment_lock.experimental_data, list)
+            else [experiment_lock.experimental_data.ref]
+        )
+        print(f"wrote {lock_path}")
+        print(f"  • {'Structure':<20} {experiment_lock.structure.ref}")
+        for ref in refs:
+            print(f"  • {'Experimental data':<20} {ref}")
         return 0
 
     if args.command == "infer":

--- a/src/diffBloch/app/cli.py
+++ b/src/diffBloch/app/cli.py
@@ -132,7 +132,8 @@ def main(argv: list[str] | None = None) -> int:
             "\n"
             "Each command has its own flags; see e.g. 'diffbloch refine --help'. "
             "reproducibility/experiment.lock is created automatically on first run; "
-            "use 'diffbloch lock experiment/' to refresh it after inputs intentionally change."
+            "use 'diffbloch lock-experiment --force experiment/' to refresh it after inputs "
+            "intentionally change."
         ),
     )
     parser.add_argument("--version", action="version", version=f"diffbloch {__version__}")
@@ -143,13 +144,18 @@ def main(argv: list[str] | None = None) -> int:
     p_validate = sub.add_parser("validate", help="Validate an experiment.yaml and report")
     p_validate.add_argument("config", help="Path to experiment.yaml")
 
-    p_lock = sub.add_parser(
-        "lock",
-        help="Rewrite reproducibility/experiment.lock from the current input files (other "
-        "commands create it automatically on first run; use this after inputs intentionally "
-        "change)",
+    p_lock_experiment = sub.add_parser(
+        "lock-experiment",
+        help="Create reproducibility/experiment.lock from the current input files (other commands "
+        "create it automatically on first run; existing locks require --force)",
     )
-    p_lock.add_argument("experiment_directory", help="Path to the experiment directory")
+    p_lock_experiment.add_argument(
+        "--force",
+        action="store_true",
+        help="rewrite an existing experiment.lock after an intentional input change; this "
+        "invalidates existing plan and refinement locks",
+    )
+    p_lock_experiment.add_argument("experiment_directory", help="Path to the experiment directory")
 
     p_converge = sub.add_parser(
         "converge", help="Test convergence of g_max, sg_max, and rocking-curve tilt steps"
@@ -222,26 +228,32 @@ def main(argv: list[str] | None = None) -> int:
         print(f"OK: experiment '{cfg.name}' validated.")
         return 0
 
-    if args.command == "lock":
+    if args.command == "lock-experiment":
+        lock_path = (
+            Path(args.experiment_directory) / "reproducibility" / "experiment.lock"
+        ).resolve()
+        replacing = lock_path.exists()
         try:
-            experiment_lock = write_experiment_lock(args.experiment_directory)
-        except (FileNotFoundError, ValidationError, yaml.YAMLError) as exc:
+            experiment_lock = write_experiment_lock(args.experiment_directory, force=args.force)
+        except (FileExistsError, FileNotFoundError, ValidationError, yaml.YAMLError) as exc:
             if args.debug:
                 raise
             print(f"error: {exc}", file=sys.stderr)
             return 1
-        lock_path = (
-            Path(args.experiment_directory) / "reproducibility" / "experiment.lock"
-        ).resolve()
         refs = (
             [entry.ref for entry in experiment_lock.experimental_data]
             if isinstance(experiment_lock.experimental_data, list)
             else [experiment_lock.experimental_data.ref]
         )
-        print(f"wrote {lock_path}")
-        print(f"  • {'Structure':<20} {experiment_lock.structure.ref}")
+        print(f"{'rewrote' if replacing else 'wrote'} {lock_path}")
+        if replacing:
+            print(
+                "warning: if this accepts changed input bytes, existing plan and refinement locks "
+                "are invalid and must be regenerated"
+            )
+        print(f"  - {'Structure':<20} {experiment_lock.structure.ref}")
         for ref in refs:
-            print(f"  • {'Experimental data':<20} {ref}")
+            print(f"  - {'Experimental data':<20} {ref}")
         return 0
 
     if args.command == "infer":

--- a/src/diffBloch/config/__init__.py
+++ b/src/diffBloch/config/__init__.py
@@ -18,6 +18,7 @@ from diffBloch.config.manifest import (
     read_refinement_lock,
     refinement_config_digest,
     sha256_file,
+    write_experiment_lock,
     write_preprocess_lock,
     write_refinement_lock,
 )
@@ -54,6 +55,7 @@ __all__ = [
     "read_refinement_lock",
     "refinement_config_digest",
     "sha256_file",
+    "write_experiment_lock",
     "write_preprocess_lock",
     "write_refinement_lock",
 ]

--- a/src/diffBloch/config/manifest.py
+++ b/src/diffBloch/config/manifest.py
@@ -151,14 +151,15 @@ def artifact_hash_for(path: str | Path, *, root: str | Path) -> ArtifactHash:
 
 def load_experiment(directory: str | Path) -> tuple[ExperimentConfig, ExperimentLock]:
     """Load ``experiment.yaml``, verifying ``experiment.lock`` (in ``reproducibility/``) against
-    input bytes -- creating that lock first, from the current input bytes, if it doesn't exist yet.
+    input bytes, creating that lock first from the current input bytes if it doesn't exist yet.
 
     First-run convenience: a brand-new experiment directory has no lock to verify against, so there
-    is nothing to protect by refusing to proceed -- the lock is created here instead, exactly as
+    is nothing to protect by refusing to proceed. The lock is created here instead, exactly as
     :func:`write_experiment_lock` would. An *existing* lock that no longer matches the input bytes
     still raises (see :func:`_verify_input`): that mismatch is the drift this file exists to catch,
-    and silently rewriting it on every run would defeat the purpose. Rerun ``diffbloch lock`` (or
-    :func:`write_experiment_lock`) to update the lock after an intentional input change.
+    and silently rewriting it on every run would defeat the purpose. Delete the lock and rerun, or
+    use ``diffbloch lock-experiment --force`` (or
+    ``write_experiment_lock(..., force=True)``), to update it after an intentional input change.
     """
     root = Path(directory)
     cfg = load_config(root / "experiment.yaml")
@@ -174,21 +175,26 @@ def load_experiment(directory: str | Path) -> tuple[ExperimentConfig, Experiment
     return cfg, lock
 
 
-def write_experiment_lock(directory: str | Path) -> ExperimentLock:
+def write_experiment_lock(directory: str | Path, *, force: bool = False) -> ExperimentLock:
     """Hash ``inputs.structure`` and every ``inputs.exp_data`` file and write
     ``reproducibility/experiment.lock`` (creating that directory if needed).
 
-    The ``diffbloch lock`` CLI command's implementation, for explicitly (re)creating the lock --
-    :func:`load_experiment` also creates one automatically on first run, but only when none exists
-    yet; use this to refresh an *existing* lock after an intentional input change (an existing lock
-    that merely mismatches is deliberately treated as drift there, not silently rewritten). Safe to
-    rerun: it always reflects the current input bytes, so rerunning with unchanged inputs reproduces
-    the lock byte-for-byte.
+    The ``diffbloch lock-experiment`` CLI command's implementation. By default this creates a lock
+    only when none exists yet: an existing lock is the experiment's accepted input baseline, so
+    replacing it requires ``force=True``. Use ``force=True`` only after an intentional input change.
+    With unchanged inputs, a forced rewrite reproduces the lock byte-for-byte. If the input bytes
+    changed, replacing the experiment lock invalidates existing plan and refinement locks.
     """
     root = Path(directory)
     cfg = load_config(root / "experiment.yaml")
+    lock_path = root / "reproducibility" / "experiment.lock"
+    if lock_path.exists() and not force:
+        raise FileExistsError(
+            f"{lock_path} already exists; remove it or rerun with --force to replace it "
+            "(replacing it after input changes invalidates existing plan and refinement locks)"
+        )
     lock = _build_experiment_lock(root, cfg)
-    _write_experiment_lock_file(root / "reproducibility" / "experiment.lock", lock)
+    _write_experiment_lock_file(lock_path, lock)
     return lock
 
 

--- a/src/diffBloch/config/manifest.py
+++ b/src/diffBloch/config/manifest.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import mimetypes
 import subprocess
 from pathlib import Path
@@ -21,6 +22,8 @@ from diffBloch import __version__
 from diffBloch.config.schema import ExperimentConfig, load_config
 
 type CellParameters = tuple[float, float, float, float, float, float]
+
+_log = logging.getLogger(__name__)
 
 
 class InputLock(BaseModel):
@@ -147,15 +150,62 @@ def artifact_hash_for(path: str | Path, *, root: str | Path) -> ArtifactHash:
 
 
 def load_experiment(directory: str | Path) -> tuple[ExperimentConfig, ExperimentLock]:
-    """Load ``experiment.yaml`` and verify ``experiment.lock`` (in ``reproducibility/``) against
-    input bytes."""
+    """Load ``experiment.yaml``, verifying ``experiment.lock`` (in ``reproducibility/``) against
+    input bytes -- creating that lock first, from the current input bytes, if it doesn't exist yet.
+
+    First-run convenience: a brand-new experiment directory has no lock to verify against, so there
+    is nothing to protect by refusing to proceed -- the lock is created here instead, exactly as
+    :func:`write_experiment_lock` would. An *existing* lock that no longer matches the input bytes
+    still raises (see :func:`_verify_input`): that mismatch is the drift this file exists to catch,
+    and silently rewriting it on every run would defeat the purpose. Rerun ``diffbloch lock`` (or
+    :func:`write_experiment_lock`) to update the lock after an intentional input change.
+    """
     root = Path(directory)
     cfg = load_config(root / "experiment.yaml")
     lock_path = root / "reproducibility" / "experiment.lock"
+    if not lock_path.exists():
+        lock = _build_experiment_lock(root, cfg)
+        _write_experiment_lock_file(lock_path, lock)
+        _log.info("created %s (no existing lock found)", lock_path)
+        return cfg, lock
     lock = ExperimentLock.model_validate(yaml.safe_load(lock_path.read_text()))
     _verify_input(root, cfg.inputs.structure, lock.structure)
     _verify_experimental_data(root, cfg.inputs.exp_data, lock.experimental_data)
     return cfg, lock
+
+
+def write_experiment_lock(directory: str | Path) -> ExperimentLock:
+    """Hash ``inputs.structure`` and every ``inputs.exp_data`` file and write
+    ``reproducibility/experiment.lock`` (creating that directory if needed).
+
+    The ``diffbloch lock`` CLI command's implementation, for explicitly (re)creating the lock --
+    :func:`load_experiment` also creates one automatically on first run, but only when none exists
+    yet; use this to refresh an *existing* lock after an intentional input change (an existing lock
+    that merely mismatches is deliberately treated as drift there, not silently rewritten). Safe to
+    rerun: it always reflects the current input bytes, so rerunning with unchanged inputs reproduces
+    the lock byte-for-byte.
+    """
+    root = Path(directory)
+    cfg = load_config(root / "experiment.yaml")
+    lock = _build_experiment_lock(root, cfg)
+    _write_experiment_lock_file(root / "reproducibility" / "experiment.lock", lock)
+    return lock
+
+
+def _build_experiment_lock(root: Path, cfg: ExperimentConfig) -> ExperimentLock:
+    """Hash ``cfg.inputs.structure`` and every ``cfg.inputs.exp_data`` file under ``root``."""
+    structure = input_lock_for(root / cfg.inputs.structure, ref=cfg.inputs.structure)
+    experimental_data: InputLock | list[InputLock]
+    if isinstance(cfg.inputs.exp_data, list):
+        experimental_data = [input_lock_for(root / ref, ref=ref) for ref in cfg.inputs.exp_data]
+    else:
+        experimental_data = input_lock_for(root / cfg.inputs.exp_data, ref=cfg.inputs.exp_data)
+    return ExperimentLock(structure=structure, experimental_data=experimental_data)
+
+
+def _write_experiment_lock_file(lock_path: Path, lock: ExperimentLock) -> None:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(lock.model_dump_json(indent=2) + "\n")
 
 
 def dataset_config_digest(config: ExperimentConfig, *, exp_data: str) -> str:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -63,7 +63,7 @@ def test_debug_flag_reraises(tmp_path: Path) -> None:
         main(["--debug", "validate", str(bad)])
 
 
-def test_lock_writes_the_experiment_lock(
+def test_lock_experiment_writes_the_experiment_lock(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     experiment = tmp_path / "experiment"
@@ -71,7 +71,7 @@ def test_lock_writes_the_experiment_lock(
     for name in ["experiment.yaml", "enantiomer_1.cif", "exp_data.cif_pets"]:
         (experiment / name).write_bytes((LOCKED / name).read_bytes())
 
-    rc = main(["lock", str(experiment)])
+    rc = main(["lock-experiment", str(experiment)])
 
     assert rc == 0
     lock_path = experiment / "reproducibility" / "experiment.lock"
@@ -82,10 +82,48 @@ def test_lock_writes_the_experiment_lock(
     assert "exp_data.cif_pets" in out
 
 
-def test_lock_missing_experiment_reports_concise_error(
+def test_lock_experiment_refuses_to_overwrite_an_existing_lock(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    experiment = tmp_path / "experiment"
+    experiment.mkdir()
+    for name in ["experiment.yaml", "enantiomer_1.cif", "exp_data.cif_pets"]:
+        (experiment / name).write_bytes((LOCKED / name).read_bytes())
+    assert main(["lock-experiment", str(experiment)]) == 0
+    capsys.readouterr()
+
+    rc = main(["lock-experiment", str(experiment)])
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert "already exists" in err
+
+
+def test_lock_experiment_force_rewrites_the_experiment_lock(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    experiment = tmp_path / "experiment"
+    experiment.mkdir()
+    for name in ["experiment.yaml", "enantiomer_1.cif", "exp_data.cif_pets"]:
+        (experiment / name).write_bytes((LOCKED / name).read_bytes())
+    assert main(["lock-experiment", str(experiment)]) == 0
+    (experiment / "enantiomer_1.cif").write_text("changed\n")
+    capsys.readouterr()
+
+    rc = main(["lock-experiment", "--force", str(experiment)])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "rewrote" in out
+    assert "warning:" in out
+    assert "plan and refinement locks" in out
+
+
+def test_lock_experiment_missing_experiment_reports_concise_error(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    rc = main(["lock", "/no/such/experiment"])
+    rc = main(["lock-experiment", "/no/such/experiment"])
     assert rc == 1
     err = capsys.readouterr().err
     assert err.startswith("error:")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -14,6 +14,7 @@ from diffBloch.observability import MultiLogger, NullLogger, OrientationOptimize
 from diffBloch.preprocess.inference import InferenceResult, RotationInference
 
 FIXTURE = Path(__file__).parent.parent / "fixtures" / "quartz_min" / "experiment.yaml"
+LOCKED = Path(__file__).parent.parent / "fixtures" / "locked_min"
 
 
 def _summary_row(out: str, label: str, value: str) -> bool:
@@ -60,6 +61,35 @@ def test_debug_flag_reraises(tmp_path: Path) -> None:
     bad.write_text("name: only-a-name\n")
     with pytest.raises(ValidationError):
         main(["--debug", "validate", str(bad)])
+
+
+def test_lock_writes_the_experiment_lock(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    experiment = tmp_path / "experiment"
+    experiment.mkdir()
+    for name in ["experiment.yaml", "enantiomer_1.cif", "exp_data.cif_pets"]:
+        (experiment / name).write_bytes((LOCKED / name).read_bytes())
+
+    rc = main(["lock", str(experiment)])
+
+    assert rc == 0
+    lock_path = experiment / "reproducibility" / "experiment.lock"
+    assert lock_path.exists()
+    out = capsys.readouterr().out
+    assert str(lock_path.resolve()) in out
+    assert "enantiomer_1.cif" in out
+    assert "exp_data.cif_pets" in out
+
+
+def test_lock_missing_experiment_reports_concise_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main(["lock", "/no/such/experiment"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert "Traceback" not in err
 
 
 def test_infer_delegates_to_run_experiment_and_reports(

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -21,6 +21,7 @@ from diffBloch.config import (
     read_refinement_lock,
     refinement_config_digest,
     sha256_file,
+    write_experiment_lock,
     write_preprocess_lock,
     write_refinement_lock,
 )
@@ -80,6 +81,76 @@ def test_load_experiment_detects_input_drift(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="input drift"):
         load_experiment(experiment)
+
+
+def test_load_experiment_creates_the_lock_on_first_run(tmp_path: Path) -> None:
+    """A brand-new experiment directory has nothing to verify against, so the first call to
+    ``load_experiment`` creates ``experiment.lock`` from the current input bytes rather than
+    failing."""
+    experiment = tmp_path / "experiment"
+    experiment.mkdir()
+    for name in ["experiment.yaml", "enantiomer_1.cif", "exp_data.cif_pets"]:
+        (experiment / name).write_bytes((LOCKED / name).read_bytes())
+    lock_path = experiment / "reproducibility" / "experiment.lock"
+    assert not lock_path.exists()
+
+    cfg, lock = load_experiment(experiment)
+
+    assert cfg.name == "locked-min"
+    assert lock_path.exists()
+    assert lock.structure.ref == "enantiomer_1.cif"
+    assert lock.structure.sha256 == sha256_file(experiment / "enantiomer_1.cif")
+    assert isinstance(lock.experimental_data, InputLock)
+    assert lock.experimental_data.ref == "exp_data.cif_pets"
+    # A second call reads back the now-existing lock rather than recreating it, and agrees.
+    _cfg, reloaded = load_experiment(experiment)
+    assert reloaded == lock
+
+
+def test_load_experiment_does_not_silently_rewrite_a_mismatched_lock(tmp_path: Path) -> None:
+    """Auto-creation only covers a missing lock; a lock that exists but no longer matches the
+    input bytes must still raise (see test_load_experiment_detects_input_drift), never be
+    silently regenerated -- that mismatch is the drift this file exists to catch."""
+    experiment = tmp_path / "experiment"
+    experiment.mkdir()
+    (experiment / "reproducibility").mkdir()
+    for name in ["experiment.yaml", "enantiomer_1.cif", "exp_data.cif_pets"]:
+        (experiment / name).write_bytes((LOCKED / name).read_bytes())
+    (experiment / "reproducibility" / "experiment.lock").write_bytes(
+        (LOCKED / "reproducibility" / "experiment.lock").read_bytes()
+    )
+    (experiment / "enantiomer_1.cif").write_text("changed\n")
+
+    with pytest.raises(ValueError, match="input drift"):
+        load_experiment(experiment)
+
+
+def test_write_experiment_lock_creates_a_lock_load_experiment_then_accepts(tmp_path: Path) -> None:
+    experiment = tmp_path / "experiment"
+    experiment.mkdir()
+    for name in ["experiment.yaml", "enantiomer_1.cif", "exp_data.cif_pets"]:
+        (experiment / name).write_bytes((LOCKED / name).read_bytes())
+
+    lock = write_experiment_lock(experiment)
+
+    assert lock.structure.ref == "enantiomer_1.cif"
+    assert lock.structure.sha256 == sha256_file(experiment / "enantiomer_1.cif")
+    assert isinstance(lock.experimental_data, InputLock)
+    assert lock.experimental_data.ref == "exp_data.cif_pets"
+    cfg, loaded = load_experiment(experiment)
+    assert loaded == lock
+    assert cfg.name == "locked-min"
+
+
+def test_write_experiment_lock_is_reproducible(tmp_path: Path) -> None:
+    experiment = tmp_path / "experiment"
+    experiment.mkdir()
+    for name in ["experiment.yaml", "enantiomer_1.cif", "exp_data.cif_pets"]:
+        (experiment / name).write_bytes((LOCKED / name).read_bytes())
+
+    first = write_experiment_lock(experiment)
+    second = write_experiment_lock(experiment)
+    assert first == second
 
 
 def test_experiment_lock_accepts_a_list_of_input_locks_for_pooled_datasets() -> None:

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -142,14 +142,46 @@ def test_write_experiment_lock_creates_a_lock_load_experiment_then_accepts(tmp_p
     assert cfg.name == "locked-min"
 
 
-def test_write_experiment_lock_is_reproducible(tmp_path: Path) -> None:
+def test_write_experiment_lock_refuses_to_replace_an_existing_lock_by_default(
+    tmp_path: Path,
+) -> None:
+    experiment = tmp_path / "experiment"
+    experiment.mkdir()
+    for name in ["experiment.yaml", "enantiomer_1.cif", "exp_data.cif_pets"]:
+        (experiment / name).write_bytes((LOCKED / name).read_bytes())
+
+    write_experiment_lock(experiment)
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        write_experiment_lock(experiment)
+
+
+def test_write_experiment_lock_force_rewrites_after_intentional_input_change(
+    tmp_path: Path,
+) -> None:
+    experiment = tmp_path / "experiment"
+    experiment.mkdir()
+    for name in ["experiment.yaml", "enantiomer_1.cif", "exp_data.cif_pets"]:
+        (experiment / name).write_bytes((LOCKED / name).read_bytes())
+    first = write_experiment_lock(experiment)
+    (experiment / "enantiomer_1.cif").write_text("changed\n")
+
+    second = write_experiment_lock(experiment, force=True)
+
+    assert first != second
+    assert second.structure.sha256 == sha256_file(experiment / "enantiomer_1.cif")
+    _cfg, loaded = load_experiment(experiment)
+    assert loaded == second
+
+
+def test_write_experiment_lock_force_is_reproducible_for_unchanged_inputs(tmp_path: Path) -> None:
     experiment = tmp_path / "experiment"
     experiment.mkdir()
     for name in ["experiment.yaml", "enantiomer_1.cif", "exp_data.cif_pets"]:
         (experiment / name).write_bytes((LOCKED / name).read_bytes())
 
     first = write_experiment_lock(experiment)
-    second = write_experiment_lock(experiment)
+    second = write_experiment_lock(experiment, force=True)
     assert first == second
 
 


### PR DESCRIPTION
## Summary

A fresh experiment directory failed with a bare traceback on first run — no
way to create `experiment.lock` except copy-pasting a hand-rolled
`regenerate_lock.py` between examples.

- New `diffbloch lock <experiment_dir>` command writes it explicitly.
- `load_experiment()` now creates it automatically on first run when missing.
  An existing lock that no longer matches input bytes still raises (that's
  the drift check working) — `diffbloch lock` refreshes it after an
  intentional input change.

Closes #139

## Test plan

- [x] `pytest tests/unit` (729 passed), `ruff`, `mypy`
- [x] Deleted `experiment.lock` from quartz-no-abs, reran `diffbloch
      converge` — recreated automatically, run completed, lock byte-identical