### PR TITLE
Stop findfont log spam when Arial is not installed

### DIFF
--- a/src/diffBloch/app/loggers/plotting.py
+++ b/src/diffBloch/app/loggers/plotting.py
@@ -23,11 +23,20 @@ _RED = "#b40426"
 
 
 def _apply_house_style(ax: Any) -> None:
-    """Shared look for report plots: Arial, blue/red palette, clean integer-ish y-ticks, no grid."""
+    """Shared look for report plots: Arial, blue/red palette, clean integer-ish y-ticks, no grid.
+
+    ``font.family`` is set to the generic ``sans-serif`` family with ``font.sans-serif`` naming
+    Arial as the preferred face, falling back silently to DejaVu Sans (matplotlib's bundled font,
+    always present) when Arial is not installed. Setting ``font.family`` directly to ``"Arial"``
+    instead makes every glyph search Arial specifically and log its own ``findfont: Font family
+    'Arial' not found`` warning when it's missing -- one plot can spam dozens of these, burying the
+    actually useful progress output, even though the plot renders fine either way.
+    """
     import matplotlib.pyplot as plt
     from matplotlib.ticker import MaxNLocator
 
-    plt.rcParams["font.family"] = "Arial"
+    plt.rcParams["font.family"] = "sans-serif"
+    plt.rcParams["font.sans-serif"] = ["Arial", "DejaVu Sans"]
     ax.grid(False)
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from diffBloch.app.loggers.plotting import ThicknessPlotLogger, plot_thickness_nn_shape
+import pytest
+
+from diffBloch.app.loggers.plotting import (
+    ThicknessPlotLogger,
+    _apply_house_style,
+    plot_thickness_nn_shape,
+)
 from diffBloch.observability import OrientationOptimized, ThicknessOptimized
 
 _EVENT = ThicknessOptimized(
@@ -84,3 +90,45 @@ def test_thickness_nn_shape_plot_carries_its_dataset_title(tmp_path: Path) -> No
 
     assert png.is_file()
     assert png.stat().st_size > 0
+
+
+def test_house_style_prefers_arial_via_the_sans_serif_fallback_list() -> None:
+    """Regression for #140: font.family must be the generic 'sans-serif' family with Arial as the
+    preferred face in font.sans-serif, not a direct font.family = "Arial" -- the direct form makes
+    every glyph search Arial by itself and log its own findfont warning when it's missing."""
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    try:
+        _apply_house_style(ax)
+        assert plt.rcParams["font.family"] == ["sans-serif"]
+        assert plt.rcParams["font.sans-serif"][:2] == ["Arial", "DejaVu Sans"]
+    finally:
+        plt.close(fig)
+
+
+def test_house_style_logs_no_findfont_warning_when_the_preferred_font_is_missing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Deterministic regardless of whether Arial is actually installed on the host: even with a
+    guaranteed-missing font first in the preference list, the sans-serif family fallback must not
+    log findfont -- proving the mechanism the #140 fix relies on, not just today's environment.
+
+    Sets rcParams directly (the same shape ``_apply_house_style`` sets, with a font guaranteed
+    absent standing in for "Arial happens to be missing") rather than monkeypatching the function
+    itself, so this exercises the real fallback mechanism, not a stand-in.
+    """
+    import logging
+
+    import matplotlib.pyplot as plt
+
+    plt.rcParams["font.family"] = "sans-serif"
+    plt.rcParams["font.sans-serif"] = ["NotARealFontXYZ", "DejaVu Sans"]
+    fig, ax = plt.subplots()
+    try:
+        with caplog.at_level(logging.WARNING, logger="matplotlib.font_manager"):
+            ax.set_title("t")
+            fig.canvas.draw()
+        assert not any("findfont" in record.getMessage() for record in caplog.records)
+    finally:
+        plt.close(fig)


### PR DESCRIPTION
Report plots asked for Arial by setting `font.family` directly to `"Arial"`. That makes matplotlib
search for that one family per glyph and, when it is missing, log

```
findfont: Font family 'Arial' not found.
```

once per lookup — dozens of lines per plot, burying the progress output the run is actually trying
to show. The plots rendered correctly the whole time; only the log was affected.

This sets the generic `font.family = "sans-serif"` and puts Arial at the head of `font.sans-serif`
instead, so Arial is still preferred where it exists and matplotlib falls through silently to its
bundled DejaVu Sans where it does not.

Fixes #140.

## Stack position

This is one of 10 PRs splitting `feature/observability-report-sections` (~1500 lines, 28 files)
into single-concern pieces. **They are stacked: each PR's base is the branch below it**, so this
PR's diff shows only its own change. **Merge bottom-up, in this order:**

| # | branch | |
|---|---|---|
| 1 | `fix/thickness-plot-findfont-spam` | **← this PR** |
| 2 | `fix/thickness-plot-y-axis-floor` | |
| 3 | `fix/unique-reflection-counts` | |
| 4 | `refactor/preprocess-outcome` | |
| 5 | `refactor/remove-quiet-flag` | |
| 6 | `feat/console-completion-boxes` | |
| 7 | `feat/validation-metrics-per-epoch` | |
| 8 | `feat/dataset-ref-on-rotations` | foundation for 9 and 10 |
| 9 | `feat/report-orientation-search-section` | needs 8 |
| 10 | `feat/report-per-dataset-summary` | needs 8 |


