### PR TITLE
Render both completion boxes from the event stream, on every entry point

### DIFF
--- a/src/diffBloch/app/cli.py
+++ b/src/diffBloch/app/cli.py
@@ -11,13 +11,12 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from typing import cast
 
 import yaml
 from pydantic import ValidationError
 
 from diffBloch import __version__
-from diffBloch.app.loggers import ConsoleLogger, CSVLogger, residual_label
+from diffBloch.app.loggers import ConsoleLogger, CSVLogger
 from diffBloch.app.loggers.summary import SummaryLogger
 from diffBloch.app.program import (
     converge_experiment,
@@ -26,30 +25,7 @@ from diffBloch.app.program import (
     run_experiment,
 )
 from diffBloch.config import load_config, write_experiment_lock
-from diffBloch.engine.plan import OrientationPlanLike
-from diffBloch.observability import (
-    Logger,
-    MultiLogger,
-    OrientationOptimized,
-    RecordingLogger,
-)
-
-
-def _print_summary_box(title: str, rows: tuple[tuple[str, str], ...]) -> None:
-    """Print a consistently aligned 62-column completion summary.
-
-    ``label_width`` must exceed the longest label any caller passes: the format spec pads but does
-    not truncate, so a longer label silently pushes its value past the box border and misaligns that
-    row against every other.
-    """
-    width = 62
-    label_width = 26
-    value_width = width - label_width - 3
-    heading = f" {title} "
-    print(f"╭{heading:─^{width}}╮")
-    for label, value in rows:
-        print(f"│ {label:<{label_width}} {value:<{value_width}} │")
-    print(f"╰{'─' * width}╯")
+from diffBloch.observability import Logger, MultiLogger
 
 
 def _add_stage_flags(parser: argparse.ArgumentParser) -> None:
@@ -273,11 +249,9 @@ def main(argv: list[str] | None = None) -> int:
             level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S"
         )
         try:
-            summary_logger = RecordingLogger()
-            logger: Logger = MultiLogger((_build_logger(csv=args.csv), summary_logger))
             plan = preprocess_experiment(
                 args.experiment_directory,
-                logger=logger,
+                logger=_build_logger(csv=args.csv),
                 checkpoint=not args.no_checkpoint,
                 refresh=args.refresh,
                 device=args.device,
@@ -291,30 +265,8 @@ def main(argv: list[str] | None = None) -> int:
                 raise
             print(f"error: {exc}", file=sys.stderr)
             return 1
-        print()
-        built = cast(tuple[OrientationPlanLike, ...], plan.orientations)
-        total_hkl = sum(int(op.pattern.hkl.shape[0]) for op in built)
-        matched_hkl = sum(int(op.alignment.hkl.shape[0]) for op in built)
-        fitted = [
-            event for event in summary_logger.events if isinstance(event, OrientationOptimized)
-        ]
-        mean_loss = (
-            f"{sum(event.score for event in fitted) / len(fitted):.6g}"
-            if fitted
-            else "n/a (checkpoint reused)"
-        )
-        mean_label = f"Mean {residual_label(fitted[0].residual)}" if fitted else "Mean score"
-        _print_summary_box(
-            "PREPROCESS COMPLETE",
-            (
-                ("Rotations", str(len(plan.orientations))),
-                ("Stages", str(len(plan.provenance))),
-                ("Total HKLs", str(total_hkl)),
-                ("Matched HKLs", str(matched_hkl)),
-                ("Solve beams (max/rotation)", str(max(int(op.beam_hkl.shape[0]) for op in built))),
-                (mean_label, mean_loss),
-            ),
-        )
+        # ConsoleLogger printed "PREPROCESS COMPLETE" the moment preprocessing settled -- the same
+        # box a refine/infer run gets, from the same sink.
         print()
         print("Pipeline")
         for index, record in enumerate(plan.provenance, start=1):
@@ -347,7 +299,7 @@ def main(argv: list[str] | None = None) -> int:
                 _build_logger(csv=args.csv),
                 SummaryLogger(report_path),
             )
-            refined = refine_experiment(
+            refine_experiment(
                 args.experiment_directory,
                 logger=MultiLogger(refine_sinks),
                 checkpoint=not args.no_checkpoint,
@@ -366,30 +318,9 @@ def main(argv: list[str] | None = None) -> int:
                 raise
             print(f"error: {exc}", file=sys.stderr)
             return 1
-        best = refined.history[refined.best_step]
-        wr2 = "n/a" if best.wr2 is None else f"{best.wr2:.6g}"
-        r_obs = "n/a" if best.r_obs is None else f"{best.r_obs:.6g}"
-        diff_loss = "n/a" if best.diff_loss is None else f"{best.diff_loss:.6g}"
-        counts = refined.reflection_counts
-        print()
-        _print_summary_box(
-            "REFINEMENT COMPLETE",
-            (
-                ("Best epoch", str(refined.best_step + 1)),
-                ("Objective", f"{refined.best_loss:.6g}"),
-                ("wR2", wr2),
-                ("R_obs", r_obs),
-                ("Diffraction loss", diff_loss),
-                (
-                    "HKLs (Observed/total)",
-                    f"{counts['matched_i_gt_3sigma']} / {counts['matched']}",
-                ),
-            ),
-        )
-        print()
-        print("Output files")
-        for name, path in refined.artifacts.items():
-            print(f"  • {name.replace('_', ' ').title():<20} {path}")
+        # ConsoleLogger printed "REFINEMENT COMPLETE" and the artifact list off the run's terminal
+        # event. The report is the one output this file chose the location of, so it is also the
+        # one line this file still prints.
         print(f"  • {'Refinement Report':<20} {report_path}")
         return 0
 
@@ -428,8 +359,9 @@ def main(argv: list[str] | None = None) -> int:
 def _build_logger(*, csv: str | None, per_rotation: bool = True) -> Logger:
     """Combine the observation sinks every command gets: the console, plus a CSV log if asked.
 
-    The single place a CLI run's sinks are assembled. ``per_rotation`` opts the console into the
-    settled per-rotation stream.
+    The single place a CLI run's sinks are assembled, so a newly observable phase is rendered by
+    teaching :class:`~diffBloch.app.loggers.ConsoleLogger` its event rather than by wiring another
+    sink into each command. ``per_rotation`` opts the console into the settled per-rotation stream.
     """
     console = ConsoleLogger(per_rotation=per_rotation)
     if csv is None:

--- a/src/diffBloch/app/loggers/__init__.py
+++ b/src/diffBloch/app/loggers/__init__.py
@@ -41,8 +41,11 @@ from diffBloch.observability import (
     OrientationOptimized,
     PlanSeeded,
     PlanStepCompleted,
+    PreprocessCompleted,
     RefinedRotationMetrics,
+    RefinementCompleted,
     RefinementOrientationStep,
+    RefinementOutputsWritten,
     RefinementStarted,
     RefinementStep,
     ThicknessOptimizationStarted,
@@ -55,6 +58,7 @@ __all__ = [
     "EarlyAbortLogger",
     "FitAbortedError",
     "format_measurements",
+    "print_summary_box",
     "namespaced_measurements",
     "residual_label",
 ]
@@ -161,6 +165,29 @@ def _render_progress_bar(current: int, total: int, elapsed: float, suffix: str) 
         sys.stdout.write("\n")
 
 
+def print_summary_box(title: str, rows: tuple[tuple[str, str], ...]) -> None:
+    """Print a consistently aligned 62-column completion summary.
+
+    ``label_width`` must exceed the longest label any caller passes: the format spec pads but does
+    not truncate, so a longer label silently pushes its value past the box border and misaligns that
+    row against every other. Every "... COMPLETE" box in a run goes through here, so they all look
+    the same regardless of which phase printed it.
+
+    Flushed on completion: the diagnostics log goes to stderr while these go to stdout, and stdout
+    is block-buffered whenever it is not a terminal. Without the flush a redirected run (CI, a SLURM
+    job file) shows the preprocess box far below the refinement lines it actually preceded, since it
+    is emitted mid-run rather than at exit.
+    """
+    width = 62
+    label_width = 26
+    value_width = width - label_width - 3
+    heading = f" {title} "
+    print(f"╭{heading:─^{width}}╮")
+    for label, value in rows:
+        print(f"│ {label:<{label_width}} {value:<{value_width}} │")
+    print(f"╰{'─' * width}╯", flush=True)
+
+
 @dataclass
 class ConsoleLogger:
     """Log each event to stdlib ``logging`` at ``level`` (console/file handlers attached by app).
@@ -194,8 +221,25 @@ class ConsoleLogger:
     _thickness_total: int = field(default=0, init=False, repr=False)
     _thickness_seen: int = field(default=0, init=False, repr=False)
     _thickness_started_at: float = field(default=0.0, init=False, repr=False)
+    # Accumulated for the PREPROCESS COMPLETE box: the orientation search's mean settled score and
+    # the residual it was scored under. Empty when the run reused a checkpoint and ran no search.
+    _orientation_scores: list[float] = field(default_factory=list, init=False, repr=False)
+    _orientation_residual: str | None = field(default=None, init=False, repr=False)
+    # Accumulated for the REFINEMENT COMPLETE box: every epoch's headline numbers, keyed by
+    # iteration, so RefinementCompleted's best_step can name the epoch whose row to print.
+    _epochs: dict[int, RefinementStep] = field(default_factory=dict, init=False, repr=False)
+    _completed: RefinementCompleted | None = field(default=None, init=False, repr=False)
 
     def report(self, event: Event) -> None:
+        if isinstance(event, PreprocessCompleted):
+            self._print_preprocess_box(event)
+            return
+        if isinstance(event, RefinementCompleted):
+            self._completed = event
+            return
+        if isinstance(event, RefinementOutputsWritten):
+            self._print_refinement_box(event)
+            return
         if isinstance(event, DeviceSelected):
             _log.log(self.level, _format_device_selection(event))
             return
@@ -358,10 +402,13 @@ class ConsoleLogger:
             )
             return
         if isinstance(event, OrientationOptimized):
+            self._orientation_scores.append(event.score)
+            self._orientation_residual = event.residual
             label = f"orientation optimization[rotation_index={event.rotation_index}]"
         elif isinstance(event, ThicknessOptimized):
             label = f"thickness optimization[rotation_index={event.rotation_index}]"
         elif isinstance(event, RefinementStep):
+            self._epochs[event.iteration] = event
             wr2 = _mean_over(event.wr2, event.n_wr2_evaluated, event.n_rotations)
             r_obs = _mean_over(event.r_obs, event.n_r_obs_evaluated, event.n_rotations)
             diff_loss = "n/a" if event.diff_loss is None else f"{event.diff_loss:.6f}"
@@ -418,6 +465,78 @@ class ConsoleLogger:
         else:
             label = event.channel if event.step is None else f"{event.channel}[{event.step}]"
         _log.log(self.level, "%s %s", label, format_measurements(event))
+
+    def _print_preprocess_box(self, event: PreprocessCompleted) -> None:
+        """Render "PREPROCESS COMPLETE" -- every entry point's preprocessing, not just the command.
+
+        Driven entirely by the event, so ``infer`` and ``refine`` (which swallow preprocessing
+        internally and go straight into their next phase) get the same box a standalone
+        ``preprocess`` run does, from the same sink, with no per-command wiring.
+        """
+        mean_label = (
+            f"Mean {residual_label(self._orientation_residual)}"
+            if self._orientation_residual
+            else "Mean score"
+        )
+        mean_value = (
+            f"{sum(self._orientation_scores) / len(self._orientation_scores):.6g}"
+            if self._orientation_scores
+            # No OrientationOptimized events means no search ran -- the settled orientations came
+            # back off a checkpoint, so there is no mean to report rather than a mean of zero.
+            else "n/a (checkpoint reused)"
+        )
+        print()
+        print_summary_box(
+            "PREPROCESS COMPLETE",
+            (
+                ("Rotations", str(event.n_rotations)),
+                ("Stages", str(event.n_stages)),
+                ("Total HKLs", str(event.total_hkl)),
+                ("Matched HKLs", str(event.matched_hkl)),
+                ("Solve beams (max/rotation)", str(event.max_solve_beams)),
+                (mean_label, mean_value),
+            ),
+        )
+        self._orientation_scores = []
+        self._orientation_residual = None
+
+    def _print_refinement_box(self, event: RefinementOutputsWritten) -> None:
+        """Render "REFINEMENT COMPLETE" + the written artifacts, on the run's terminal event.
+
+        ``RefinementOutputsWritten`` is deliberately the trigger rather than ``RefinementCompleted``:
+        the box lists the files, so it must not print until they exist. The numbers come from the
+        epoch this run selected (``RefinementCompleted.best_step`` indexing the remembered
+        ``RefinementStep`` stream), which is why both events are tracked rather than one.
+        """
+        completed = self._completed
+        best = None if completed is None else self._epochs.get(completed.best_step)
+        if completed is not None and best is not None:
+            counts = completed.reflection_counts
+
+            def cell(value: float | None) -> str:
+                return "n/a" if value is None else f"{value:.6g}"
+
+            print()
+            print_summary_box(
+                "REFINEMENT COMPLETE",
+                (
+                    ("Best epoch", str(completed.best_step + 1)),
+                    ("Objective", f"{completed.best_loss:.6g}"),
+                    ("wR2", cell(best.wr2)),
+                    ("R_obs", cell(best.r_obs)),
+                    ("Diffraction loss", cell(best.diff_loss)),
+                    (
+                        "HKLs (Observed/total)",
+                        f"{counts['matched_i_gt_3sigma']} / {counts['matched']}",
+                    ),
+                ),
+            )
+        print()
+        print("Output files")
+        for name, path in event.artifacts.items():
+            print(f"  • {name.replace('_', ' ').title():<20} {path}")
+        self._epochs = {}
+        self._completed = None
 
 
 @dataclass

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, replace
 from pathlib import Path
+from typing import cast
 
 import gemmi
 import numpy as np
@@ -69,6 +70,7 @@ from diffBloch.engine import (
     build_refinement_problem,
     run_refinement_model,
 )
+from diffBloch.engine.plan import OrientationPlanLike
 from diffBloch.io import (
     ExperimentalRecord,
     StructureRecord,
@@ -81,6 +83,7 @@ from diffBloch.observability import (
     DeviceSelected,
     Logger,
     MultiLogger,
+    PreprocessCompleted,
     RefinedRotationMetrics,
     RefinementOutputsWritten,
 )
@@ -1013,6 +1016,16 @@ def _preprocess(
         None
         if any(sha is None for sha in lock_sha256s)
         else tuple(sha for sha in lock_sha256s if sha is not None)
+    )
+    built = cast(tuple[OrientationPlanLike, ...], pooled.orientations)
+    logger.report(
+        PreprocessCompleted(
+            n_rotations=len(built),
+            n_stages=len(pooled.provenance),
+            total_hkl=sum(int(op.pattern.hkl.shape[0]) for op in built),
+            matched_hkl=sum(int(op.alignment.hkl.shape[0]) for op in built),
+            max_solve_beams=max(int(op.beam_hkl.shape[0]) for op in built),
+        )
     )
     return PreprocessOutcome(
         refinement=refinement_setup,

--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -46,6 +46,7 @@ __all__ = [
     "OrientationOptimizationSummary",
     "PlanSeeded",
     "PlanStepCompleted",
+    "PreprocessCompleted",
     "RecordingLogger",
     "RefinedRotationMetrics",
     "RefinementCompleted",
@@ -481,6 +482,45 @@ class CouplingSummary:
     @property
     def step(self) -> int | None:
         return None
+
+
+@dataclass(frozen=True)
+class PreprocessCompleted:
+    """The pooled ``Plan``'s settled shape, emitted once when preprocessing finishes.
+
+    Emitted from the shared ``_preprocess`` spine every public entry point
+    (``preprocess_experiment``, ``run_experiment``, ``refine_experiment``) funnels through, so a
+    console sink can print the same "preprocessing is done" summary regardless of which one is
+    running. Before this event existed, only ``preprocess_experiment``'s own CLI handler could show
+    it -- it alone had the settled ``Plan`` back in hand to inspect after the call returned;
+    ``run_experiment``/``refine_experiment`` swallow preprocessing internally and go straight into
+    their own next phase, so a sink attached to *them* had no equivalent moment to react to.
+
+    ``n_stages`` is the settled plan's recipe length (``provenance``) and ``max_solve_beams`` the
+    widest per-rotation solve; both are here because the console box shows them, and an event that
+    carried only the cheap-to-compute fields would quietly shrink what a sink can render.
+    """
+
+    channel: ClassVar[str] = "preprocess"
+    n_rotations: int
+    n_stages: int
+    total_hkl: int
+    matched_hkl: int
+    max_solve_beams: int
+
+    @property
+    def step(self) -> int | None:
+        return None  # a run-level aggregate has no position on the per-rotation axis
+
+    @property
+    def measurements(self) -> Mapping[str, float]:
+        return {
+            "n_rotations": float(self.n_rotations),
+            "n_stages": float(self.n_stages),
+            "total_hkl": float(self.total_hkl),
+            "matched_hkl": float(self.matched_hkl),
+            "max_solve_beams": float(self.max_solve_beams),
+        }
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -10,11 +10,22 @@ from pydantic import ValidationError
 
 from diffBloch.app.cli import main
 from diffBloch.app.loggers import ConsoleLogger
-from diffBloch.observability import MultiLogger, OrientationOptimized
+from diffBloch.observability import (
+    Logger,
+    MultiLogger,
+    OrientationOptimized,
+    PreprocessCompleted,
+    RefinementCompleted,
+    RefinementOutputsWritten,
+    RefinementStep,
+)
 from diffBloch.preprocess.inference import InferenceResult, RotationInference
 
 FIXTURE = Path(__file__).parent.parent / "fixtures" / "quartz_min" / "experiment.yaml"
 LOCKED = Path(__file__).parent.parent / "fixtures" / "locked_min"
+# A real CIF on disk: SummaryLogger reads the written structure back on the terminal event, so the
+# artifact path a fake emits has to point at a file that parses.
+REFINED_CIF = Path(__file__).parent.parent / "fixtures" / "quartz_anchor" / "enantiomer_1.cif"
 
 
 def _summary_row(out: str, label: str, value: str) -> bool:
@@ -159,7 +170,8 @@ def test_infer_delegates_to_run_experiment_and_reports(
 
     assert rc == 0
     assert captured["dir"] == "/some/experiment"
-    assert isinstance(captured["logger"], ConsoleLogger)  # console on by default (no --quiet)
+    # One sink renders everything, boxes included, so the default shape is a bare ConsoleLogger.
+    assert isinstance(captured["logger"], ConsoleLogger)
     assert captured["checkpoint"] is True  # checkpoint on by default
     assert captured["refresh"] is False
     assert captured["workers"] == 1  # sequential by default
@@ -328,6 +340,13 @@ def test_preprocess_delegates_and_reports_without_scoring(
                 pass_cap=2000,
             )
         )
+        # _preprocess() itself emits this once preprocessing settles; ConsoleLogger is what turns
+        # it into the PREPROCESS COMPLETE box, so the fake must emit it too.
+        logger.report(
+            PreprocessCompleted(
+                n_rotations=2, n_stages=3, total_hkl=7, matched_hkl=5, max_solve_beams=9
+            )
+        )
         return _FakePlan()
 
     monkeypatch.setattr("diffBloch.app.cli.preprocess_experiment", fake_preprocess_experiment)
@@ -335,14 +354,16 @@ def test_preprocess_delegates_and_reports_without_scoring(
 
     assert rc == 0
     assert captured["dir"] == "/some/experiment"
-    assert isinstance(captured["logger"], MultiLogger)
+    assert isinstance(captured["logger"], ConsoleLogger)
     assert captured["checkpoint"] is True and captured["refresh"] is False
     assert captured["workers"] == 1 and captured["device"] == "cuda"
     out = capsys.readouterr().out
     assert "PREPROCESS COMPLETE" in out
     assert _summary_row(out, "Rotations", "2")
+    assert _summary_row(out, "Stages", "3")
     assert _summary_row(out, "Total HKLs", "7")
     assert _summary_row(out, "Matched HKLs", "5")
+    assert _summary_row(out, "Solve beams (max/rotation)", "9")
     assert _summary_row(out, "Mean wR2", "0.375")
     assert "Optimize Orientation" in out
     assert "Optimize Thickness" in out
@@ -421,13 +442,15 @@ def _fake_refinement_result() -> SimpleNamespace:
             "matched_i_le_3sigma": 4,
             "unmatched_observed": 3,
         },
-        artifacts={"refined_structure": "/tmp/refined_structure.cif"},
+        artifacts={"refined_structure": str(REFINED_CIF)},
     )
 
 
 def test_refine_delegates_and_reports(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:
+    # A real directory: the fake emits the terminal event, so SummaryLogger actually writes its
+    # report next to it -- the same fan-out a real run does.
     captured: dict[str, object] = {}
 
     def fake_refine_experiment(
@@ -447,13 +470,41 @@ def test_refine_delegates_and_reports(
         captured["dir"] = experiment_dir
         captured["logger"] = logger
         captured["checkpoint"] = checkpoint
-        return _fake_refinement_result()
+        result = _fake_refinement_result()
+        # The box now comes off the event stream rather than off this return value, so the fake
+        # emits what a real refine_experiment emits: the per-epoch steps, then the run summary,
+        # then the terminal outputs event the box and the file list print on.
+        assert isinstance(logger, Logger)
+        for iteration, step in enumerate(result.history):
+            logger.report(
+                RefinementStep(
+                    iteration=iteration,
+                    loss=float(result.losses[iteration]),
+                    wr2=step.wr2,
+                    r_obs=step.r_obs,
+                    diff_loss=step.diff_loss,
+                )
+            )
+        logger.report(
+            RefinementCompleted(
+                n_steps=len(result.history),
+                best_step=result.best_step,
+                best_loss=result.best_loss,
+                reflection_counts=result.reflection_counts,
+            )
+        )
+        logger.report(
+            RefinementOutputsWritten(
+                structure=result.artifacts["refined_structure"], artifacts=result.artifacts
+            )
+        )
+        return result
 
     monkeypatch.setattr("diffBloch.app.cli.refine_experiment", fake_refine_experiment)
-    rc = main(["refine", "/some/experiment"])
+    rc = main(["refine", str(tmp_path)])
 
     assert rc == 0
-    assert captured["dir"] == "/some/experiment"
+    assert captured["dir"] == str(tmp_path)
     # The refine path fans out to the console and to the summary sink that writes
     # refinement_report.txt -- composed here, not inside refine_experiment.
     logger = captured["logger"]
@@ -467,7 +518,7 @@ def test_refine_delegates_and_reports(
     assert _summary_row(out, "Diffraction loss", "1")
     assert _summary_row(out, "HKLs (Observed/total)", "8 / 12")
     assert "Refined Structure" in out
-    assert "/tmp/refined_structure.cif" in out
+    assert str(REFINED_CIF) in out
 
 
 def test_refine_flags_thread_through(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import csv
 import logging
+import re
 import sys
 import types
 from pathlib import Path
@@ -42,9 +43,11 @@ from diffBloch.observability import (
     OrientationOptimizationSummary,
     OrientationOptimized,
     PlanStepCompleted,
+    PreprocessCompleted,
     RecordingLogger,
     RefinementCompleted,
     RefinementOrientationStep,
+    RefinementOutputsWritten,
     RefinementStarted,
     RefinementStep,
     RotationCoupling,
@@ -749,3 +752,108 @@ def test_console_logger_omits_the_marker_without_a_pass_header() -> None:
     """No announced threshold means no claim about settling, rather than a guess."""
     logger = ConsoleLogger(level=logging.INFO)
     assert logger._r_factor_threshold is None
+
+
+# --- ConsoleLogger completion boxes ------------------------------------------------------------
+
+
+def _preprocess_completed(**overrides: int) -> PreprocessCompleted:
+    fields = {
+        "n_rotations": 2,
+        "n_stages": 3,
+        "total_hkl": 100,
+        "matched_hkl": 80,
+        "max_solve_beams": 40,
+    }
+    return PreprocessCompleted(**{**fields, **overrides})
+
+
+def test_console_logger_prints_the_preprocess_box_on_preprocess_completed(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The box prints from the event stream alone -- the same way whether the caller is
+    preprocess_experiment, run_experiment, or refine_experiment, since all three funnel through
+    the shared _preprocess spine that emits PreprocessCompleted."""
+    logger = ConsoleLogger()
+    logger.report(_fitted(index=0, score=0.4, residual="wr2"))
+    logger.report(_fitted(index=1, score=0.2, residual="wr2"))
+    logger.report(_preprocess_completed())
+
+    out = capsys.readouterr().out
+    assert "PREPROCESS COMPLETE" in out
+    assert re.search(r"Rotations\s+2", out)
+    assert re.search(r"Stages\s+3", out)
+    assert re.search(r"Total HKLs\s+100", out)
+    assert re.search(r"Matched HKLs\s+80", out)
+    assert re.search(r"Solve beams \(max/rotation\)\s+40", out)
+    assert re.search(r"Mean wR2\s+0\.3", out)  # mean of 0.4 and 0.2
+
+
+def test_console_logger_preprocess_box_states_checkpoint_reuse_with_no_orientation_events(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A reused checkpoint runs no orientation search -- the box must say so, not claim a mean."""
+    logger = ConsoleLogger()
+    logger.report(_preprocess_completed(n_rotations=5, total_hkl=50, matched_hkl=40))
+
+    out = capsys.readouterr().out
+    assert re.search(r"Mean score\s+n/a \(checkpoint reused\)", out)
+
+
+def test_console_logger_preprocess_box_resets_between_completions() -> None:
+    """A logger instance reused across two settle events must not leak the first run's scores into
+    the second's mean."""
+    logger = ConsoleLogger()
+    logger.report(_fitted(index=0, score=0.9, residual="wr2"))
+    logger.report(_preprocess_completed())
+    logger.report(_preprocess_completed())
+
+    assert logger._orientation_scores == []
+    assert logger._orientation_residual is None
+
+
+def test_console_logger_prints_the_refinement_box_on_outputs_written(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The box reports the *selected* epoch's numbers, so it needs both the step stream (for the
+    per-epoch values) and RefinementCompleted (for which epoch was selected); it prints on
+    RefinementOutputsWritten because it also lists files that must exist by then."""
+    logger = ConsoleLogger()
+    logger.report(RefinementStep(iteration=0, loss=1.0, wr2=0.5, r_obs=0.4, diff_loss=0.3))
+    logger.report(RefinementStep(iteration=1, loss=0.5, wr2=0.2, r_obs=0.1, diff_loss=0.05))
+    logger.report(
+        RefinementCompleted(
+            n_steps=2,
+            best_step=1,
+            best_loss=0.5,
+            reflection_counts={"matched": 90, "matched_i_gt_3sigma": 60},
+        )
+    )
+    logger.report(
+        RefinementOutputsWritten(
+            structure="/out/refined_structure.cif",
+            artifacts={"refined_structure": "/out/refined_structure.cif"},
+        )
+    )
+
+    out = capsys.readouterr().out
+    assert "REFINEMENT COMPLETE" in out
+    assert re.search(r"Best epoch\s+2", out)  # 1-based, from best_step=1
+    assert re.search(r"wR2\s+0\.2", out)  # epoch 2's value, not epoch 1's
+    assert re.search(r"HKLs \(Observed/total\)\s+60 / 90", out)
+    assert "Refined Structure" in out and "/out/refined_structure.cif" in out
+
+
+def test_console_logger_lists_outputs_even_without_a_refinement_summary(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """RefinementOutputsWritten is emitted by paths that never ran a refinement loop, so the file
+    list must not depend on a RefinementCompleted that never arrives."""
+    logger = ConsoleLogger()
+    logger.report(
+        RefinementOutputsWritten(structure="/out/s.cif", artifacts={"structure": "/out/s.cif"})
+    )
+
+    out = capsys.readouterr().out
+    assert "REFINEMENT COMPLETE" not in out
+    assert "Output files" in out


### PR DESCRIPTION
Only a standalone `preprocess` run could show `PREPROCESS COMPLETE`. It alone had the settled `Plan`
back in hand to inspect after the call returned; `run_experiment` and `refine_experiment` swallow
preprocessing internally and go straight into their next phase, so **a long `refine` gave no sign
that preprocessing had finished at all** — including any orientation search it ran.

This adds `PreprocessCompleted`, emitted from the shared `_preprocess` spine all three entry points
funnel through, and lets `ConsoleLogger` render the box off it. The event carries the plan's whole
settled shape — rotations, stages, total and matched HKLs, widest per-rotation solve — rather than
only the fields that were cheap at the emit site, so a sink is not silently limited in what it can
show.

`REFINEMENT COMPLETE` and the output-file list move the same way, onto `RefinementCompleted` plus
`RefinementOutputsWritten`, which already carried every field `cli.py` was reassembling from the
return value. Outputs-written is the trigger rather than completed, since the box lists files that
must exist by then.

That leaves **one** place rendering console output instead of two, and `cli.py`'s three handlers
collapse to call-and-return. The only line `cli.py` still prints is the report path, because
`cli.py` is what chose where `SummaryLogger` writes and that path is not among the run's artifacts.

### The flush

The boxes now flush. They are emitted mid-run, and stdout is block-buffered whenever it is not a
terminal while the diagnostics log goes to stderr — so without it a redirected run (CI, a SLURM job
file) showed the preprocess box far below the refinement lines it actually preceded. Verified
against a real piped `refine` on the quartz example.

### Testing

Box rendering is tested at the `ConsoleLogger` level; the CLI tests now drive the boxes by emitting
the same events a real run emits, rather than asserting on a return value the CLI no longer reads.
End-to-end on `examples/Colmey_et_al_2026/data/quartz-no-abs`: both boxes appear, in the right order
when piped, with all six `PREPROCESS COMPLETE` rows.

---

## Stack position

This is one of 10 PRs splitting `feature/observability-report-sections` (~1500 lines, 28 files)
into single-concern pieces. **They are stacked: this PR's base is `refactor/remove-quiet-flag`**, so the diff shows
only its own change. **Merge bottom-up, in this order** — merging out of order will pull in
unreviewed commits from below:

| # | PR | branch | |
|---|---|---|---|
| 1 | #179 | `fix/thickness-plot-findfont-spam` |  |
| 2 | #180 | `fix/thickness-plot-y-axis-floor` |  |
| 3 | #181 | `fix/unique-reflection-counts` |  |
| 4 | #182 | `refactor/preprocess-outcome` |  |
| 5 | #183 | `refactor/remove-quiet-flag` |  |
| 6 | _not yet opened_ | `feat/console-completion-boxes` |  **← this PR** |
| 7 | _not yet opened_ | `feat/validation-metrics-per-epoch` |  |
| 8 | _not yet opened_ | `feat/dataset-ref-on-rotations` | foundation for 9 and 10 |
| 9 | _not yet opened_ | `feat/report-orientation-search-section` | needs 8 |
| 10 | _not yet opened_ | `feat/report-per-dataset-summary` | needs 8 |

