### PR TITLE
Floor the score-vs-thickness plot's y-axis at zero

### DIFF
--- a/src/diffBloch/app/loggers/plotting.py
+++ b/src/diffBloch/app/loggers/plotting.py
@@ -23,11 +23,20 @@ _RED = "#b40426"
 
 
 def _apply_house_style(ax: Any) -> None:
-    """Shared look for report plots: Arial, blue/red palette, clean integer-ish y-ticks, no grid."""
+    """Shared look for report plots: Arial, blue/red palette, clean integer-ish y-ticks, no grid.
+
+    ``font.family`` is set to the generic ``sans-serif`` family with ``font.sans-serif`` naming
+    Arial as the preferred face, falling back silently to DejaVu Sans (matplotlib's bundled font,
+    always present) when Arial is not installed. Setting ``font.family`` directly to ``"Arial"``
+    instead makes every glyph search Arial specifically and log its own ``findfont: Font family
+    'Arial' not found`` warning when it's missing -- one plot can spam dozens of these, burying the
+    actually useful progress output, even though the plot renders fine either way.
+    """
     import matplotlib.pyplot as plt
     from matplotlib.ticker import MaxNLocator
 
-    plt.rcParams["font.family"] = "Arial"
+    plt.rcParams["font.family"] = "sans-serif"
+    plt.rcParams["font.sans-serif"] = ["Arial", "DejaVu Sans"]
     ax.grid(False)
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)

--- a/src/diffBloch/app/loggers/plotting.py
+++ b/src/diffBloch/app/loggers/plotting.py
@@ -89,6 +89,7 @@ class ThicknessPlotLogger:
         ax.set_xlabel("Thickness (Å)")
         ax.set_ylabel(label)
         ax.set_title(f"{label} vs thickness — rotation {event.rotation_index}")
+        ax.set_ylim(bottom=0)
         _apply_house_style(ax)
         fig.tight_layout()
         fig.savefig(self.output_dir / f"{event.rotation_index}.png")

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from diffBloch.app.loggers.plotting import ThicknessPlotLogger, plot_thickness_nn_shape
+import pytest
+
+from diffBloch.app.loggers.plotting import (
+    ThicknessPlotLogger,
+    _apply_house_style,
+    plot_thickness_nn_shape,
+)
 from diffBloch.observability import OrientationOptimized, ThicknessOptimized
 
 _EVENT = ThicknessOptimized(
@@ -84,3 +90,45 @@ def test_thickness_nn_shape_plot_carries_its_dataset_title(tmp_path: Path) -> No
 
     assert png.is_file()
     assert png.stat().st_size > 0
+
+
+def test_house_style_prefers_arial_via_the_sans_serif_fallback_list() -> None:
+    """Regression for #140: font.family must be the generic 'sans-serif' family with Arial as the
+    preferred face in font.sans-serif, not a direct font.family = "Arial" -- the direct form makes
+    every glyph search Arial by itself and log its own findfont warning when it's missing."""
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    try:
+        _apply_house_style(ax)
+        assert plt.rcParams["font.family"] == ["sans-serif"]
+        assert plt.rcParams["font.sans-serif"][:2] == ["Arial", "DejaVu Sans"]
+    finally:
+        plt.close(fig)
+
+
+def test_house_style_logs_no_findfont_warning_when_the_preferred_font_is_missing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Deterministic regardless of whether Arial is actually installed on the host: even with a
+    guaranteed-missing font first in the preference list, the sans-serif family fallback must not
+    log findfont -- proving the mechanism the #140 fix relies on, not just today's environment.
+
+    Sets rcParams directly (the same shape ``_apply_house_style`` sets, with a font guaranteed
+    absent standing in for "Arial happens to be missing") rather than monkeypatching the function
+    itself, so this exercises the real fallback mechanism, not a stand-in.
+    """
+    import logging
+
+    import matplotlib.pyplot as plt
+
+    plt.rcParams["font.family"] = "sans-serif"
+    plt.rcParams["font.sans-serif"] = ["NotARealFontXYZ", "DejaVu Sans"]
+    fig, ax = plt.subplots()
+    try:
+        with caplog.at_level(logging.WARNING, logger="matplotlib.font_manager"):
+            ax.set_title("t")
+            fig.canvas.draw()
+        assert not any("findfont" in record.getMessage() for record in caplog.records)
+    finally:
+        plt.close(fig)

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -81,6 +81,24 @@ def test_report_writes_a_separate_png_per_rotation(tmp_path: Path) -> None:
     assert {p.name for p in output_dir.iterdir()} == {"3.png", "4.png"}
 
 
+def test_report_floors_the_y_axis_at_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """wR2/R_obs never go negative, so the plot must not auto-zoom into a narrow non-zero band."""
+    import matplotlib.axes
+
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    original = matplotlib.axes.Axes.set_ylim
+
+    def recording_set_ylim(self: matplotlib.axes.Axes, *args: object, **kwargs: object) -> object:
+        calls.append((args, kwargs))
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(matplotlib.axes.Axes, "set_ylim", recording_set_ylim)
+
+    ThicknessPlotLogger(tmp_path / "thickness_optim").report(_EVENT)
+
+    assert any(kwargs.get("bottom") == 0 for _, kwargs in calls)
+
+
 def test_thickness_nn_shape_plot_carries_its_dataset_title(tmp_path: Path) -> None:
     png = tmp_path / "thickness_nn_shape_a.png"
 


### PR DESCRIPTION
wR2 and R_obs are non-negative, so a run whose scores sit in a narrow band well above zero got an
axis auto-zoomed into that band. The curve then looked far more dramatic than it is: a fit varying
between 0.048 and 0.052 filled the frame top to bottom and read as a strong, well-determined
minimum rather than the flat curve it actually is.

Anchoring the bottom at zero keeps the vertical scale honest, so the depth of the minimum is
readable at a glance and comparable between rotations.

---

## Stack position

This is one of 10 PRs splitting `feature/observability-report-sections` (~1500 lines, 28 files)
into single-concern pieces. **They are stacked: this PR's base is `fix/thickness-plot-findfont-spam`**, so the diff shows
only its own change. **Merge bottom-up, in this order** — merging out of order will pull in
unreviewed commits from below:

| # | PR | branch | |
|---|---|---|---|
| 1 | #179 | `fix/thickness-plot-findfont-spam` |  |
| 2 | _not yet opened_ | `fix/thickness-plot-y-axis-floor` |  **← this PR** |
| 3 | _not yet opened_ | `fix/unique-reflection-counts` |  |
| 4 | _not yet opened_ | `refactor/preprocess-outcome` |  |
| 5 | _not yet opened_ | `refactor/remove-quiet-flag` |  |
| 6 | _not yet opened_ | `feat/console-completion-boxes` |  |
| 7 | _not yet opened_ | `feat/validation-metrics-per-epoch` |  |
| 8 | _not yet opened_ | `feat/dataset-ref-on-rotations` | foundation for 9 and 10 |
| 9 | _not yet opened_ | `feat/report-orientation-search-section` | needs 8 |
| 10 | _not yet opened_ | `feat/report-per-dataset-summary` | needs 8 |

