### PR TITLE
Add inputs.isotropic_displacements_only to force Uiso refinement

### DIFF
--- a/docs/hyperparameter-selection.md
+++ b/docs/hyperparameter-selection.md
@@ -220,6 +220,7 @@ Input file references, relative to the experiment directory only (`Inputs`).
 | `exp_data` | required | Relative path to a `.cif_pets`, or (with `multi_dataset: true`) a list of 2+ paths. |
 | `multi_dataset` | `false` | See [Combining multiple datasets](#combining-multiple-datasets) below. |
 | `load_hydrogens` | `false` | Include hydrogen atom sites from the structure CIF (molecular crystals). |
+| `isotropic_displacements_only` | `false` | Force every atom to refine with isotropic ADPs. CIF `Uani` sites are seeded from their crystallographic `Ueq`; see [ADP parameterization](inputs.md#adp-parameterization). |
 
 ### Combining multiple datasets
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -17,6 +17,8 @@ Paths written in `experiment.yaml` are measured from the experiment directory:
 inputs:
   structure: structure.cif
   exp_data: experiment.cif_pets
+  # Optional: force all CIF ADPs to refine as Uiso.
+  isotropic_displacements_only: false
 ```
 
 The structure CIF supplies the atoms, fractional coordinates, occupancies, atomic displacement
@@ -32,6 +34,23 @@ structure-CIF cell as a consistency check.
 
 - A difference greater than 1% in any cell parameter produces a warning.
 - A difference greater than 5% stops the calculation.
+
+## ADP parameterization
+
+By default, diffBloch preserves the ADP kinds declared by the structure CIF: `Uani` sites refine with
+anisotropic ADPs, and `Uiso` sites refine with isotropic ADPs. Set
+`inputs.isotropic_displacements_only: true` to force every atom onto isotropic ADPs even when the CIF
+contains `_atom_site_aniso_*` rows.
+
+Atoms that were already `Uiso` keep their CIF `U_iso_or_equiv` seed. Atoms that were `Uani` are
+seeded from the crystallographic equivalent isotropic value, `Ueq`, computed from their CIF `Uij`
+tensor using the same unit cell that defines the refinement ADP frame. The original parsed structure
+record is not mutated; this is an experiment parameterization choice applied when refinement inputs
+are built.
+
+The flag changes the preprocessed starting point and is recorded in the per-dataset checkpoint
+identity. When refinement writes `refined_structure.cif`, force-converted atoms are written as `Uiso`
+and stale anisotropic rows are removed so the output re-reads with the same effective ADP kinds.
 
 
 

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -756,6 +756,13 @@ def _write_refinement_outputs(
         if block.find_pair("_cell_volume") is not None:
             authoritative_unit_cell = cell_matrix_from_parameters(refinement.cell_parameters)
             block.set_pair("_cell_volume", f"{cell_volume(authoritative_unit_cell):.5f}")
+    # The *effective* ADP kind (post inputs.isotropic_displacements_only override), not
+    # structure.adp.kind (the raw CIF classification): an atom the override force-converted to
+    # Uiso must be written back as Uiso, with its stale _atom_site_aniso_* row stripped below --
+    # otherwise re-reading this file classifies it back to Uani by the aniso row's mere presence
+    # (see io.cif._adp_for_site) and silently loses the override.
+    effective_kind = refinement.spec.adp_kind
+    assert effective_kind is not None
     atom_loop = block.find_loop("_atom_site_label").get_loop()
     tags = list(atom_loop.tags)
     label_column = tags.index("_atom_site_label")
@@ -771,7 +778,7 @@ def _write_refinement_outputs(
             "_atom_site_fract_z": positions[index, 2],
             "_atom_site_occupancy": occupancies[index],
         }
-        if structure.adp.kind[index] == "Uiso":
+        if effective_kind[index] == "Uiso":
             updates["_atom_site_U_iso_or_equiv"] = np.sum(
                 uij_star[index] * reciprocal_metric
             ) / np.sum(reciprocal_metric * reciprocal_metric)
@@ -798,8 +805,14 @@ def _write_refinement_outputs(
             "_atom_site_aniso_U_23": (1, 2),
         }
         scale = reciprocal_lengths[:, None] * reciprocal_lengths[None, :]
+        stale_aniso_labels: list[str] = []
         for index, label in enumerate(structure.labels):
-            if structure.adp.kind[index] != "Uani" or label not in aniso_rows:
+            if label not in aniso_rows:
+                continue
+            if effective_kind[index] != "Uani":
+                # Was Uani in the CIF but the override forces it to Uiso: strip the row rather than
+                # leaving it untouched (stale) or refreshing it with new anisotropic-looking values.
+                stale_aniso_labels.append(label)
                 continue
             row = aniso_rows[label]
             uij_cif = uij_star[index] / scale
@@ -807,6 +820,10 @@ def _write_refinement_outputs(
                 if tag in aniso_tags:
                     column = aniso_tags.index(tag)
                     aniso_loop[row, column] = f"{float(uij_cif[i, j]):.10g}"
+        if stale_aniso_labels:
+            aniso_table = block.find(list(aniso_loop.tags))
+            for label in stale_aniso_labels:
+                aniso_table.remove_row(aniso_table.find_row(label).row_index)
     document.write_file(str(structure_path))
 
     params = result.best_params

--- a/src/diffBloch/config/manifest.py
+++ b/src/diffBloch/config/manifest.py
@@ -206,6 +206,7 @@ def dataset_config_digest(config: ExperimentConfig, *, exp_data: str) -> str:
             "structure": dump["inputs"]["structure"],
             "exp_data": exp_data,
             "load_hydrogens": dump["inputs"]["load_hydrogens"],
+            "isotropic_displacements_only": dump["inputs"]["isotropic_displacements_only"],
         },
         # Resolve the optional per-dataset mapping to this Plan's effective seed. This keeps a
         # change for dataset B from invalidating dataset A's checkpoint.

--- a/src/diffBloch/config/schema.py
+++ b/src/diffBloch/config/schema.py
@@ -449,6 +449,8 @@ class Inputs(_StrictConfig):
     # solves the whole pooled experiment at one energy (see preprocess.pool).
     multi_dataset: bool = False
     load_hydrogens: bool = False  # include hydrogen atom sites (molecular crystals; off by default)
+    # Force every atom onto Uiso even if the CIF marks it Uani (seeded from the CIF Ueq).
+    isotropic_displacements_only: bool = False
 
     @field_validator("structure")
     @classmethod

--- a/src/diffBloch/core/__init__.py
+++ b/src/diffBloch/core/__init__.py
@@ -7,6 +7,7 @@ from diffBloch.core.adp import (
     cif_adp_to_star,
     equivalent_isotropic_adp,
     isotropic_adp,
+    ueq_from_cif_uij,
 )
 from diffBloch.core.constraints import (
     apply_adp_constraints,
@@ -130,6 +131,7 @@ __all__ = [
     "structure_factors",
     "structure_matrix",
     "structure_matrix_prefactor",
+    "ueq_from_cif_uij",
     "unit_interval",
     "w_rbragg",
     "wavelength2energy",

--- a/src/diffBloch/core/adp.py
+++ b/src/diffBloch/core/adp.py
@@ -74,6 +74,20 @@ def equivalent_isotropic_adp(uij: Tensor) -> Tensor:
     return torch.diagonal(uij, dim1=-2, dim2=-1).sum(dim=-1) / 3.0
 
 
+def ueq_from_cif_uij(uij_cif: Tensor, reciprocal_lengths: Tensor, metric_tensor: Tensor) -> Tensor:
+    """Return the crystallographic equivalent isotropic displacement ``Ueq`` for CIF-frame ``Uij``.
+
+    ``Ueq = (1/3) sum_ij Uij_cif d*_i d*_j (a_i . a_j)`` (Fischer & Tillmanns 1988): the reciprocal
+    ``U*`` tensor (:func:`cif_adp_to_star`) contracted with the direct-cell metric tensor
+    ``metric_tensor = cell @ cell.T``. Not ``trace(uij_cif) / 3`` -- that shortcut only equals Ueq in
+    an orthonormal frame, and is wrong whenever the cell has non-90-degree angles or unequal axes.
+    """
+    star = cif_adp_to_star(uij_cif, reciprocal_lengths)
+    if metric_tensor.shape != (3, 3):
+        raise ValueError("metric_tensor must have shape (3, 3)")
+    return torch.einsum("...ij,ij->...", star, metric_tensor) / 3.0
+
+
 def _require_trailing_matrix(value: Tensor, *, name: str) -> None:
     if value.ndim < 2 or tuple(value.shape[-2:]) != (3, 3):
         raise ValueError(f"{name} must have trailing shape (3, 3)")

--- a/src/diffBloch/preprocess/experiment.py
+++ b/src/diffBloch/preprocess/experiment.py
@@ -24,7 +24,7 @@ from numpy.typing import NDArray
 from torch import Tensor
 
 from diffBloch.config.schema import DataSplitConfig, ExperimentConfig
-from diffBloch.core.adp import cholesky_raw_from_adp
+from diffBloch.core.adp import cholesky_raw_from_adp, ueq_from_cif_uij
 from diffBloch.core.crystal import cell_matrix_from_parameters, reciprocal_cell
 from diffBloch.core.dynamical import (
     energy2sigma,
@@ -137,6 +137,7 @@ class RefinementSetup:
         structure: StructureRecord,
         *,
         cell_parameters: NDArray[np.float64] | None = None,
+        isotropic_displacements_only: bool = False,
     ) -> RefinementSetup:
         """Assemble the structure-side refinement inputs from a parsed :class:`StructureRecord`.
 
@@ -152,21 +153,35 @@ class RefinementSetup:
         natively from the structure's symmetry operators (:func:`symmetry_constraints`): an atom
         special position is held on its site under refinement, so it is neither over-parameterized
         nor free to drift off. A general-position atom gets the identity projector (unconstrained).
+
+        ``isotropic_displacements_only`` (``inputs.isotropic_displacements_only``) forces every atom
+        onto Uiso via a derived ADP record (:func:`_force_isotropic_adp`), never by mutating
+        ``structure`` itself.
         """
         positions = torch.tensor(structure.frac_positions, dtype=torch.float64)
-        uij_raw, u_iso_raw = _initial_adp_params(structure.adp)
-        constraints = symmetry_constraints(structure)
         resolved_cell_parameters = (
             structure.cell_parameters if cell_parameters is None else np.asarray(cell_parameters)
         )
         unit_cell = cell_matrix_from_parameters(resolved_cell_parameters)
+        reciprocal_basis = reciprocal_cell(unit_cell)
+        adp = structure.adp
+        if isotropic_displacements_only:
+            adp = _force_isotropic_adp(
+                adp,
+                reciprocal_lengths=torch.tensor(
+                    np.linalg.norm(reciprocal_basis, axis=1), dtype=torch.float64
+                ),
+                metric_tensor=torch.tensor(unit_cell @ unit_cell.T, dtype=torch.float64),
+            )
+        uij_raw, u_iso_raw = _initial_adp_params(adp)
+        constraints = symmetry_constraints(structure)
         spec = ConstraintSpec(
             position_projection=torch.tensor(constraints.position_projection, dtype=torch.float64),
             position_offset=torch.tensor(constraints.position_offset, dtype=torch.float64),
             occupancies=torch.tensor(structure.occupancies, dtype=torch.float64),
-            adp_kind=structure.adp.kind,
+            adp_kind=adp.kind,
             adp_constraints=constraints.adp_constraints,
-            reciprocal_basis=torch.tensor(reciprocal_cell(unit_cell), dtype=torch.float64),
+            reciprocal_basis=torch.tensor(reciprocal_basis, dtype=torch.float64),
         )
         return cls(
             asu_plan=build_asu_expansion_plan(
@@ -252,7 +267,9 @@ def setup_datasets(
     grid = StructureFactorGrid.from_cell_for_beam_cutoff(authoritative_unit_cell, solve_cutoff)
     beam_hkl = seed_beam_hkl(grid, g_max=solve_cutoff)
     refinement_setup = RefinementSetup.from_structure(
-        structure, cell_parameters=authoritative_cell_parameters
+        structure,
+        cell_parameters=authoritative_cell_parameters,
+        isotropic_displacements_only=config.inputs.isotropic_displacements_only,
     )
     absorption = config.blochwave.to_absorption()
 
@@ -555,6 +572,34 @@ def validation_mask(n_rotations: int, split: DataSplitConfig) -> NDArray[np.bool
     step = round(1.0 / split.val_frac)
     mask: NDArray[np.bool_] = (np.arange(n_rotations) + 1) % step == 0
     return mask
+
+
+def _force_isotropic_adp(
+    adp: AdpRecord, *, reciprocal_lengths: Tensor, metric_tensor: Tensor
+) -> AdpRecord:
+    """Force every ADP to Uiso (``inputs.isotropic_displacements_only``), never mutating ``adp``.
+
+    Every ``kind`` becomes ``"Uiso"``. An atom that was ``Uani`` in the CIF is re-seeded with its
+    crystallographic equivalent isotropic value (Ueq, :func:`diffBloch.core.adp.ueq_from_cif_uij`)
+    computed from its own CIF ``Uij`` tensor -- not whatever the CIF's own (often absent, and
+    sometimes merely a rounded courtesy figure) ``_atom_site_U_iso_or_equiv`` column already held for
+    that row, and not a naive ``trace(Uij) / 3``, which only equals Ueq in an orthonormal frame.
+    """
+    if "missing" in adp.kind:
+        raise ValueError("missing ADPs require an explicit initialization policy")
+    was_uani = np.array([kind == "Uani" for kind in adp.kind], dtype=np.bool_)
+    u_iso = np.array(adp.u_iso, dtype=np.float64, copy=True)
+    if was_uani.any():
+        uij_cif = torch.tensor(adp.uij_cif[was_uani], dtype=torch.float64)
+        ueq = ueq_from_cif_uij(uij_cif, reciprocal_lengths, metric_tensor)
+        u_iso[was_uani] = ueq.numpy()
+    return AdpRecord(
+        kind=tuple("Uiso" for _ in adp.kind),
+        u_iso=u_iso,
+        u_iso_su=adp.u_iso_su,
+        uij_cif=adp.uij_cif,
+        uij_cif_su=adp.uij_cif_su,
+    )
 
 
 def _initial_adp_params(adp: AdpRecord) -> tuple[Tensor | None, Tensor | None]:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -596,6 +596,22 @@ def test_load_hydrogens_defaults_off_and_parses() -> None:
     assert withH.inputs.load_hydrogens is True
 
 
+def test_isotropic_displacements_only_defaults_off_and_parses() -> None:
+    base = {"name": "abi", "inputs": {"structure": "a.cif", "exp_data": "a.cif_pets"}}
+    assert ExperimentConfig.model_validate(base).inputs.isotropic_displacements_only is False
+    forced = ExperimentConfig.model_validate(
+        {
+            "name": "abi",
+            "inputs": {
+                "structure": "a.cif",
+                "exp_data": "a.cif_pets",
+                "isotropic_displacements_only": True,
+            },
+        }
+    )
+    assert forced.inputs.isotropic_displacements_only is True
+
+
 def test_refinement_rejects_hydrogen_mode_as_unknown_key() -> None:
     # H handling is scientific composition (Python/API via with_hydrogen_riding), not a config mode;
     # a strict config rejects the removed key rather than silently accepting a dead knob.

--- a/tests/unit/test_core_constraints.py
+++ b/tests/unit/test_core_constraints.py
@@ -6,6 +6,7 @@ from diffBloch.core import (
     apply_adp_constraints,
     apply_symmetry_projection,
     cartesian_adp_to_star,
+    cell_matrix_from_parameters,
     cholesky_adp,
     cholesky_raw_from_adp,
     cif_adp_to_star,
@@ -13,6 +14,8 @@ from diffBloch.core import (
     equivalent_isotropic_adp,
     isotropic_adp,
     positive,
+    reciprocal_cell,
+    ueq_from_cif_uij,
     unit_interval,
 )
 from diffBloch.params import ConstraintSpec, RefinableParams, constrain
@@ -126,6 +129,49 @@ def test_equivalent_isotropic_adp_uses_trace_average() -> None:
     )
 
     assert equivalent_isotropic_adp(uij).tolist() == pytest.approx([0.05])
+
+
+def test_ueq_from_cif_uij_matches_trace_average_for_a_cubic_cell() -> None:
+    # Cubic cell: the CIF Uij frame is already orthonormal (up to a uniform scale), so Ueq must
+    # coincide with the plain trace/3 that only holds in an orthonormal frame.
+    a = 5.0
+    reciprocal_lengths = torch.full((3,), 1.0 / a, dtype=torch.float64)
+    metric_tensor = torch.eye(3, dtype=torch.float64) * a**2
+    uij = torch.tensor(
+        [[0.06, 0.01, 0.0], [0.01, 0.04, 0.0], [0.0, 0.0, 0.05]], dtype=torch.float64
+    )
+
+    ueq = ueq_from_cif_uij(uij, reciprocal_lengths, metric_tensor)
+
+    assert ueq.item() == pytest.approx(0.05)
+    assert ueq.item() == pytest.approx(equivalent_isotropic_adp(uij).item())
+
+
+def test_ueq_from_cif_uij_matches_an_independent_cartesian_route_for_an_oblique_cell() -> None:
+    # Monoclinic cell (beta != 90): the naive trace(Uij_cif)/3 is wrong here because the CIF Uij
+    # frame is oblique. Cross-check ueq_from_cif_uij against a route that never uses it: expand
+    # Uij_cif into the genuine orthonormal Cartesian frame (Ucart = cell.T @ U* @ cell, the inverse
+    # of cartesian_adp_to_star) and take the plain trace/3 there, which *is* valid in that frame.
+    cell_parameters = torch.tensor([5.0, 6.0, 7.0, 90.0, 100.0, 90.0], dtype=torch.float64)
+    cell = torch.tensor(cell_matrix_from_parameters(cell_parameters.numpy()), dtype=torch.float64)
+    reciprocal_basis = torch.tensor(reciprocal_cell(cell.numpy()), dtype=torch.float64)
+    reciprocal_lengths = torch.linalg.norm(reciprocal_basis, dim=1)
+    metric_tensor = cell @ cell.T
+
+    uij = torch.tensor(
+        [[0.020, 0.0010, 0.0005], [0.0010, 0.030, 0.0002], [0.0005, 0.0002, 0.025]],
+        dtype=torch.float64,
+    )
+
+    ueq = ueq_from_cif_uij(uij, reciprocal_lengths, metric_tensor)
+
+    star = cif_adp_to_star(uij, reciprocal_lengths)
+    u_cart = cell.T @ star @ cell
+    expected = equivalent_isotropic_adp(u_cart)
+
+    assert ueq.item() == pytest.approx(expected.item())
+    # The point of the function: the naive shortcut disagrees measurably on this oblique cell.
+    assert ueq.item() != pytest.approx(torch.trace(uij).item() / 3.0, rel=1e-3)
 
 
 def test_isotropic_adp_expands_to_scaled_identity() -> None:

--- a/tests/unit/test_from_experiment.py
+++ b/tests/unit/test_from_experiment.py
@@ -554,9 +554,9 @@ def test_isotropic_displacements_only_uses_pets_authoritative_cell_for_ueq() -> 
     pets_unit_cell = cell_matrix_from_parameters(pets_cell)
     pets_reciprocal_basis = reciprocal_cell(pets_unit_cell)
     pets_reciprocal_metric = pets_reciprocal_basis @ pets_reciprocal_basis.T
-    seeded_uiso = float(torch.sum(state.uij_star[0] * torch.tensor(pets_reciprocal_metric))) / float(
-        np.sum(pets_reciprocal_metric * pets_reciprocal_metric)
-    )
+    seeded_uiso = float(
+        torch.sum(state.uij_star[0] * torch.tensor(pets_reciprocal_metric))
+    ) / float(np.sum(pets_reciprocal_metric * pets_reciprocal_metric))
     expected_pets_ueq = ueq_from_cif_uij(
         torch.tensor(_UANI, dtype=torch.float64),
         torch.tensor(np.linalg.norm(pets_reciprocal_basis, axis=1), dtype=torch.float64),

--- a/tests/unit/test_from_experiment.py
+++ b/tests/unit/test_from_experiment.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 from diffBloch.config import load_config
+from diffBloch.core.adp import ueq_from_cif_uij
 from diffBloch.core.crystal import cell_matrix_from_parameters, reciprocal_cell
 from diffBloch.core.products import MosaicSmoothed
 from diffBloch.io import read_experimental_data, read_structure
@@ -457,3 +458,85 @@ def test_refinement_setup_mixed_uani_uiso_constrains_each_atom_by_kind() -> None
 def _setup_state(structure: StructureRecord) -> tuple:
     setup = RefinementSetup.from_structure(structure)
     return setup.params, setup.spec
+
+
+# --- inputs.isotropic_displacements_only override --------------------------------------------
+
+
+def _oblique_structure(kinds: tuple[str, ...]) -> StructureRecord:
+    """A P1 monoclinic (beta = 100 degrees) variant of :func:`_ortho_structure`.
+
+    An orthorhombic cell's off-diagonal direct-metric terms vanish, so Ueq degenerates to
+    ``trace(Uij) / 3`` there and cannot distinguish the correct metric-tensor contraction from the
+    naive shortcut. The non-90-degree ``beta`` here keeps the metric tensor's off-diagonal term
+    non-zero, so the two routes give observably different answers.
+    """
+    n = len(kinds)
+    uij_cif = np.stack([_UANI if k == "Uani" else np.full((3, 3), np.nan) for k in kinds])
+    u_iso = np.array([_UISO if k == "Uiso" else np.nan for k in kinds])
+    cell_parameters = np.array([5.0, 6.0, 7.0, 90.0, 100.0, 90.0])
+    return StructureRecord(
+        unit_cell=cell_matrix_from_parameters(cell_parameters),
+        cell_parameters=cell_parameters,
+        cell_parameters_su=np.full((6,), np.nan),
+        spacegroup_hm="P1",
+        symops_R=np.eye(3)[None, :, :],
+        symops_t=np.zeros((1, 3)),
+        labels=tuple(f"A{i}" for i in range(n)),
+        numbers=np.array([14] * n),
+        frac_positions=np.linspace(0.1, 0.6, n * 3).reshape(n, 3),
+        frac_positions_su=np.full((n, 3), np.nan),
+        occupancies=np.ones(n),
+        occupancies_su=np.full((n,), np.nan),
+        adp=AdpRecord(
+            kind=kinds,
+            u_iso=u_iso,
+            u_iso_su=np.full((n,), np.nan),
+            uij_cif=uij_cif,
+            uij_cif_su=np.full((n, 3, 3), np.nan),
+        ),
+    )
+
+
+def test_isotropic_displacements_only_forces_uani_to_uiso_seeded_from_cif_ueq() -> None:
+    structure = _oblique_structure(("Uani", "Uiso"))
+
+    setup = RefinementSetup.from_structure(structure, isotropic_displacements_only=True)
+
+    # Every atom refines as Uiso now, including the one that was Uani in the CIF -- and the
+    # override never touched the CIF-parsed record itself.
+    assert setup.spec.adp_kind == ("Uiso", "Uiso")
+    assert structure.adp.kind == ("Uani", "Uiso")
+    assert setup.params.uij_raw is None
+    assert setup.params.u_iso_raw is not None and setup.params.u_iso_raw.shape == (2,)
+
+    unit_cell = cell_matrix_from_parameters(structure.cell_parameters)
+    reciprocal_basis = reciprocal_cell(unit_cell)
+    reciprocal_lengths = torch.tensor(np.linalg.norm(reciprocal_basis, axis=1))
+    metric_tensor = torch.tensor(unit_cell @ unit_cell.T)
+    expected_ueq = ueq_from_cif_uij(
+        torch.tensor(_UANI, dtype=torch.float64), reciprocal_lengths, metric_tensor
+    ).item()
+    # The naive trace(Uij)/3 shortcut disagrees on this non-cubic (5, 6, 7) cell -- confirming the
+    # seed genuinely comes from the metric-tensor contraction, not the wrong shortcut.
+    assert expected_ueq != pytest.approx(float(np.trace(_UANI) / 3.0), rel=1e-3)
+
+    state = constrain(setup.params, setup.spec)
+    reciprocal_metric = reciprocal_basis @ reciprocal_basis.T
+    # Both atoms are now genuinely isotropic: uij_star = Uiso * G* exactly, so Uiso is recoverable.
+    seeded_uiso = [
+        float(torch.sum(state.uij_star[i] * torch.tensor(reciprocal_metric)))
+        / float(np.sum(reciprocal_metric * reciprocal_metric))
+        for i in range(2)
+    ]
+    assert seeded_uiso[0] == pytest.approx(expected_ueq)
+    # The atom that was already Uiso in the CIF keeps its own CIF value, untouched by the override.
+    assert seeded_uiso[1] == pytest.approx(_UISO)
+
+
+def test_isotropic_displacements_only_defaults_to_off() -> None:
+    structure = _ortho_structure(("Uani", "Uiso"))
+
+    setup = RefinementSetup.from_structure(structure)
+
+    assert setup.spec.adp_kind == structure.adp.kind

--- a/tests/unit/test_from_experiment.py
+++ b/tests/unit/test_from_experiment.py
@@ -534,6 +534,50 @@ def test_isotropic_displacements_only_forces_uani_to_uiso_seeded_from_cif_ueq() 
     assert seeded_uiso[1] == pytest.approx(_UISO)
 
 
+def test_isotropic_displacements_only_uses_pets_authoritative_cell_for_ueq() -> None:
+    structure = _oblique_structure(("Uani",))
+    experimental_data = read_experimental_data(QUARTZ / "exp_data.cif_pets")
+    pets_cell = structure.cell_parameters.copy()
+    pets_cell[4] = 104.0  # below the 5% mismatch guard, but enough to change oblique-cell Ueq
+    experimental_data = experimental_data.model_copy(update={"cell_parameters": pets_cell})
+    base = load_config(QUARTZ / "experiment.yaml")
+    config = base.model_copy(
+        update={
+            "inputs": base.inputs.model_copy(update={"isotropic_displacements_only": True}),
+            "blochwave": base.blochwave.model_copy(update={"mosaicity": False}),
+        }
+    )
+
+    setup = from_experiment(structure, experimental_data, config)
+
+    state = constrain(setup.refinement.params, setup.refinement.spec)
+    pets_unit_cell = cell_matrix_from_parameters(pets_cell)
+    pets_reciprocal_basis = reciprocal_cell(pets_unit_cell)
+    pets_reciprocal_metric = pets_reciprocal_basis @ pets_reciprocal_basis.T
+    seeded_uiso = float(torch.sum(state.uij_star[0] * torch.tensor(pets_reciprocal_metric))) / float(
+        np.sum(pets_reciprocal_metric * pets_reciprocal_metric)
+    )
+    expected_pets_ueq = ueq_from_cif_uij(
+        torch.tensor(_UANI, dtype=torch.float64),
+        torch.tensor(np.linalg.norm(pets_reciprocal_basis, axis=1), dtype=torch.float64),
+        torch.tensor(pets_unit_cell @ pets_unit_cell.T, dtype=torch.float64),
+    ).item()
+
+    cif_unit_cell = cell_matrix_from_parameters(structure.cell_parameters)
+    cif_reciprocal_basis = reciprocal_cell(cif_unit_cell)
+    cif_ueq = ueq_from_cif_uij(
+        torch.tensor(_UANI, dtype=torch.float64),
+        torch.tensor(np.linalg.norm(cif_reciprocal_basis, axis=1), dtype=torch.float64),
+        torch.tensor(cif_unit_cell @ cif_unit_cell.T, dtype=torch.float64),
+    ).item()
+
+    assert setup.refinement.spec.adp_kind == ("Uiso",)
+    assert setup.refinement.cell_parameters is not None
+    np.testing.assert_allclose(setup.refinement.cell_parameters, pets_cell)
+    assert seeded_uiso == pytest.approx(expected_pets_ueq)
+    assert seeded_uiso != pytest.approx(cif_ueq, rel=1e-4)
+
+
 def test_isotropic_displacements_only_defaults_to_off() -> None:
     structure = _ortho_structure(("Uani", "Uiso"))
 

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -146,6 +146,19 @@ def test_dataset_config_digest_is_stable_and_value_sensitive() -> None:
     )
 
 
+def test_dataset_config_digest_is_sensitive_to_isotropic_displacements_only() -> None:
+    """Toggling inputs.isotropic_displacements_only changes the initial refinable ADP parameters
+    (RefinementSetup.from_structure), so it must restale a committed per-dataset checkpoint --
+    exactly as inputs.load_hydrogens already does."""
+    cfg = load_config(LOCKED / "experiment.yaml")
+    forced = cfg.model_copy(
+        update={"inputs": cfg.inputs.model_copy(update={"isotropic_displacements_only": True})}
+    )
+    assert dataset_config_digest(forced, exp_data=EXP_REF) != dataset_config_digest(
+        cfg, exp_data=EXP_REF
+    )
+
+
 def test_dataset_config_digest_scopes_per_dataset_mean_thickness() -> None:
     cfg = load_config(LOCKED / "experiment.yaml")
     raw = cfg.model_dump()

--- a/tests/unit/test_program_refine.py
+++ b/tests/unit/test_program_refine.py
@@ -129,14 +129,24 @@ def _refinement_result_for(
     tmp_path: Path,
     *,
     cell_parameters: np.ndarray | None = None,
+    isotropic_displacements_only: bool = False,
 ) -> tuple[ExperimentConfig, RefinementSetup, ModelRefinementResult]:
     source = tmp_path / "q.cif"
     source.write_text(_MINIMAL_CIF)
     cfg = ExperimentConfig.model_validate(
-        {"name": "q", "inputs": {"structure": "q.cif", "exp_data": "q.cif_pets"}}
+        {
+            "name": "q",
+            "inputs": {
+                "structure": "q.cif",
+                "exp_data": "q.cif_pets",
+                "isotropic_displacements_only": isotropic_displacements_only,
+            },
+        }
     )
     refinement = RefinementSetup.from_structure(
-        read_structure(source), cell_parameters=cell_parameters
+        read_structure(source),
+        cell_parameters=cell_parameters,
+        isotropic_displacements_only=isotropic_displacements_only,
     )
     params = replace(
         refinement.params,
@@ -202,6 +212,27 @@ def test_write_refinement_outputs_persists_best_cif_and_params(tmp_path: Path) -
         assert params_file["asu_positions"].shape == (2, 3)
         assert params_file["occupancy_raw"].shape == (2,)
     assert not (tmp_path / "refinement_summary.json").exists()  # superseded by the .txt report
+
+
+def test_write_refinement_outputs_strips_stale_aniso_row_when_forced_isotropic(
+    tmp_path: Path,
+) -> None:
+    """``inputs.isotropic_displacements_only`` forces O1 (Uani in the CIF) onto Uiso; its
+    ``_atom_site_aniso_*`` row must be removed, not left stale or refreshed with new anisotropic
+    values -- otherwise re-reading the file classifies O1 back to Uani (io.cif._adp_for_site keys
+    purely on aniso-row presence) and silently loses the override."""
+    cfg, refinement, result = _refinement_result_for(tmp_path, isotropic_displacements_only=True)
+    assert refinement.spec.adp_kind == ("Uiso", "Uiso")
+
+    _write_refinement_outputs(tmp_path, cfg, refinement, result, plan_lock_sha256s=("ab" * 32,))
+
+    text = (tmp_path / "refined_structure.cif").read_text()
+    assert "_atom_site_aniso" not in text  # the whole now-empty aniso loop is gone
+
+    refined = read_structure(tmp_path / "refined_structure.cif")
+    assert refined.adp.kind == ("Uiso", "Uiso")
+    assert np.all(np.isfinite(refined.adp.u_iso))
+    assert np.all(np.isnan(refined.adp.uij_cif))
 
 
 def test_write_refinement_outputs_rewrites_the_refined_cif_cell_header(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- inputs.isotropic_displacements_only forces every atom to Uiso, seeding
  Uani atoms with their CIF Ueq (metric-tensor contraction, not trace/3).
- Fixes a round-trip bug: the refined-CIF writer now strips the stale
  _atom_site_aniso_* row for force-converted atoms instead of leaving it
  stale.

## Test plan
- [x] just check
- [x] just test-all

Fixes #148