### PR TITLE
Fix multi-dataset preprocessing bugs (#147)

### DIFF
--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -897,9 +897,11 @@ def _preprocess(
 
     ``plot_thickness`` (API/CLI) ORs with ``cfg.preprocess.thickness.plot`` -- either can turn
     plotting on. ``plot_thickness_dir`` overrides the default output directory,
-    ``<inputs.structure's directory>/thickness_optim``, when given. Both are execution-only (they
-    only decide whether/where a PNG gets written, never the fitted ``Plan``) -- see
-    :func:`~diffBloch.config.manifest.dataset_config_digest`.
+    ``<inputs.structure's directory>/thickness_optim``, when given. A multi-dataset experiment gets
+    one subdirectory per dataset under it (named by :func:`~diffBloch.config.schema.
+    dataset_checkpoint_stem`), so two datasets sharing a rotation index never overwrite each other's
+    PNG. Both are execution-only (they only decide whether/where a PNG gets written, never the
+    fitted ``Plan``) -- see :func:`~diffBloch.config.manifest.dataset_config_digest`.
     """
     structure = _read_structure(root, cfg, logger=logger)
     records = _read_experimental_data(root, cfg, logger=logger)
@@ -914,26 +916,37 @@ def _preprocess(
         float(cell[4]),
         float(cell[5]),
     )
-    if plot_thickness or cfg.preprocess.thickness.plot:
-        from diffBloch.app.loggers.plotting import ThicknessPlotLogger
-
-        effective_plot_dir = (
+    effective_plot_dir = (
+        (
             Path(plot_thickness_dir)
             if plot_thickness_dir is not None
             else (root / cfg.inputs.structure).parent / "thickness_optim"
         )
-        logger = MultiLogger((logger, ThicknessPlotLogger(effective_plot_dir)))
+        if plot_thickness or cfg.preprocess.thickness.plot
+        else None
+    )
 
     structure_lock = input_lock_for(root / cfg.inputs.structure, ref=cfg.inputs.structure)
     prepared_plans: list[Plan] = []
     lock_sha256s: list[str | None] = []
-    for ref, dataset in zip(refs, datasets, strict=True):
+    for i, (ref, dataset) in enumerate(zip(refs, datasets, strict=True)):
+        _log.info("preprocessing dataset %r (%d/%d)", ref, i + 1, len(refs))
+        dataset_logger = logger
+        if effective_plot_dir is not None:
+            from diffBloch.app.loggers.plotting import ThicknessPlotLogger
+
+            dataset_logger = MultiLogger(
+                (
+                    logger,
+                    ThicknessPlotLogger(effective_plot_dir / dataset_checkpoint_stem(ref)),
+                )
+            )
         steps = _recipe_steps(
             cfg,
             refinement_setup,
             dataset.integration,
             dataset.mosaicity,
-            logger,
+            dataset_logger,
             device=device,
             workers=workers,
             max_batch=max_batch,
@@ -950,7 +963,7 @@ def _preprocess(
             dataset_lock=input_lock_for(root / ref, ref=ref),
             checkpoint=checkpoint,
             refresh=refresh,
-            logger=logger,
+            logger=dataset_logger,
         )
         prepared_plans.append(prepared)
         lock_sha256s.append(lock_sha256)

--- a/tests/unit/test_program_recipe.py
+++ b/tests/unit/test_program_recipe.py
@@ -249,6 +249,118 @@ def test_preprocess_wraps_the_logger_with_a_thickness_plot_logger(tmp_path: Path
     assert plot_dir.is_dir()
 
 
+def test_preprocess_gives_each_dataset_its_own_thickness_plot_subdirectory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two datasets must not share a ``ThicknessPlotLogger`` output directory.
+
+    Regression for https://github.com/Differentiable-Electron-Crystallography/diffBloch/issues/147
+    (bug 1): a single ``ThicknessPlotLogger`` reused across datasets names files by
+    ``rotation_index`` alone, which is file-local -- so dataset 2's rotation 0 silently overwrites
+    dataset 1's. Each dataset must get its own subdirectory (keyed by
+    :func:`~diffBloch.config.schema.dataset_checkpoint_stem`) under ``plot_thickness_dir``.
+    """
+    root = FIXTURES / "quartz_anchor"
+    cfg, _ = load_experiment(root)
+    (tmp_path / "a.cif_pets").write_bytes((root / cfg.inputs.exp_data).read_bytes())
+    (tmp_path / "b.cif_pets").write_bytes((root / cfg.inputs.exp_data).read_bytes())
+    (tmp_path / "q.cif").write_bytes((root / cfg.inputs.structure).read_bytes())
+    cfg = cfg.model_copy(
+        update={
+            "inputs": cfg.inputs.model_copy(
+                update={
+                    "structure": "q.cif",
+                    "exp_data": ["a.cif_pets", "b.cif_pets"],
+                    "multi_dataset": True,
+                }
+            ),
+            "preprocess": cfg.preprocess.model_copy(
+                update={"optimize_orientation": False, "optimize_thickness": False}
+            ),
+        }
+    )
+    plot_dir = tmp_path / "thickness_optim"
+
+    created_dirs: list[Path] = []
+
+    class _SpyThicknessPlotLogger:
+        def __init__(self, output_dir: Path) -> None:
+            self.output_dir = Path(output_dir)
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+            created_dirs.append(self.output_dir)
+
+        def report(self, event: object) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "diffBloch.app.loggers.plotting.ThicknessPlotLogger", _SpyThicknessPlotLogger
+    )
+
+    _preprocess(
+        tmp_path,
+        cfg,
+        logger=NULL_LOGGER,
+        checkpoint=False,
+        refresh=False,
+        device=None,
+        workers=1,
+        max_batch=None,
+        plot_thickness=True,
+        plot_thickness_dir=plot_dir,
+    )
+
+    assert len(created_dirs) == 2
+    assert created_dirs[0] != created_dirs[1]
+    assert all(d.parent == plot_dir for d in created_dirs)
+
+
+def test_preprocess_logs_which_dataset_it_is_on(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The dataset loop must announce each dataset before running its recipe.
+
+    Regression for https://github.com/Differentiable-Electron-Crystallography/diffBloch/issues/147
+    (bug 2): "Preprocess seed" / "Preprocess stage N" console lines carried no dataset reference,
+    so a multi-dataset run's log couldn't be attributed to a dataset except by matching timestamps.
+    """
+    root = FIXTURES / "quartz_anchor"
+    cfg, _ = load_experiment(root)
+    (tmp_path / "a.cif_pets").write_bytes((root / cfg.inputs.exp_data).read_bytes())
+    (tmp_path / "b.cif_pets").write_bytes((root / cfg.inputs.exp_data).read_bytes())
+    (tmp_path / "q.cif").write_bytes((root / cfg.inputs.structure).read_bytes())
+    cfg = cfg.model_copy(
+        update={
+            "inputs": cfg.inputs.model_copy(
+                update={
+                    "structure": "q.cif",
+                    "exp_data": ["a.cif_pets", "b.cif_pets"],
+                    "multi_dataset": True,
+                }
+            ),
+            "preprocess": cfg.preprocess.model_copy(
+                update={"optimize_orientation": False, "optimize_thickness": False}
+            ),
+        }
+    )
+
+    with caplog.at_level("INFO", logger="diffBloch.app.program"):
+        _preprocess(
+            tmp_path,
+            cfg,
+            logger=NULL_LOGGER,
+            checkpoint=False,
+            refresh=False,
+            device=None,
+            workers=1,
+            max_batch=None,
+        )
+
+    dataset_lines = [r.message for r in caplog.records if "a.cif_pets" in r.message]
+    assert dataset_lines, "expected a log line naming dataset 'a.cif_pets'"
+    dataset_lines = [r.message for r in caplog.records if "b.cif_pets" in r.message]
+    assert dataset_lines, "expected a log line naming dataset 'b.cif_pets'"
+
+
 def test_fit_stages_can_be_enabled_independently() -> None:
     root = FIXTURES / "quartz_anchor"
     cfg, _ = load_experiment(root)


### PR DESCRIPTION
Fixes #147.

- Thickness PNGs no longer overwrite across datasets — each dataset gets its own subdirectory under plot_thickness_dir.
- Console log now names the dataset being preprocessed.

## Test plan
- [x] Full unit suite passes (725 tests)
- [x] New regression tests cover both bugs