### PR TITLE
Carry each rotation's exp_data ref on its own pattern

### DIFF
--- a/src/diffBloch/app/cli.py
+++ b/src/diffBloch/app/cli.py
@@ -11,13 +11,12 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from typing import cast
 
 import yaml
 from pydantic import ValidationError
 
 from diffBloch import __version__
-from diffBloch.app.loggers import ConsoleLogger, CSVLogger, residual_label
+from diffBloch.app.loggers import ConsoleLogger, CSVLogger
 from diffBloch.app.loggers.summary import SummaryLogger
 from diffBloch.app.program import (
     converge_experiment,
@@ -26,30 +25,7 @@ from diffBloch.app.program import (
     run_experiment,
 )
 from diffBloch.config import load_config, write_experiment_lock
-from diffBloch.engine.plan import OrientationPlanLike
-from diffBloch.observability import (
-    Logger,
-    MultiLogger,
-    OrientationOptimized,
-    RecordingLogger,
-)
-
-
-def _print_summary_box(title: str, rows: tuple[tuple[str, str], ...]) -> None:
-    """Print a consistently aligned 62-column completion summary.
-
-    ``label_width`` must exceed the longest label any caller passes: the format spec pads but does
-    not truncate, so a longer label silently pushes its value past the box border and misaligns that
-    row against every other.
-    """
-    width = 62
-    label_width = 26
-    value_width = width - label_width - 3
-    heading = f" {title} "
-    print(f"╭{heading:─^{width}}╮")
-    for label, value in rows:
-        print(f"│ {label:<{label_width}} {value:<{value_width}} │")
-    print(f"╰{'─' * width}╯")
+from diffBloch.observability import Logger, MultiLogger
 
 
 def _add_stage_flags(parser: argparse.ArgumentParser) -> None:
@@ -273,11 +249,9 @@ def main(argv: list[str] | None = None) -> int:
             level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S"
         )
         try:
-            summary_logger = RecordingLogger()
-            logger: Logger = MultiLogger((_build_logger(csv=args.csv), summary_logger))
             plan = preprocess_experiment(
                 args.experiment_directory,
-                logger=logger,
+                logger=_build_logger(csv=args.csv),
                 checkpoint=not args.no_checkpoint,
                 refresh=args.refresh,
                 device=args.device,
@@ -291,30 +265,8 @@ def main(argv: list[str] | None = None) -> int:
                 raise
             print(f"error: {exc}", file=sys.stderr)
             return 1
-        print()
-        built = cast(tuple[OrientationPlanLike, ...], plan.orientations)
-        total_hkl = sum(int(op.pattern.hkl.shape[0]) for op in built)
-        matched_hkl = sum(int(op.alignment.hkl.shape[0]) for op in built)
-        fitted = [
-            event for event in summary_logger.events if isinstance(event, OrientationOptimized)
-        ]
-        mean_loss = (
-            f"{sum(event.score for event in fitted) / len(fitted):.6g}"
-            if fitted
-            else "n/a (checkpoint reused)"
-        )
-        mean_label = f"Mean {residual_label(fitted[0].residual)}" if fitted else "Mean score"
-        _print_summary_box(
-            "PREPROCESS COMPLETE",
-            (
-                ("Rotations", str(len(plan.orientations))),
-                ("Stages", str(len(plan.provenance))),
-                ("Total HKLs", str(total_hkl)),
-                ("Matched HKLs", str(matched_hkl)),
-                ("Solve beams (max/rotation)", str(max(int(op.beam_hkl.shape[0]) for op in built))),
-                (mean_label, mean_loss),
-            ),
-        )
+        # ConsoleLogger printed "PREPROCESS COMPLETE" the moment preprocessing settled -- the same
+        # box a refine/infer run gets, from the same sink.
         print()
         print("Pipeline")
         for index, record in enumerate(plan.provenance, start=1):
@@ -347,7 +299,7 @@ def main(argv: list[str] | None = None) -> int:
                 _build_logger(csv=args.csv),
                 SummaryLogger(report_path),
             )
-            refined = refine_experiment(
+            refine_experiment(
                 args.experiment_directory,
                 logger=MultiLogger(refine_sinks),
                 checkpoint=not args.no_checkpoint,
@@ -366,30 +318,9 @@ def main(argv: list[str] | None = None) -> int:
                 raise
             print(f"error: {exc}", file=sys.stderr)
             return 1
-        best = refined.history[refined.best_step]
-        wr2 = "n/a" if best.wr2 is None else f"{best.wr2:.6g}"
-        r_obs = "n/a" if best.r_obs is None else f"{best.r_obs:.6g}"
-        diff_loss = "n/a" if best.diff_loss is None else f"{best.diff_loss:.6g}"
-        counts = refined.reflection_counts
-        print()
-        _print_summary_box(
-            "REFINEMENT COMPLETE",
-            (
-                ("Best epoch", str(refined.best_step + 1)),
-                ("Objective", f"{refined.best_loss:.6g}"),
-                ("wR2", wr2),
-                ("R_obs", r_obs),
-                ("Diffraction loss", diff_loss),
-                (
-                    "HKLs (Observed/total)",
-                    f"{counts['matched_i_gt_3sigma']} / {counts['matched']}",
-                ),
-            ),
-        )
-        print()
-        print("Output files")
-        for name, path in refined.artifacts.items():
-            print(f"  • {name.replace('_', ' ').title():<20} {path}")
+        # ConsoleLogger printed "REFINEMENT COMPLETE" and the artifact list off the run's terminal
+        # event. The report is the one output this file chose the location of, so it is also the
+        # one line this file still prints.
         print(f"  • {'Refinement Report':<20} {report_path}")
         return 0
 
@@ -428,8 +359,9 @@ def main(argv: list[str] | None = None) -> int:
 def _build_logger(*, csv: str | None, per_rotation: bool = True) -> Logger:
     """Combine the observation sinks every command gets: the console, plus a CSV log if asked.
 
-    The single place a CLI run's sinks are assembled. ``per_rotation`` opts the console into the
-    settled per-rotation stream.
+    The single place a CLI run's sinks are assembled, so a newly observable phase is rendered by
+    teaching :class:`~diffBloch.app.loggers.ConsoleLogger` its event rather than by wiring another
+    sink into each command. ``per_rotation`` opts the console into the settled per-rotation stream.
     """
     console = ConsoleLogger(per_rotation=per_rotation)
     if csv is None:

--- a/src/diffBloch/app/loggers/__init__.py
+++ b/src/diffBloch/app/loggers/__init__.py
@@ -41,8 +41,11 @@ from diffBloch.observability import (
     OrientationOptimized,
     PlanSeeded,
     PlanStepCompleted,
+    PreprocessCompleted,
     RefinedRotationMetrics,
+    RefinementCompleted,
     RefinementOrientationStep,
+    RefinementOutputsWritten,
     RefinementStarted,
     RefinementStep,
     ThicknessOptimizationStarted,
@@ -55,6 +58,7 @@ __all__ = [
     "EarlyAbortLogger",
     "FitAbortedError",
     "format_measurements",
+    "print_summary_box",
     "namespaced_measurements",
     "residual_label",
 ]
@@ -161,6 +165,29 @@ def _render_progress_bar(current: int, total: int, elapsed: float, suffix: str) 
         sys.stdout.write("\n")
 
 
+def print_summary_box(title: str, rows: tuple[tuple[str, str], ...]) -> None:
+    """Print a consistently aligned 62-column completion summary.
+
+    ``label_width`` must exceed the longest label any caller passes: the format spec pads but does
+    not truncate, so a longer label silently pushes its value past the box border and misaligns that
+    row against every other. Every "... COMPLETE" box in a run goes through here, so they all look
+    the same regardless of which phase printed it.
+
+    Flushed on completion: the diagnostics log goes to stderr while these go to stdout, and stdout
+    is block-buffered whenever it is not a terminal. Without the flush a redirected run (CI, a SLURM
+    job file) shows the preprocess box far below the refinement lines it actually preceded, since it
+    is emitted mid-run rather than at exit.
+    """
+    width = 62
+    label_width = 26
+    value_width = width - label_width - 3
+    heading = f" {title} "
+    print(f"╭{heading:─^{width}}╮")
+    for label, value in rows:
+        print(f"│ {label:<{label_width}} {value:<{value_width}} │")
+    print(f"╰{'─' * width}╯", flush=True)
+
+
 @dataclass
 class ConsoleLogger:
     """Log each event to stdlib ``logging`` at ``level`` (console/file handlers attached by app).
@@ -194,8 +221,25 @@ class ConsoleLogger:
     _thickness_total: int = field(default=0, init=False, repr=False)
     _thickness_seen: int = field(default=0, init=False, repr=False)
     _thickness_started_at: float = field(default=0.0, init=False, repr=False)
+    # Accumulated for the PREPROCESS COMPLETE box: the orientation search's mean settled score and
+    # the residual it was scored under. Empty when the run reused a checkpoint and ran no search.
+    _orientation_scores: list[float] = field(default_factory=list, init=False, repr=False)
+    _orientation_residual: str | None = field(default=None, init=False, repr=False)
+    # Accumulated for the REFINEMENT COMPLETE box: every epoch's headline numbers, keyed by
+    # iteration, so RefinementCompleted's best_step can name the epoch whose row to print.
+    _epochs: dict[int, RefinementStep] = field(default_factory=dict, init=False, repr=False)
+    _completed: RefinementCompleted | None = field(default=None, init=False, repr=False)
 
     def report(self, event: Event) -> None:
+        if isinstance(event, PreprocessCompleted):
+            self._print_preprocess_box(event)
+            return
+        if isinstance(event, RefinementCompleted):
+            self._completed = event
+            return
+        if isinstance(event, RefinementOutputsWritten):
+            self._print_refinement_box(event)
+            return
         if isinstance(event, DeviceSelected):
             _log.log(self.level, _format_device_selection(event))
             return
@@ -358,10 +402,13 @@ class ConsoleLogger:
             )
             return
         if isinstance(event, OrientationOptimized):
+            self._orientation_scores.append(event.score)
+            self._orientation_residual = event.residual
             label = f"orientation optimization[rotation_index={event.rotation_index}]"
         elif isinstance(event, ThicknessOptimized):
             label = f"thickness optimization[rotation_index={event.rotation_index}]"
         elif isinstance(event, RefinementStep):
+            self._epochs[event.iteration] = event
             wr2 = _mean_over(event.wr2, event.n_wr2_evaluated, event.n_rotations)
             r_obs = _mean_over(event.r_obs, event.n_r_obs_evaluated, event.n_rotations)
             diff_loss = "n/a" if event.diff_loss is None else f"{event.diff_loss:.6f}"
@@ -418,6 +465,78 @@ class ConsoleLogger:
         else:
             label = event.channel if event.step is None else f"{event.channel}[{event.step}]"
         _log.log(self.level, "%s %s", label, format_measurements(event))
+
+    def _print_preprocess_box(self, event: PreprocessCompleted) -> None:
+        """Render "PREPROCESS COMPLETE" -- every entry point's preprocessing, not just the command.
+
+        Driven entirely by the event, so ``infer`` and ``refine`` (which swallow preprocessing
+        internally and go straight into their next phase) get the same box a standalone
+        ``preprocess`` run does, from the same sink, with no per-command wiring.
+        """
+        mean_label = (
+            f"Mean {residual_label(self._orientation_residual)}"
+            if self._orientation_residual
+            else "Mean score"
+        )
+        mean_value = (
+            f"{sum(self._orientation_scores) / len(self._orientation_scores):.6g}"
+            if self._orientation_scores
+            # No OrientationOptimized events means no search ran -- the settled orientations came
+            # back off a checkpoint, so there is no mean to report rather than a mean of zero.
+            else "n/a (checkpoint reused)"
+        )
+        print()
+        print_summary_box(
+            "PREPROCESS COMPLETE",
+            (
+                ("Rotations", str(event.n_rotations)),
+                ("Stages", str(event.n_stages)),
+                ("Total HKLs", str(event.total_hkl)),
+                ("Matched HKLs", str(event.matched_hkl)),
+                ("Solve beams (max/rotation)", str(event.max_solve_beams)),
+                (mean_label, mean_value),
+            ),
+        )
+        self._orientation_scores = []
+        self._orientation_residual = None
+
+    def _print_refinement_box(self, event: RefinementOutputsWritten) -> None:
+        """Render "REFINEMENT COMPLETE" + the written artifacts, on the run's terminal event.
+
+        ``RefinementOutputsWritten`` is deliberately the trigger rather than ``RefinementCompleted``:
+        the box lists the files, so it must not print until they exist. The numbers come from the
+        epoch this run selected (``RefinementCompleted.best_step`` indexing the remembered
+        ``RefinementStep`` stream), which is why both events are tracked rather than one.
+        """
+        completed = self._completed
+        best = None if completed is None else self._epochs.get(completed.best_step)
+        if completed is not None and best is not None:
+            counts = completed.reflection_counts
+
+            def cell(value: float | None) -> str:
+                return "n/a" if value is None else f"{value:.6g}"
+
+            print()
+            print_summary_box(
+                "REFINEMENT COMPLETE",
+                (
+                    ("Best epoch", str(completed.best_step + 1)),
+                    ("Objective", f"{completed.best_loss:.6g}"),
+                    ("wR2", cell(best.wr2)),
+                    ("R_obs", cell(best.r_obs)),
+                    ("Diffraction loss", cell(best.diff_loss)),
+                    (
+                        "HKLs (Observed/total)",
+                        f"{counts['matched_i_gt_3sigma']} / {counts['matched']}",
+                    ),
+                ),
+            )
+        print()
+        print("Output files")
+        for name, path in event.artifacts.items():
+            print(f"  • {name.replace('_', ' ').title():<20} {path}")
+        self._epochs = {}
+        self._completed = None
 
 
 @dataclass

--- a/src/diffBloch/app/loggers/__init__.py
+++ b/src/diffBloch/app/loggers/__init__.py
@@ -350,6 +350,14 @@ class ConsoleLogger:
             wr2 = _mean_over(event.wr2, event.n_wr2_evaluated, event.n_rotations)
             r_obs = _mean_over(event.r_obs, event.n_r_obs_evaluated, event.n_rotations)
             suffix = f"epoch │ wR2 {wr2} │ R_obs {r_obs}"
+            if event.val_wr2 is not None:
+                val_wr2 = _mean_over(
+                    event.val_wr2, event.val_n_wr2_evaluated, event.val_n_rotations
+                )
+                val_r_obs = _mean_over(
+                    event.val_r_obs, event.val_n_r_obs_evaluated, event.val_n_rotations
+                )
+                suffix += f" │ val wR2 {val_wr2} │ val R_obs {val_r_obs}"
             # The bar owns its line (``\r``, no newline), so penalties ride in the suffix rather
             # than as extra log lines that would overwrite it.
             for term, values in _penalty_components(event):
@@ -420,6 +428,19 @@ class ConsoleLogger:
                 r_obs,
                 diff_loss,
             )
+            if event.val_wr2 is not None:
+                val_wr2 = _mean_over(
+                    event.val_wr2, event.val_n_wr2_evaluated, event.val_n_rotations
+                )
+                val_r_obs = _mean_over(
+                    event.val_r_obs, event.val_n_r_obs_evaluated, event.val_n_rotations
+                )
+                _log.log(
+                    self.level,
+                    "  validation      │ wR2 %s │ R_obs %s",
+                    val_wr2,
+                    val_r_obs,
+                )
             for term, values in _penalty_components(event):
                 _log.log(
                     self.level,

--- a/src/diffBloch/app/loggers/__init__.py
+++ b/src/diffBloch/app/loggers/__init__.py
@@ -58,8 +58,8 @@ __all__ = [
     "EarlyAbortLogger",
     "FitAbortedError",
     "format_measurements",
-    "print_summary_box",
     "namespaced_measurements",
+    "print_summary_box",
     "residual_label",
 ]
 
@@ -307,7 +307,17 @@ class ConsoleLogger:
             self._refinement_started_at = time.perf_counter()
             return
         if isinstance(event, OrientationOptimizationStarted):
-            _log.log(self.level, "Orientation optimization │ %d rotation(s)", event.total_rotations)
+            if event.dataset:
+                _log.log(
+                    self.level,
+                    "Orientation optimization │ %s │ %d rotation(s)",
+                    event.dataset,
+                    event.total_rotations,
+                )
+            else:
+                _log.log(
+                    self.level, "Orientation optimization │ %d rotation(s)", event.total_rotations
+                )
             self._orientation_total = event.total_rotations
             self._orientation_seen = 0
             self._orientation_started_at = time.perf_counter()
@@ -327,7 +337,17 @@ class ConsoleLogger:
             )
             return
         if isinstance(event, ThicknessOptimizationStarted):
-            _log.log(self.level, "Thickness optimization │ %d rotation(s)", event.total_rotations)
+            if event.dataset:
+                _log.log(
+                    self.level,
+                    "Thickness optimization │ %s │ %d rotation(s)",
+                    event.dataset,
+                    event.total_rotations,
+                )
+            else:
+                _log.log(
+                    self.level, "Thickness optimization │ %d rotation(s)", event.total_rotations
+                )
             self._thickness_total = event.total_rotations
             self._thickness_seen = 0
             self._thickness_started_at = time.perf_counter()

--- a/src/diffBloch/app/loggers/summary.py
+++ b/src/diffBloch/app/loggers/summary.py
@@ -158,6 +158,7 @@ class SummaryLogger:
         self._crystallographic_parameters(lines, rule, Path(outputs.structure))
         self._objective_terms(lines, rule)
         self._objective_components(lines, rule)
+        self._epoch_curve(lines, rule)
         self._rotation_metrics(lines, rule)
         self._thickness_profile(lines, rule)
         self._refined_structure(lines, rule, Path(outputs.structure))
@@ -299,6 +300,31 @@ class SummaryLogger:
         # Every row is a term the objective actually composed. A restraint that was not composed
         # has no row, so this table never reports an inactive term as a satisfied zero.
         lines.append(" (terms not composed into the objective have no row)")
+
+    def _epoch_curve(self, lines: list[str], rule: Callable[[str], None]) -> None:
+        rule("Epoch curve")
+        if not self._steps:
+            lines.append(" n/a (no recorded refinement steps)")
+            return
+
+        def cell(value: float | None) -> str:
+            return "n/a" if value is None or not math.isfinite(value) else f"{value:.6f}"
+
+        # val_wr2/val_r_obs are populated only when refinement.split.train_test held out a
+        # validation set (see RefinementStep) -- included here whenever any step carries them, so
+        # the train/validation curves sit side by side rather than validation only ever surfacing
+        # once, in the final "Validation set" table.
+        has_validation = any(step.val_wr2 is not None for step in self._steps)
+        headers = ["Epoch", "wR2", "R_obs"]
+        if has_validation:
+            headers += ["Val wR2", "Val R_obs"]
+        rows = []
+        for step in self._steps:
+            row = [str(step.iteration + 1), cell(step.wr2), cell(step.r_obs)]
+            if has_validation:
+                row += [cell(step.val_wr2), cell(step.val_r_obs)]
+            rows.append(row)
+        lines.append(ascii_table(headers, rows))
 
     def _rotation_metrics(self, lines: list[str], rule: Callable[[str], None]) -> None:
         def block(rows: Sequence[RefinedRotationMetrics]) -> None:

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, replace
 from pathlib import Path
+from typing import cast
 
 import gemmi
 import numpy as np
@@ -69,6 +70,7 @@ from diffBloch.engine import (
     build_refinement_problem,
     run_refinement_model,
 )
+from diffBloch.engine.plan import OrientationPlanLike
 from diffBloch.io import (
     ExperimentalRecord,
     StructureRecord,
@@ -81,6 +83,7 @@ from diffBloch.observability import (
     DeviceSelected,
     Logger,
     MultiLogger,
+    PreprocessCompleted,
     RefinedRotationMetrics,
     RefinementOutputsWritten,
 )
@@ -1013,6 +1016,16 @@ def _preprocess(
         None
         if any(sha is None for sha in lock_sha256s)
         else tuple(sha for sha in lock_sha256s if sha is not None)
+    )
+    built = cast(tuple[OrientationPlanLike, ...], pooled.orientations)
+    logger.report(
+        PreprocessCompleted(
+            n_rotations=len(built),
+            n_stages=len(pooled.provenance),
+            total_hkl=sum(int(op.pattern.hkl.shape[0]) for op in built),
+            matched_hkl=sum(int(op.alignment.hkl.shape[0]) for op in built),
+            max_solve_beams=max(int(op.beam_hkl.shape[0]) for op in built),
+        )
     )
     return PreprocessOutcome(
         refinement=refinement_setup,

--- a/src/diffBloch/app/program.py
+++ b/src/diffBloch/app/program.py
@@ -99,6 +99,7 @@ from diffBloch.preprocess import (
     optimize_orientation,
     optimize_thickness,
     pipeline,
+    plan_is_readable,
     pool,
     read_plan,
     resolve_recipe,
@@ -625,7 +626,9 @@ def _report_refinement_outcome(
     (which cover held-out rotations too) and the trained thickness curve have to be emitted here,
     where the reporting engine and the split are both in scope. :class:`RefinementOutputsWritten`
     goes last and is the run's terminal event -- a sink that must write exactly once, after
-    everything else, acts on it.
+    everything else, acts on it. Each row already knows its dataset ref (``RotationMetrics.dataset``,
+    read off the rotation's own ``pattern``), so the per-dataset breakdown in the report costs
+    nothing here.
     """
     for row in engine.per_rotation_metrics(result.best_model):
         logger.report(
@@ -635,6 +638,7 @@ def _report_refinement_outcome(
                 r_obs=row.r_obs,
                 n_matched=row.n_matched,
                 is_validation=row.rotation_index in validation_rotation_indices,
+                dataset=row.dataset,
             )
         )
     if raw_alphas is not None:
@@ -664,7 +668,12 @@ def _thickness_networks(
     Ranges follow the cumulative pre-ignore rotation counts in ``inputs.exp_data`` order --
     exactly how :func:`~diffBloch.preprocess.pool` numbers the pooled ``rotation_index`` space --
     so the networks partition that space and composition finds exactly one thickness per
-    orientation. Alphas are normalized independently per dataset so overlapping tilt ranges do
+    orientation. This offset arithmetic looks like the dataset attribution a rotation now carries on
+    its own ``pattern.dataset``, but it is a different quantity and cannot be replaced by it:
+    ``ApparentThicknessNN`` indexes ``normalized_alphas`` by ``rotation_index - start`` and requires
+    the range to be exactly the alphas wide, so the range must span the dataset's *pre-ignore* block.
+    Grouping the settled plan by dataset label would yield the narrower observed span and misalign
+    every alpha lookup. Alphas are normalized independently per dataset so overlapping tilt ranges do
     not share one thickness-vs-alpha curve. A single dataset is simply the N=1 case.
     """
     bounds = ThicknessBounds(spec.min_thickness, spec.max_thickness)
@@ -924,7 +933,9 @@ def _preprocess(
     stable under ignore edits), and the sha256s of the plan locks this run verified or wrote (in
     ``exp_data`` order) -- ``None`` when the run didn't checkpoint, so ``refinement.lock`` never
     chains to a leftover lock this run never validated. Hydrogen sites are loaded per
-    ``inputs.load_hydrogens``.
+    ``inputs.load_hydrogens``. Dataset attribution is *not* returned alongside: each rotation
+    already carries its own ``pattern.dataset`` from :func:`~diffBloch.preprocess.setup_datasets`,
+    which survives the pooled renumbering.
 
     ``plot_thickness`` (API/CLI) ORs with ``cfg.preprocess.thickness.plot`` -- either can turn
     plotting on. ``plot_thickness_dir`` overrides the default output directory,
@@ -1214,7 +1225,7 @@ def _prepare(
         lock = _read_lock_or_none(lock_path)
         status = (
             "stale"
-            if lock is None
+            if lock is None or not plan_is_readable(npz)
             else preprocess_lock_status(
                 lock,
                 structure=structure_lock,

--- a/src/diffBloch/core/products.py
+++ b/src/diffBloch/core/products.py
@@ -214,12 +214,21 @@ class PatternBatch:
 
     Build with :meth:`from_experimental_record` from a validated ``io.ExperimentalRecord`` (optionally
     restricted to one PETS zone-axis row).
+
+    ``dataset`` is the ``inputs.exp_data`` ref this rotation was measured in, stamped once at
+    :func:`~diffBloch.preprocess.setup_datasets` where the ref and the rotations are both in hand.
+    It rides *with* the rotation rather than being looked up from a table of index ranges, so it
+    survives multi-dataset pooling (which renumbers ``rotation_index`` into a global space), the
+    train/validation subsetting in ``refine_experiment``, and any future filtering or reordering --
+    nothing downstream has to re-derive dataset membership from cumulative offsets. Empty only for
+    a directly constructed batch outside the experiment loader (tests, ad hoc API use).
     """
 
     hkl: Tensor
     intensities: Tensor
     sigmas: Tensor
     rotation_index: int = 0
+    dataset: str = ""
 
     @classmethod
     def from_experimental_record(
@@ -228,6 +237,7 @@ class PatternBatch:
         *,
         zone_axis_id: int | None = None,
         rotation_index: int = 0,
+        dataset: str = "",
     ) -> Self:
         """Tensorise observed reflections, optionally filtering to one ``zone_axis_id``."""
         select = slice(None)
@@ -243,6 +253,7 @@ class PatternBatch:
             intensities=torch.as_tensor(select_i, dtype=torch.float64),
             sigmas=torch.as_tensor(select_s, dtype=torch.float64),
             rotation_index=rotation_index,
+            dataset=dataset,
         )
 
 

--- a/src/diffBloch/engine/forward.py
+++ b/src/diffBloch/engine/forward.py
@@ -151,13 +151,17 @@ class RotationMetrics:
     Report/plot use (:meth:`RefinementEngine.per_rotation_metrics`), not the objective: each metric
     independently re-optimises its own intensity scale (:func:`diffBloch.core.losses.optimal_scale`),
     exactly as ``refinement_metrics``/the training objective do, so ``wr2``/``r_obs`` here match what
-    those report elsewhere. ``rotation_index`` is the original zero-based PETS rotation index.
+    those report elsewhere. ``rotation_index`` is the original zero-based PETS rotation index (the
+    *pooled* one for a multi-dataset experiment), and ``dataset`` the ``inputs.exp_data`` ref it
+    came from -- both read straight off the rotation's own ``pattern``, so a per-dataset breakdown
+    never re-derives dataset membership from index offsets.
     """
 
     rotation_index: int
     wr2: float
     r_obs: float
     n_matched: int
+    dataset: str = ""
 
 
 @dataclass(frozen=True)
@@ -445,6 +449,7 @@ class RefinementEngine:
                         wr2=float(wr2_scores[best_t]),
                         r_obs=float(r_obs_scores[best_t]),
                         n_matched=int(aligned.observed.shape[-1]),
+                        dataset=orientation.pattern.dataset,
                     )
                 )
         return tuple(rows)

--- a/src/diffBloch/engine/forward.py
+++ b/src/diffBloch/engine/forward.py
@@ -1076,6 +1076,19 @@ def run_refinement_model(
         # ExperimentConfig.loss_metrics, so refinement always reports both -- free, unlike the
         # preprocessing search, which reports only the metric it actually spent a solve computing.
         diagnostics = reported_objective.diagnostics
+        # Scored before the event below so its wR2/R_obs ride on the *same* RefinementStep as the
+        # training numbers -- this scoring already happens every epoch purely to pick best_model, so
+        # reporting it is free; without it, the validation curve never surfaces until the run ends.
+        selection_loss = loss_value
+        selection_diagnostics: Mapping[str, float] | None = None
+        if selection_engine is not None:
+            with torch.no_grad():
+                selection_objective = selection_engine.objective_value_model(
+                    snapshot, penalties=problem.penalties
+                )
+            selection_loss = _scalar_float(selection_objective.total)
+            selection_losses.append(selection_loss)
+            selection_diagnostics = selection_objective.diagnostics
         event = RefinementStep(
             iteration=step,
             loss=loss_value,
@@ -1087,6 +1100,21 @@ def run_refinement_model(
             n_rotations=int(diagnostics["n_rotations"]),
             n_wr2_evaluated=int(diagnostics["n_wr2_evaluated"]),
             n_r_obs_evaluated=int(diagnostics["n_r_obs_evaluated"]),
+            val_wr2=None if selection_diagnostics is None else selection_diagnostics["wr2"],
+            val_r_obs=None if selection_diagnostics is None else selection_diagnostics["r_obs"],
+            val_n_rotations=(
+                None if selection_diagnostics is None else int(selection_diagnostics["n_rotations"])
+            ),
+            val_n_wr2_evaluated=(
+                None
+                if selection_diagnostics is None
+                else int(selection_diagnostics["n_wr2_evaluated"])
+            ),
+            val_n_r_obs_evaluated=(
+                None
+                if selection_diagnostics is None
+                else int(selection_diagnostics["n_r_obs_evaluated"])
+            ),
         )
         history.append(event)
         logger.report(event)
@@ -1101,14 +1129,6 @@ def run_refinement_model(
                         diff_loss=entry["diff_loss"],
                     )
                 )
-        selection_loss = loss_value
-        if selection_engine is not None:
-            with torch.no_grad():
-                selection_objective = selection_engine.objective_value_model(
-                    snapshot, penalties=problem.penalties
-                )
-            selection_loss = _scalar_float(selection_objective.total)
-            selection_losses.append(selection_loss)
         if selection_loss < best_loss:
             best_loss, best_step, best_model = selection_loss, step, snapshot
     _, n_matched, n_strong, n_weak, n_unmatched = engine.refinement_metrics(best_model)

--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -815,6 +815,13 @@ class RefinementStep:
     rotation can contribute to one and not the other -- and a mean whose denominator is implicit can
     improve simply by evaluating fewer rotations. Compare
     :class:`InferenceCompleted`, which has always reported ``n_evaluated`` beside its mean.
+
+    ``val_wr2``/``val_r_obs`` (and their own ``val_n_rotations``/``val_n_wr2_evaluated``/
+    ``val_n_r_obs_evaluated`` denominators) are the *same* diagnostics scored on the held-out
+    validation set, present only when ``run_refinement_model`` was given a ``selection_engine``
+    (``refinement.split.train_test``). That scoring already happens every epoch purely to pick
+    ``best_model`` -- reporting it here is free, and lets a sink show the training/validation curves
+    side by side instead of the validation numbers only ever surfacing once, at the very end.
     """
 
     channel: ClassVar[str] = "refinement"
@@ -828,6 +835,11 @@ class RefinementStep:
     n_rotations: int | None = None
     n_wr2_evaluated: int | None = None
     n_r_obs_evaluated: int | None = None
+    val_wr2: float | None = None
+    val_r_obs: float | None = None
+    val_n_rotations: int | None = None
+    val_n_wr2_evaluated: int | None = None
+    val_n_r_obs_evaluated: int | None = None
 
     def __post_init__(self) -> None:
         copied = {name: MappingProxyType(dict(values)) for name, values in self.components.items()}
@@ -854,6 +866,16 @@ class RefinementStep:
             values["n_wr2_evaluated"] = float(self.n_wr2_evaluated)
         if self.n_r_obs_evaluated is not None:
             values["n_r_obs_evaluated"] = float(self.n_r_obs_evaluated)
+        if self.val_wr2 is not None:
+            values["val_wr2"] = self.val_wr2
+        if self.val_r_obs is not None:
+            values["val_r_obs"] = self.val_r_obs
+        if self.val_n_rotations is not None:
+            values["val_n_rotations"] = float(self.val_n_rotations)
+        if self.val_n_wr2_evaluated is not None:
+            values["val_n_wr2_evaluated"] = float(self.val_n_wr2_evaluated)
+        if self.val_n_r_obs_evaluated is not None:
+            values["val_n_r_obs_evaluated"] = float(self.val_n_r_obs_evaluated)
         for term, entries in self.components.items():
             for name, value in entries.items():
                 values[f"{term}/{name}"] = value

--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -232,11 +232,16 @@ class OrientationOptimizationStarted:
     only assembled deep inside the step itself. Deliberately a distinct channel from
     ``OrientationOptimized`` (not merely a different type) -- a consumer such as
     :class:`~diffBloch.app.loggers.EarlyAbortLogger` that filters by ``event.channel`` alone must
-    not mistake this for a per-rotation result.
+    not mistake this for a per-rotation result. ``dataset`` is the ``inputs.exp_data`` ref this
+    search is fitting, read off the plan's own rotations
+    (:func:`~diffBloch.preprocess.dataset_of`) -- without it, a pooled multi-dataset run's console
+    log cannot tell which dataset a "N rotation(s)" announcement belongs to. It is ``""`` only when
+    the plan names no single dataset (a pooled or unlabelled plan reaching the fit directly).
     """
 
     channel: ClassVar[str] = "orientation_started"
     total_rotations: int
+    dataset: str = ""
 
     @property
     def step(self) -> int | None:
@@ -253,7 +258,11 @@ class OrientationOptimized:
 
     The fit is the long phase of a run (a coupled search solves ~100+ trials per rotation), so this
     is the progress stream that makes it observable: ``rotation_index`` is the original zero-based
-    PETS rotation index, ``score`` the final orientation's value under ``residual`` -- the
+    PETS rotation index -- *file-local* to ``dataset`` (the raw ``inputs.exp_data`` ref this search
+    ran against, matching :attr:`ThicknessProfile.label`'s convention, and read off the rotation's
+    own ``pattern``), since ``optimize_orientation`` runs once per dataset, before a multi-dataset
+    pool renumbers anything -- so a rotation index alone cannot disambiguate a pooled run; pair it
+    with ``dataset``. ``score`` the final orientation's value under ``residual`` -- the
     :class:`~diffBloch.config.schema.LossMetricsConfig` name (``"wr2"``/``"robs"``) that produced
     it, carried alongside so a consumer can label the number correctly
     (:attr:`measurements` keys on it directly, e.g. ``{"wr2": ...}`` or ``{"robs": ...}``) rather
@@ -274,6 +283,7 @@ class OrientationOptimized:
     n_trials: int
     n_passes: int
     pass_cap: int
+    dataset: str
 
     @property
     def step(self) -> int | None:
@@ -335,11 +345,13 @@ class ThicknessOptimizationStarted:
     :class:`OrientationOptimizationStarted`. Deliberately a distinct channel from
     ``ThicknessOptimized`` (not merely a different type) -- a consumer such as
     :class:`~diffBloch.app.loggers.EarlyAbortLogger` that filters by ``event.channel`` alone must
-    not mistake this for a per-rotation result.
+    not mistake this for a per-rotation result. ``dataset`` is the ``inputs.exp_data`` ref this
+    grid search is fitting, mirroring :attr:`OrientationOptimizationStarted.dataset`.
     """
 
     channel: ClassVar[str] = "thickness_started"
     total_rotations: int
+    dataset: str = ""
 
     @property
     def step(self) -> int | None:
@@ -617,7 +629,11 @@ class RefinedRotationMetrics:
     is the settled result, scored once on the best model by the *reporting* engine, so it covers
     every rotation including the held-out ones (``is_validation`` marks those). The refinement loop
     cannot emit it -- the loop only ever sees the training engine -- so the app boundary emits it
-    once the run has finished.
+    once the run has finished. ``dataset`` is the raw ``inputs.exp_data`` ref ``rotation_index``
+    (the *pooled* index for a multi-dataset run) belongs to, matching :attr:`ThicknessProfile.label`'s
+    convention. It is carried on the rotation's own ``pattern`` from
+    :func:`~diffBloch.preprocess.setup_datasets` onwards, so nothing downstream re-derives dataset
+    membership from pooled index offsets.
     """
 
     channel: ClassVar[str] = "refined rotation"
@@ -626,6 +642,7 @@ class RefinedRotationMetrics:
     r_obs: float
     n_matched: int
     is_validation: bool
+    dataset: str
 
     @property
     def step(self) -> int | None:

--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -46,6 +46,7 @@ __all__ = [
     "OrientationOptimizationSummary",
     "PlanSeeded",
     "PlanStepCompleted",
+    "PreprocessCompleted",
     "RecordingLogger",
     "RefinedRotationMetrics",
     "RefinementCompleted",
@@ -481,6 +482,45 @@ class CouplingSummary:
     @property
     def step(self) -> int | None:
         return None
+
+
+@dataclass(frozen=True)
+class PreprocessCompleted:
+    """The pooled ``Plan``'s settled shape, emitted once when preprocessing finishes.
+
+    Emitted from the shared ``_preprocess`` spine every public entry point
+    (``preprocess_experiment``, ``run_experiment``, ``refine_experiment``) funnels through, so a
+    console sink can print the same "preprocessing is done" summary regardless of which one is
+    running. Before this event existed, only ``preprocess_experiment``'s own CLI handler could show
+    it -- it alone had the settled ``Plan`` back in hand to inspect after the call returned;
+    ``run_experiment``/``refine_experiment`` swallow preprocessing internally and go straight into
+    their own next phase, so a sink attached to *them* had no equivalent moment to react to.
+
+    ``n_stages`` is the settled plan's recipe length (``provenance``) and ``max_solve_beams`` the
+    widest per-rotation solve; both are here because the console box shows them, and an event that
+    carried only the cheap-to-compute fields would quietly shrink what a sink can render.
+    """
+
+    channel: ClassVar[str] = "preprocess"
+    n_rotations: int
+    n_stages: int
+    total_hkl: int
+    matched_hkl: int
+    max_solve_beams: int
+
+    @property
+    def step(self) -> int | None:
+        return None  # a run-level aggregate has no position on the per-rotation axis
+
+    @property
+    def measurements(self) -> Mapping[str, float]:
+        return {
+            "n_rotations": float(self.n_rotations),
+            "n_stages": float(self.n_stages),
+            "total_hkl": float(self.total_hkl),
+            "matched_hkl": float(self.matched_hkl),
+            "max_solve_beams": float(self.max_solve_beams),
+        }
 
 
 @dataclass(frozen=True)

--- a/src/diffBloch/preprocess/__init__.py
+++ b/src/diffBloch/preprocess/__init__.py
@@ -60,13 +60,14 @@ from diffBloch.preprocess.pipeline import (
 from diffBloch.preprocess.plan import (
     CandidatePlan,
     Plan,
+    dataset_of,
     require_built_plans,
     require_candidate_plans,
     require_orientation_plans,
 )
 from diffBloch.preprocess.pool import pool
 from diffBloch.preprocess.scoring import build_engine, score_orientations
-from diffBloch.preprocess.serialize import read_plan, write_plan
+from diffBloch.preprocess.serialize import plan_is_readable, read_plan, write_plan
 from diffBloch.preprocess.steps.beams import (
     build_orientation_plans,
     klar_beam_mask,
@@ -143,6 +144,7 @@ __all__ = [
     "klar_beam_mask",
     "maximize_scalar",
     "couple_beams",
+    "dataset_of",
     "orientation_basis",
     "orientation_matrices",
     "rotation_axis_correction",
@@ -150,6 +152,7 @@ __all__ = [
     "plan_coverage",
     "pool",
     "report_coupling",
+    "plan_is_readable",
     "read_plan",
     "require_built_plans",
     "require_candidate_plans",

--- a/src/diffBloch/preprocess/experiment.py
+++ b/src/diffBloch/preprocess/experiment.py
@@ -290,6 +290,15 @@ def setup_datasets(
         if isinstance(config.inputs.exp_data, list)
         else (config.inputs.exp_data,)
     )
+    # ``records`` is read *from* ``inputs.exp_data``, so they correspond one-to-one by construction.
+    # Stated rather than assumed: two call sites index refs by dataset position (the per-dataset
+    # seed thickness and each rotation's dataset label), and a silent mismatch would mislabel every
+    # rotation of the extra datasets instead of failing.
+    if len(records) != len(dataset_refs):
+        raise ValueError(
+            f"setup_datasets got {len(records)} experimental record(s) but inputs.exp_data names "
+            f"{len(dataset_refs)} ({', '.join(dataset_refs)}); they must correspond one-to-one"
+        )
     datasets: list[DatasetSetup] = []
     offset = 0
     for dataset_index, record in enumerate(records):
@@ -328,6 +337,10 @@ def setup_datasets(
                     record,
                     zone_axis_id=int(zone_id),
                     rotation_index=local_index,
+                    # Stamped here, the one place the exp_data ref and the rotations are both in
+                    # hand: from here on the rotation carries its own dataset identity, so pooling,
+                    # the train/val split, and the report never re-derive it from index offsets.
+                    dataset=dataset_refs[dataset_index],
                 ),
                 energy=energy,
                 thickness=seed_thicknesses,

--- a/src/diffBloch/preprocess/plan.py
+++ b/src/diffBloch/preprocess/plan.py
@@ -34,6 +34,7 @@ __all__ = [
     "CandidatePlan",
     "Plan",
     "coupling_stats",
+    "dataset_of",
     "require_built_plans",
     "require_candidate_plans",
     "require_orientation_plans",
@@ -221,6 +222,19 @@ def coupling_stats(op: CandidatePlan | OrientationPlanLike) -> dict[str, int]:
         "n_union_beams": beams,
         "max_beams_per_segment": beams,
     }
+
+
+def dataset_of(plans: Iterable[OrientationPlanLike]) -> str:
+    """The single ``inputs.exp_data`` ref ``plans`` all belong to, or ``""`` if they do not.
+
+    Each rotation carries its own ``pattern.dataset`` (stamped at
+    :func:`~diffBloch.preprocess.setup_datasets`), so a per-dataset step can label its observability
+    events by reading the plan rather than taking a dataset argument it would otherwise have to be
+    threaded from the app boundary. Returns ``""`` for a pooled (mixed-dataset) or unlabelled plan,
+    which is the honest answer for a label: there is no one dataset to name.
+    """
+    labels = {op.pattern.dataset for op in plans}
+    return labels.pop() if len(labels) == 1 else ""
 
 
 def unique_hkl_count(hkl_batches: Iterable[Tensor]) -> int:

--- a/src/diffBloch/preprocess/serialize.py
+++ b/src/diffBloch/preprocess/serialize.py
@@ -45,9 +45,9 @@ from diffBloch.engine.plan import (
 from diffBloch.preprocess.pipeline import StepRecord
 from diffBloch.preprocess.plan import Plan, require_built_plans
 
-__all__ = ["read_plan", "write_plan"]
+__all__ = ["plan_is_readable", "read_plan", "write_plan"]
 
-_FORMAT_VERSION = 5
+_FORMAT_VERSION = 6
 
 
 def write_plan(plan: Plan, path: str | Path) -> None:
@@ -65,6 +65,7 @@ def write_plan(plan: Plan, path: str | Path) -> None:
             "energy": op.energy,
             "u0": op.u0,
             "rotation_index": op.pattern.rotation_index,
+            "dataset": op.pattern.dataset,
             "tilt_reduction": _dump_reduction(op.tilt_reduction),
         }
         if isinstance(op, CoupledOrientationPlan):
@@ -90,6 +91,25 @@ def write_plan(plan: Plan, path: str | Path) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
     with target.open("wb") as file:
         np.savez_compressed(file, **arrays)  # type: ignore[arg-type]
+
+
+def plan_is_readable(path: str | Path) -> bool:
+    """Whether :func:`read_plan` can read ``path``'s checkpoint format (and the file at all).
+
+    ``read_plan`` *raises* on a format it cannot read, but the checkpoint reuse gate
+    (:func:`~diffBloch.config.preprocess_lock_status`) keys on the release ``__version__``, not on
+    this format -- so a checkpoint written by an earlier format within the same release still passes
+    the lock and would then blow up inside ``read_plan``. Callers ask this first and treat ``False``
+    as *stale* (recompute + rewrite), which is what a checkpoint this build cannot read actually is.
+    A corrupt or truncated ``.npz`` is ``False`` for the same reason. Reads only the JSON metadata
+    array, never the geometry, so it stays cheap enough to call on every checkpoint hit.
+    """
+    try:
+        with np.load(Path(path), allow_pickle=False) as data:
+            meta = json.loads(str(data["__meta__"].item()))
+        return int(meta["format_version"]) == _FORMAT_VERSION
+    except (OSError, ValueError, KeyError, TypeError):
+        return False
 
 
 def read_plan(path: str | Path) -> Plan:
@@ -119,6 +139,7 @@ def _read_orientation(
         intensities=torch.as_tensor(data[f"pat_int_{i}"]),
         sigmas=torch.as_tensor(data[f"pat_sig_{i}"]),
         rotation_index=int(entry["rotation_index"]),
+        dataset=str(entry["dataset"]),
     )
     energy = float(entry["energy"])
     thickness = torch.as_tensor(data[f"thickness_{i}"])

--- a/src/diffBloch/preprocess/steps/optimize_orientation.py
+++ b/src/diffBloch/preprocess/steps/optimize_orientation.py
@@ -74,7 +74,12 @@ from diffBloch.preprocess.coupling import build_coupling_segments
 from diffBloch.preprocess.experiment import RefinementSetup
 from diffBloch.preprocess.orientation import goniometer_rotation
 from diffBloch.preprocess.pipeline import PlanStep, as_step
-from diffBloch.preprocess.plan import Plan, require_built_plans, unique_hkl_count
+from diffBloch.preprocess.plan import (
+    Plan,
+    dataset_of,
+    require_built_plans,
+    unique_hkl_count,
+)
 from diffBloch.preprocess.scoring import active_structure_factor_indices, build_engine
 from diffBloch.preprocess.steps.beams import klar_beam_mask
 from diffBloch.specs import (
@@ -229,7 +234,12 @@ def optimize_orientation(
             )
 
         built = require_built_plans(plan)
-        logger.report(OrientationOptimizationStarted(total_rotations=len(built)))
+        # This step runs once per dataset, before a multi-dataset pool renumbers anything, so its
+        # rotation_index is file-local and cannot disambiguate a pooled report on its own. The ref
+        # rides on each rotation's own pattern (stamped at setup_datasets), so it is read off the
+        # plan rather than passed in -- a recipe step takes no dataset argument.
+        dataset = dataset_of(built)
+        logger.report(OrientationOptimizationStarted(total_rotations=len(built), dataset=dataset))
         results_by_index: dict[int, tuple[OrientationPlanLike, float, int, int]] = {}
         cap = search.max_iterations
 
@@ -250,6 +260,7 @@ def optimize_orientation(
                     n_trials=n_trials,
                     n_passes=n_passes,
                     pass_cap=cap,
+                    dataset=dataset,
                 )
             )
 

--- a/src/diffBloch/preprocess/steps/optimize_thickness.py
+++ b/src/diffBloch/preprocess/steps/optimize_thickness.py
@@ -42,7 +42,7 @@ from diffBloch.observability import (
 from diffBloch.params import Device
 from diffBloch.preprocess.experiment import RefinementSetup
 from diffBloch.preprocess.pipeline import PlanStep, as_step
-from diffBloch.preprocess.plan import Plan, require_built_plans
+from diffBloch.preprocess.plan import Plan, dataset_of, require_built_plans
 from diffBloch.preprocess.scoring import build_engine
 from diffBloch.specs import NO_ABSORPTION, Absorption, ThicknessGrid
 
@@ -112,7 +112,11 @@ def optimize_thickness(
         )
         candidate_thicknesses = tuple(float(value) for value in candidates.tolist())
         built = require_built_plans(plan)
-        logger.report(ThicknessOptimizationStarted(total_rotations=len(built)))
+        # The exp_data ref rides on each rotation's own pattern (see optimize_orientation), so this
+        # step takes no dataset argument either.
+        logger.report(
+            ThicknessOptimizationStarted(total_rotations=len(built), dataset=dataset_of(built))
+        )
         fitted = []
         for op in built:
             orientation, score, thickness, candidate_scores = _fit_one(engine, fgb, op, candidates)

--- a/tests/fixtures/quartz_anchor/reproducibility/plan.exp_data.lock
+++ b/tests/fixtures/quartz_anchor/reproducibility/plan.exp_data.lock
@@ -114,8 +114,8 @@
   ],
   "plan": {
     "path": "reproducibility/plan.exp_data.npz",
-    "sha256": "605244a47e1988e6b2bd9edad52af21d94f295a076a204092eabc559fb4b838c",
-    "bytes": 584390,
+    "sha256": "2445de089aa6b9b2772ea41c8df2b4922f8851e538cbf8fa68f5e100d01c7869",
+    "bytes": 584464,
     "media_type": "application/octet-stream"
   }
 }

--- a/tests/fixtures/quartz_anchor/reproducibility/plan.exp_data.npz
+++ b/tests/fixtures/quartz_anchor/reproducibility/plan.exp_data.npz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:605244a47e1988e6b2bd9edad52af21d94f295a076a204092eabc559fb4b838c
-size 584390
+oid sha256:2445de089aa6b9b2772ea41c8df2b4922f8851e538cbf8fa68f5e100d01c7869
+size 584464

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -10,11 +10,22 @@ from pydantic import ValidationError
 
 from diffBloch.app.cli import main
 from diffBloch.app.loggers import ConsoleLogger
-from diffBloch.observability import MultiLogger, OrientationOptimized
+from diffBloch.observability import (
+    Logger,
+    MultiLogger,
+    OrientationOptimized,
+    PreprocessCompleted,
+    RefinementCompleted,
+    RefinementOutputsWritten,
+    RefinementStep,
+)
 from diffBloch.preprocess.inference import InferenceResult, RotationInference
 
 FIXTURE = Path(__file__).parent.parent / "fixtures" / "quartz_min" / "experiment.yaml"
 LOCKED = Path(__file__).parent.parent / "fixtures" / "locked_min"
+# A real CIF on disk: SummaryLogger reads the written structure back on the terminal event, so the
+# artifact path a fake emits has to point at a file that parses.
+REFINED_CIF = Path(__file__).parent.parent / "fixtures" / "quartz_anchor" / "enantiomer_1.cif"
 
 
 def _summary_row(out: str, label: str, value: str) -> bool:
@@ -159,7 +170,8 @@ def test_infer_delegates_to_run_experiment_and_reports(
 
     assert rc == 0
     assert captured["dir"] == "/some/experiment"
-    assert isinstance(captured["logger"], ConsoleLogger)  # console on by default (no --quiet)
+    # One sink renders everything, boxes included, so the default shape is a bare ConsoleLogger.
+    assert isinstance(captured["logger"], ConsoleLogger)
     assert captured["checkpoint"] is True  # checkpoint on by default
     assert captured["refresh"] is False
     assert captured["workers"] == 1  # sequential by default
@@ -328,6 +340,13 @@ def test_preprocess_delegates_and_reports_without_scoring(
                 pass_cap=2000,
             )
         )
+        # _preprocess() itself emits this once preprocessing settles; ConsoleLogger is what turns
+        # it into the PREPROCESS COMPLETE box, so the fake must emit it too.
+        logger.report(
+            PreprocessCompleted(
+                n_rotations=2, n_stages=3, total_hkl=7, matched_hkl=5, max_solve_beams=9
+            )
+        )
         return _FakePlan()
 
     monkeypatch.setattr("diffBloch.app.cli.preprocess_experiment", fake_preprocess_experiment)
@@ -335,14 +354,16 @@ def test_preprocess_delegates_and_reports_without_scoring(
 
     assert rc == 0
     assert captured["dir"] == "/some/experiment"
-    assert isinstance(captured["logger"], MultiLogger)
+    assert isinstance(captured["logger"], ConsoleLogger)
     assert captured["checkpoint"] is True and captured["refresh"] is False
     assert captured["workers"] == 1 and captured["device"] == "cuda"
     out = capsys.readouterr().out
     assert "PREPROCESS COMPLETE" in out
     assert _summary_row(out, "Rotations", "2")
+    assert _summary_row(out, "Stages", "3")
     assert _summary_row(out, "Total HKLs", "7")
     assert _summary_row(out, "Matched HKLs", "5")
+    assert _summary_row(out, "Solve beams (max/rotation)", "9")
     assert _summary_row(out, "Mean wR2", "0.375")
     assert "Optimize Orientation" in out
     assert "Optimize Thickness" in out
@@ -421,13 +442,15 @@ def _fake_refinement_result() -> SimpleNamespace:
             "matched_i_le_3sigma": 4,
             "unmatched_observed": 3,
         },
-        artifacts={"refined_structure": "/tmp/refined_structure.cif"},
+        artifacts={"refined_structure": str(REFINED_CIF)},
     )
 
 
 def test_refine_delegates_and_reports(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:
+    # A real directory: the fake emits the terminal event, so SummaryLogger actually writes its
+    # report next to it -- the same fan-out a real run does.
     captured: dict[str, object] = {}
 
     def fake_refine_experiment(
@@ -447,13 +470,41 @@ def test_refine_delegates_and_reports(
         captured["dir"] = experiment_dir
         captured["logger"] = logger
         captured["checkpoint"] = checkpoint
-        return _fake_refinement_result()
+        result = _fake_refinement_result()
+        # The box now comes off the event stream rather than off this return value, so the fake
+        # emits what a real refine_experiment emits: the per-epoch steps, then the run summary,
+        # then the terminal outputs event the box and the file list print on.
+        assert isinstance(logger, Logger)
+        for iteration, step in enumerate(result.history):
+            logger.report(
+                RefinementStep(
+                    iteration=iteration,
+                    loss=float(result.losses[iteration]),
+                    wr2=step.wr2,
+                    r_obs=step.r_obs,
+                    diff_loss=step.diff_loss,
+                )
+            )
+        logger.report(
+            RefinementCompleted(
+                n_steps=len(result.history),
+                best_step=result.best_step,
+                best_loss=result.best_loss,
+                reflection_counts=result.reflection_counts,
+            )
+        )
+        logger.report(
+            RefinementOutputsWritten(
+                structure=result.artifacts["refined_structure"], artifacts=result.artifacts
+            )
+        )
+        return result
 
     monkeypatch.setattr("diffBloch.app.cli.refine_experiment", fake_refine_experiment)
-    rc = main(["refine", "/some/experiment"])
+    rc = main(["refine", str(tmp_path)])
 
     assert rc == 0
-    assert captured["dir"] == "/some/experiment"
+    assert captured["dir"] == str(tmp_path)
     # The refine path fans out to the console and to the summary sink that writes
     # refinement_report.txt -- composed here, not inside refine_experiment.
     logger = captured["logger"]
@@ -467,7 +518,7 @@ def test_refine_delegates_and_reports(
     assert _summary_row(out, "Diffraction loss", "1")
     assert _summary_row(out, "HKLs (Observed/total)", "8 / 12")
     assert "Refined Structure" in out
-    assert "/tmp/refined_structure.cif" in out
+    assert str(REFINED_CIF) in out
 
 
 def test_refine_flags_thread_through(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -327,6 +327,7 @@ def test_preprocess_delegates_and_reports_without_scoring(
                 n_trials=10,
                 n_passes=3,
                 pass_cap=2000,
+                dataset="q.cif_pets",
             )
         )
         logger.report(
@@ -338,6 +339,7 @@ def test_preprocess_delegates_and_reports_without_scoring(
                 n_trials=10,
                 n_passes=3,
                 pass_cap=2000,
+                dataset="q.cif_pets",
             )
         )
         # _preprocess() itself emits this once preprocessing settles; ConsoleLogger is what turns

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -555,6 +555,35 @@ def test_refine_best_params_can_track_a_selection_engine() -> None:
     steps_reported = [e.loss for e in recorder.events if isinstance(e, RefinementStep)]
     assert steps_reported == [float(x) for x in result.losses]
 
+    # The validation scoring already happens every epoch purely to pick best_model -- reporting it
+    # on the same RefinementStep must not cost an extra evaluation or ever surface as unevaluated.
+    step_events = [e for e in recorder.events if isinstance(e, RefinementStep)]
+    assert len(step_events) == 8
+    assert all(e.val_wr2 is not None and e.val_r_obs is not None for e in step_events)
+    assert all(e.val_n_rotations == 1 for e in step_events)
+
+
+def test_refinement_step_omits_validation_fields_without_a_selection_engine() -> None:
+    """No selection_engine -> no val_* fields, not zeros or NaNs standing in for "not scored"."""
+    engine = _engine(loss=mse_loss, pattern=_observed_pattern(_params(occupancy_logit=2.2)))
+    recorder = RecordingLogger()
+
+    run_refinement_model(
+        engine,
+        build_refinement_model(initial=_params(occupancy_logit=0.0)),
+        RefinementProblem(),
+        trainable=TrainableSpec(occupancy=AtomSelection.all()),
+        steps=3,
+        optimizer="adam",
+        lr=0.2,
+        logger=recorder,
+    )
+
+    step_events = [e for e in recorder.events if isinstance(e, RefinementStep)]
+    assert len(step_events) == 3
+    assert all(e.val_wr2 is None and e.val_r_obs is None for e in step_events)
+    assert all("val_wr2" not in e.measurements for e in step_events)
+
 
 def test_refine_emits_a_step_stream_and_a_completion_event() -> None:
     engine = _engine(loss=mse_loss, pattern=_observed_pattern(_params(occupancy_logit=2.2)))

--- a/tests/unit/test_multi_dataset.py
+++ b/tests/unit/test_multi_dataset.py
@@ -28,10 +28,24 @@ FIXTURE_ROOT = Path(__file__).parent.parent / "fixtures"
 QUARTZ = FIXTURE_ROOT / "quartz_anchor"
 
 
-def _quartz_inputs():
+def _quartz_inputs(n_datasets: int = 1):
+    """Quartz structure + record, with a config naming ``n_datasets`` exp_data refs.
+
+    ``setup_datasets`` requires ``records`` to correspond one-to-one with ``inputs.exp_data``, so a
+    test feeding it the same record N times must widen the config to match -- exactly what a real
+    multi-dataset experiment.yaml does.
+    """
     structure = read_structure(QUARTZ / "enantiomer_1.cif")
     record = read_experimental_data(QUARTZ / "exp_data.cif_pets")
     config = load_config(QUARTZ / "experiment.yaml")
+    if n_datasets > 1:
+        raw = config.model_dump(mode="python")
+        raw["inputs"] = {
+            **raw["inputs"],
+            "exp_data": [f"dataset_{i}.cif_pets" for i in range(n_datasets)],
+            "multi_dataset": True,
+        }
+        config = ExperimentConfig.model_validate(raw)
     return structure, record, config
 
 
@@ -77,7 +91,7 @@ def test_setup_datasets_rejects_empty_records() -> None:
 
 
 def test_setup_datasets_keeps_file_local_indices_and_shares_the_grid() -> None:
-    structure, record, config = _quartz_inputs()
+    structure, record, config = _quartz_inputs(2)
     _, datasets = setup_datasets(structure, (record, record), config)
     for dataset in datasets:
         assert [op.pattern.rotation_index for op in dataset.plan.orientations] == list(
@@ -90,7 +104,7 @@ def test_setup_datasets_keeps_file_local_indices_and_shares_the_grid() -> None:
 
 def test_setup_datasets_gives_each_dataset_its_own_integration_geometry() -> None:
     """The old shared-semiangle restriction is gone: pooled precession angles may differ."""
-    structure, record, config = _quartz_inputs()
+    structure, record, config = _quartz_inputs(2)
     other_angle = record.model_copy(
         update={"precession_angles": np.full_like(np.asarray(record.precession_angles), 2.0)}
     )
@@ -100,7 +114,7 @@ def test_setup_datasets_gives_each_dataset_its_own_integration_geometry() -> Non
 
 
 def test_setup_datasets_preserves_each_dataset_collection_geometry() -> None:
-    structure, record, config = _quartz_inputs()
+    structure, record, config = _quartz_inputs(2)
     precession = record.model_copy(update={"data_collection_geometry": "precession"})
     _, datasets = setup_datasets(structure, (record, precession), config)
     assert datasets[0].integration.geometry == "continuous_rotation"
@@ -108,7 +122,7 @@ def test_setup_datasets_preserves_each_dataset_collection_geometry() -> None:
 
 
 def test_setup_datasets_seeds_each_dataset_with_its_configured_mean_thickness() -> None:
-    structure, record, config = _quartz_inputs()
+    structure, record, config = _quartz_inputs(2)
     raw = config.model_dump(mode="python")
     raw["inputs"] = {
         **raw["inputs"],
@@ -131,7 +145,7 @@ def test_setup_datasets_seeds_each_dataset_with_its_configured_mean_thickness() 
 
 
 def test_setup_datasets_translates_global_ignore_to_file_local_slices() -> None:
-    structure, record, config = _quartz_inputs()
+    structure, record, config = _quartz_inputs(2)
     n = record.n_rotations
     ignoring = config.model_copy(
         update={
@@ -149,7 +163,7 @@ def test_setup_datasets_translates_global_ignore_to_file_local_slices() -> None:
 
 
 def test_setup_datasets_rejects_out_of_range_and_fully_ignored() -> None:
-    structure, record, config = _quartz_inputs()
+    structure, record, config = _quartz_inputs(2)
     n = record.n_rotations
     out_of_range = config.model_copy(
         update={"blochwave": config.blochwave.model_copy(update={"ignore_orientations": (2 * n,)})}
@@ -171,7 +185,7 @@ def test_setup_datasets_rejects_out_of_range_and_fully_ignored() -> None:
 def test_setup_datasets_computes_u0_once_per_distinct_energy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    structure, record, config = _quartz_inputs()
+    structure, record, config = _quartz_inputs(3)
     calls: list[float] = []
 
     def counting(*args, **kwargs):
@@ -186,7 +200,7 @@ def test_setup_datasets_computes_u0_once_per_distinct_energy(
 def test_multi_dataset_second_file_checked_against_first_not_structure(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    structure, record, config = _quartz_inputs()
+    structure, record, config = _quartz_inputs(2)
     cell = np.asarray(record.cell_parameters, dtype=np.float64)
     second = record.model_copy(
         update={
@@ -210,7 +224,7 @@ def test_multi_dataset_second_file_checked_against_first_not_structure(
 
 
 def test_multi_dataset_over_5pct_between_combined_files_raises() -> None:
-    structure, record, config = _quartz_inputs()
+    structure, record, config = _quartz_inputs(2)
     second = record.model_copy(
         update={
             "cell_parameters": record.cell_parameters * np.array([1.08, 1.0, 1.0, 1.0, 1.0, 1.0]),

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import csv
 import logging
+import re
 import sys
 import types
 from pathlib import Path
@@ -42,9 +43,11 @@ from diffBloch.observability import (
     OrientationOptimizationSummary,
     OrientationOptimized,
     PlanStepCompleted,
+    PreprocessCompleted,
     RecordingLogger,
     RefinementCompleted,
     RefinementOrientationStep,
+    RefinementOutputsWritten,
     RefinementStarted,
     RefinementStep,
     RotationCoupling,
@@ -749,3 +752,108 @@ def test_console_logger_omits_the_marker_without_a_pass_header() -> None:
     """No announced threshold means no claim about settling, rather than a guess."""
     logger = ConsoleLogger(level=logging.INFO)
     assert logger._r_factor_threshold is None
+
+
+# --- ConsoleLogger completion boxes ------------------------------------------------------------
+
+
+def _preprocess_completed(**overrides: int) -> PreprocessCompleted:
+    fields = {
+        "n_rotations": 2,
+        "n_stages": 3,
+        "total_hkl": 100,
+        "matched_hkl": 80,
+        "max_solve_beams": 40,
+    }
+    return PreprocessCompleted(**{**fields, **overrides})
+
+
+def test_console_logger_prints_the_preprocess_box_on_preprocess_completed(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The box prints from the event stream alone -- the same way whether the caller is
+    preprocess_experiment, run_experiment, or refine_experiment, since all three funnel through
+    the shared _preprocess spine that emits PreprocessCompleted."""
+    logger = ConsoleLogger()
+    logger.report(_fitted(index=0, score=0.4, residual="wr2"))
+    logger.report(_fitted(index=1, score=0.2, residual="wr2"))
+    logger.report(_preprocess_completed())
+
+    out = capsys.readouterr().out
+    assert "PREPROCESS COMPLETE" in out
+    assert re.search(r"Rotations\s+2", out)
+    assert re.search(r"Stages\s+3", out)
+    assert re.search(r"Total HKLs\s+100", out)
+    assert re.search(r"Matched HKLs\s+80", out)
+    assert re.search(r"Solve beams \(max/rotation\)\s+40", out)
+    assert re.search(r"Mean wR2\s+0\.3", out)  # mean of 0.4 and 0.2
+
+
+def test_console_logger_preprocess_box_states_checkpoint_reuse_with_no_orientation_events(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A reused checkpoint runs no orientation search -- the box must say so, not claim a mean."""
+    logger = ConsoleLogger()
+    logger.report(_preprocess_completed(n_rotations=5, total_hkl=50, matched_hkl=40))
+
+    out = capsys.readouterr().out
+    assert re.search(r"Mean score\s+n/a \(checkpoint reused\)", out)
+
+
+def test_console_logger_preprocess_box_resets_between_completions() -> None:
+    """A logger instance reused across two settle events must not leak the first run's scores into
+    the second's mean."""
+    logger = ConsoleLogger()
+    logger.report(_fitted(index=0, score=0.9, residual="wr2"))
+    logger.report(_preprocess_completed())
+    logger.report(_preprocess_completed())
+
+    assert logger._orientation_scores == []
+    assert logger._orientation_residual is None
+
+
+def test_console_logger_prints_the_refinement_box_on_outputs_written(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The box reports the *selected* epoch's numbers, so it needs both the step stream (for the
+    per-epoch values) and RefinementCompleted (for which epoch was selected); it prints on
+    RefinementOutputsWritten because it also lists files that must exist by then."""
+    logger = ConsoleLogger()
+    logger.report(RefinementStep(iteration=0, loss=1.0, wr2=0.5, r_obs=0.4, diff_loss=0.3))
+    logger.report(RefinementStep(iteration=1, loss=0.5, wr2=0.2, r_obs=0.1, diff_loss=0.05))
+    logger.report(
+        RefinementCompleted(
+            n_steps=2,
+            best_step=1,
+            best_loss=0.5,
+            reflection_counts={"matched": 90, "matched_i_gt_3sigma": 60},
+        )
+    )
+    logger.report(
+        RefinementOutputsWritten(
+            structure="/out/refined_structure.cif",
+            artifacts={"refined_structure": "/out/refined_structure.cif"},
+        )
+    )
+
+    out = capsys.readouterr().out
+    assert "REFINEMENT COMPLETE" in out
+    assert re.search(r"Best epoch\s+2", out)  # 1-based, from best_step=1
+    assert re.search(r"wR2\s+0\.2", out)  # epoch 2's value, not epoch 1's
+    assert re.search(r"HKLs \(Observed/total\)\s+60 / 90", out)
+    assert "Refined Structure" in out and "/out/refined_structure.cif" in out
+
+
+def test_console_logger_lists_outputs_even_without_a_refinement_summary(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """RefinementOutputsWritten is emitted by paths that never ran a refinement loop, so the file
+    list must not depend on a RefinementCompleted that never arrives."""
+    logger = ConsoleLogger()
+    logger.report(
+        RefinementOutputsWritten(structure="/out/s.cif", artifacts={"structure": "/out/s.cif"})
+    )
+
+    out = capsys.readouterr().out
+    assert "REFINEMENT COMPLETE" not in out
+    assert "Output files" in out

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -66,6 +66,7 @@ def _fitted(index: int, score: float, residual: str = "wr2") -> OrientationOptim
         n_trials=10,
         n_passes=3,
         pass_cap=2000,
+        dataset="q.cif_pets",
     )
 
 

--- a/tests/unit/test_optimize_orientation.py
+++ b/tests/unit/test_optimize_orientation.py
@@ -12,6 +12,7 @@ is deferred to the real quartz e2e.
 from __future__ import annotations
 
 import time
+from dataclasses import replace
 
 import numpy as np
 import pytest
@@ -152,6 +153,52 @@ def test_fit_orientation_leaves_a_self_consistent_orientation_unchanged() -> Non
 
     # Already optimal: the search must not wander it away from the seed.
     assert np.linalg.norm(np.asarray(refined.orientation) - true_orientation) < 1e-2
+
+
+def test_fit_orientation_reads_the_dataset_label_off_the_plan() -> None:
+    """The label comes from the rotations' own pattern.dataset, not from a step argument, so a
+    pooled multi-dataset console log can tell which dataset a "N rotation(s)" announcement belongs
+    to without the app boundary threading a label into the recipe."""
+    from diffBloch.observability import (
+        OrientationOptimizationStarted,
+        OrientationOptimized,
+        RecordingLogger,
+    )
+
+    grid, asu_plan, spec, numbers = _silicon()
+    matched = _self_consistent(grid, asu_plan, spec, numbers, np.eye(3, dtype=np.float64))
+    labelled = replace(matched, pattern=replace(matched.pattern, dataset="a.cif_pets"))
+    refinement = _refinement(asu_plan, spec, numbers)
+    recorder = RecordingLogger()
+
+    optimize_orientation(refinement, NelderMeadSearch(), logger=recorder)(
+        Plan(structure_factor_grid=grid, orientations=(labelled,))
+    )
+
+    (started,) = [e for e in recorder.events if isinstance(e, OrientationOptimizationStarted)]
+    assert started.dataset == "a.cif_pets"
+    (fitted,) = [e for e in recorder.events if isinstance(e, OrientationOptimized)]
+    assert fitted.dataset == "a.cif_pets"
+
+
+def test_fit_orientation_leaves_the_label_empty_for_a_mixed_dataset_plan() -> None:
+    """A pooled plan names no single dataset, so the label is empty rather than an arbitrary pick
+    from whichever rotation happened to be first."""
+    from diffBloch.observability import OrientationOptimizationStarted, RecordingLogger
+
+    grid, asu_plan, spec, numbers = _silicon()
+    matched = _self_consistent(grid, asu_plan, spec, numbers, np.eye(3, dtype=np.float64))
+    a = replace(matched, pattern=replace(matched.pattern, dataset="a.cif_pets", rotation_index=0))
+    b = replace(matched, pattern=replace(matched.pattern, dataset="b.cif_pets", rotation_index=1))
+    refinement = _refinement(asu_plan, spec, numbers)
+    recorder = RecordingLogger()
+
+    optimize_orientation(refinement, NelderMeadSearch(), logger=recorder)(
+        Plan(structure_factor_grid=grid, orientations=(a, b))
+    )
+
+    (started,) = [e for e in recorder.events if isinstance(e, OrientationOptimizationStarted)]
+    assert started.dataset == ""
 
 
 def test_fit_orientation_threads_the_rocking_curve_tilts_through_the_search() -> None:

--- a/tests/unit/test_optimize_thickness.py
+++ b/tests/unit/test_optimize_thickness.py
@@ -17,7 +17,11 @@ from tests.unit.synthetic import make_constraint_spec
 from diffBloch.core.products import PatternBatch
 from diffBloch.core.symmetry import build_asu_expansion_plan
 from diffBloch.engine import OrientationPlan, RefinementEngine, StructureFactorGrid, w_rbragg_loss
-from diffBloch.observability import RecordingLogger, ThicknessOptimized
+from diffBloch.observability import (
+    RecordingLogger,
+    ThicknessOptimizationStarted,
+    ThicknessOptimized,
+)
 from diffBloch.params import ConstraintSpec, RefinableParams
 from diffBloch.preprocess import RefinementSetup, optimize_thickness
 from diffBloch.preprocess.plan import Plan
@@ -166,6 +170,27 @@ def test_fit_thickness_emits_one_thicknessfitted_per_rotation() -> None:
     # each event's thickness is the value baked onto the matching returned orientation
     for index, event in enumerate(events):
         assert event.thickness == float(fitted.orientations[index].thickness[0])
+
+
+def test_fit_thickness_reads_the_dataset_label_off_the_plan() -> None:
+    """The label comes from the rotations' own pattern.dataset, mirroring optimize_orientation, so
+    a pooled multi-dataset console log can tell which dataset a "N rotation(s)" announcement
+    belongs to without the step taking a dataset argument."""
+    grid, asu_plan, spec, numbers = _silicon()
+    observed = _observed_at(grid, asu_plan, spec, numbers, _TRUE_THICKNESS)
+    labelled = replace(observed, dataset="a.cif_pets")
+    op = OrientationPlan.build(grid, _BEAM_HKL, labelled, energy=_ENERGY, thickness=(900.0,))
+    plan = Plan(structure_factor_grid=grid, orientations=(op,))
+
+    log = RecordingLogger()
+    optimize_thickness(
+        _refinement(asu_plan, spec, numbers),
+        ThicknessGrid(min_thickness=200.0, max_thickness=400.0, n_steps=5),
+        logger=log,
+    )(plan)
+
+    (started,) = [event for event in log.events if isinstance(event, ThicknessOptimizationStarted)]
+    assert started.dataset == "a.cif_pets"
 
 
 # --- device knob (the grid search runs on the accelerator; params.device is authoritative) --------

--- a/tests/unit/test_plan_serialize.py
+++ b/tests/unit/test_plan_serialize.py
@@ -9,7 +9,11 @@ path the reverted serializer never handled) -- plus faithful provenance.
 
 from __future__ import annotations
 
+import json
+from dataclasses import replace
+
 import numpy as np
+import pytest
 import torch
 from tests.unit.test_inference import (
     _BEAM_HKL,
@@ -27,7 +31,7 @@ from diffBloch.preprocess.orientation import rocking_curve_tilts
 from diffBloch.preprocess.pipeline import StepRecord
 from diffBloch.preprocess.plan import Plan
 from diffBloch.preprocess.scoring import build_engine
-from diffBloch.preprocess.serialize import read_plan, write_plan
+from diffBloch.preprocess.serialize import plan_is_readable, read_plan, write_plan
 
 _TILTS = rocking_curve_tilts(1.0, 4, geometry="continuous_rotation")  # (4, 3, 3)
 
@@ -129,3 +133,65 @@ def test_mixed_plan_round_trips(tmp_path) -> None:
     loaded = _assert_round_trips(plan, tmp_path)
     assert isinstance(loaded.orientations[0], OrientationPlan)
     assert isinstance(loaded.orientations[1], CoupledOrientationPlan)
+
+
+def test_dataset_label_survives_the_round_trip(tmp_path) -> None:
+    """``pattern.dataset`` is checkpoint state, not a runtime decoration.
+
+    A reused checkpoint must come back knowing which ``inputs.exp_data`` file its rotations came
+    from, or the per-dataset report sections would silently go blank on exactly the runs that
+    skipped preprocessing.
+    """
+    grid, *_ = _silicon()
+    op = OrientationPlan.build(
+        grid,
+        _BEAM_HKL,
+        replace(_pattern(), dataset="a.cif_pets"),
+        energy=_ENERGY,
+        thickness=(300.0,),
+    )
+    path = tmp_path / "plan.npz"
+    write_plan(Plan(structure_factor_grid=grid, orientations=(op,)), path)
+
+    (loaded,) = read_plan(path).orientations
+    assert loaded.pattern.dataset == "a.cif_pets"
+
+
+def test_plan_is_readable_accepts_what_this_build_wrote(tmp_path) -> None:
+    grid, *_ = _silicon()
+    op = OrientationPlan.build(grid, _BEAM_HKL, _pattern(), energy=_ENERGY, thickness=(300.0,))
+    path = tmp_path / "plan.npz"
+    write_plan(Plan(structure_factor_grid=grid, orientations=(op,)), path)
+
+    assert plan_is_readable(path) is True
+
+
+def test_plan_is_readable_rejects_an_older_format_instead_of_read_plan_raising(tmp_path) -> None:
+    """An older-format checkpoint is *stale*, not an error.
+
+    The checkpoint reuse gate keys on the release version, not on this format, so a checkpoint
+    written by an earlier format within the same release still passes the lock. Without this probe
+    the run would reach ``read_plan`` and die on what is, from the user's side, an ordinary resume.
+    """
+    grid, *_ = _silicon()
+    op = OrientationPlan.build(grid, _BEAM_HKL, _pattern(), energy=_ENERGY, thickness=(300.0,))
+    path = tmp_path / "plan.npz"
+    write_plan(Plan(structure_factor_grid=grid, orientations=(op,)), path)
+
+    with np.load(path, allow_pickle=False) as data:
+        arrays = {name: data[name] for name in data.files}
+    meta = json.loads(str(arrays["__meta__"].item()))
+    meta["format_version"] -= 1
+    arrays["__meta__"] = np.array(json.dumps(meta))
+    with path.open("wb") as handle:
+        np.savez_compressed(handle, **arrays)
+
+    assert plan_is_readable(path) is False
+    with pytest.raises(ValueError, match="unsupported plan checkpoint format"):
+        read_plan(path)
+
+
+def test_plan_is_readable_rejects_a_corrupt_file(tmp_path) -> None:
+    path = tmp_path / "plan.npz"
+    path.write_bytes(b"not an npz")
+    assert plan_is_readable(path) is False

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -56,6 +56,7 @@ def test_report_ignores_events_that_are_not_thickness_optimized(tmp_path: Path) 
             n_trials=40,
             n_passes=12,
             pass_cap=60,
+            dataset="q.cif_pets",
         )
     )
 

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from diffBloch.config import load_config
+from diffBloch.config import ExperimentConfig, load_config
 from diffBloch.io import read_experimental_data, read_structure
 from diffBloch.preprocess import pool, setup_datasets
 from diffBloch.preprocess.pipeline import StepRecord
@@ -13,15 +13,29 @@ FIXTURE_ROOT = Path(__file__).parent.parent / "fixtures"
 QUARTZ = FIXTURE_ROOT / "quartz_anchor"
 
 
-def _quartz_inputs():
+def _quartz_inputs(n_datasets: int = 1):
+    """Quartz structure + record, with a config naming ``n_datasets`` exp_data refs.
+
+    ``setup_datasets`` requires ``records`` to correspond one-to-one with ``inputs.exp_data``, so a
+    test feeding it the same record N times must widen the config to match -- exactly what a real
+    multi-dataset experiment.yaml does.
+    """
     structure = read_structure(QUARTZ / "enantiomer_1.cif")
     record = read_experimental_data(QUARTZ / "exp_data.cif_pets")
     config = load_config(QUARTZ / "experiment.yaml")
+    if n_datasets > 1:
+        raw = config.model_dump(mode="python")
+        raw["inputs"] = {
+            **raw["inputs"],
+            "exp_data": [f"dataset_{i}.cif_pets" for i in range(n_datasets)],
+            "multi_dataset": True,
+        }
+        config = ExperimentConfig.model_validate(raw)
     return structure, record, config
 
 
 def test_pool_renumbers_with_file_offsets_preserving_ignore_gaps() -> None:
-    structure, record, config = _quartz_inputs()
+    structure, record, config = _quartz_inputs(2)
     n = record.n_rotations
     # Global ignore 1 lands on dataset 0 (local 1); global n lands on dataset 1 (local 0).
     ignoring = config.model_copy(
@@ -48,7 +62,7 @@ def test_pool_single_plan_is_identity_on_indices() -> None:
 
 
 def test_pool_rejects_mismatched_energies() -> None:
-    structure, record, config = _quartz_inputs()
+    structure, record, config = _quartz_inputs(2)
     other_voltage = record.model_copy(update={"wavelength": 0.0335})  # ~120 kV vs quartz's 200 kV
     _, datasets = setup_datasets(structure, (record, other_voltage), config)
     with pytest.raises(ValueError, match="different beam energies"):
@@ -78,14 +92,14 @@ def test_pool_rejects_empty_and_mismatched_offsets() -> None:
 
 
 def test_pool_rejects_colliding_offsets() -> None:
-    structure, record, config = _quartz_inputs()
+    structure, record, config = _quartz_inputs(2)
     _, datasets = setup_datasets(structure, (record, record), config)
     with pytest.raises(ValueError, match="collide"):
         pool([d.plan for d in datasets], offsets=[0, 0])
 
 
 def test_pool_carries_the_first_plans_provenance() -> None:
-    structure, record, config = _quartz_inputs()
+    structure, record, config = _quartz_inputs(2)
     _, datasets = setup_datasets(structure, (record, record), config)
     stamped = datasets[0].plan.__class__(
         structure_factor_grid=datasets[0].plan.structure_factor_grid,
@@ -94,3 +108,23 @@ def test_pool_carries_the_first_plans_provenance() -> None:
     )
     pooled = pool([stamped, datasets[1].plan], offsets=[0, record.n_rotations])
     assert [r.name for r in pooled.provenance] == ["select_beams"]
+
+
+def test_pool_keeps_each_rotation_attributable_to_its_dataset() -> None:
+    """Pooling renumbers ``rotation_index`` into a global space but must not lose which file a
+    rotation came from -- that attribution is what the per-dataset report sections key on, and it
+    survives because it rides on the rotation's own pattern rather than in a table of offsets."""
+    structure, record, config = _quartz_inputs(2)
+    _, datasets = setup_datasets(structure, (record, record), config)
+
+    pooled = pool([d.plan for d in datasets], offsets=[0, record.n_rotations])
+
+    by_dataset: dict[str, list[int]] = {}
+    for op in pooled.orientations:
+        by_dataset.setdefault(op.pattern.dataset, []).append(op.pattern.rotation_index)
+    assert sorted(by_dataset) == ["dataset_0.cif_pets", "dataset_1.cif_pets"]
+    # Disjoint blocks of the pooled space, renumbered but still attributable.
+    assert by_dataset["dataset_0.cif_pets"] == list(range(record.n_rotations))
+    assert by_dataset["dataset_1.cif_pets"] == list(
+        range(record.n_rotations, 2 * record.n_rotations)
+    )

--- a/tests/unit/test_summary_logger.py
+++ b/tests/unit/test_summary_logger.py
@@ -131,10 +131,19 @@ def _run(
 
 
 def _rotation(
-    index: int, *, wr2: float = 0.2, is_validation: bool = False
+    index: int,
+    *,
+    wr2: float = 0.2,
+    is_validation: bool = False,
+    dataset: str = "q.cif_pets",
 ) -> RefinedRotationMetrics:
     return RefinedRotationMetrics(
-        rotation_index=index, wr2=wr2, r_obs=0.15, n_matched=5, is_validation=is_validation
+        rotation_index=index,
+        wr2=wr2,
+        r_obs=0.15,
+        n_matched=5,
+        is_validation=is_validation,
+        dataset=dataset,
     )
 
 

--- a/tests/unit/test_summary_logger.py
+++ b/tests/unit/test_summary_logger.py
@@ -368,3 +368,60 @@ def test_ascii_table_widens_a_column_to_its_content() -> None:
     table = ascii_table(["A", "B"], [["a-very-long-cell", "1"]])
     header, rule, row = table.splitlines()
     assert len(header) == len(rule) == len(row)
+
+
+def test_summary_epoch_curve_lists_every_recorded_step(tmp_path: Path) -> None:
+    """The epoch curve is the whole trajectory, not just the best epoch."""
+    text = _run(
+        tmp_path,
+        steps=(
+            _step(iteration=0, wr2=0.9, r_obs=0.8),
+            _step(iteration=1, wr2=0.1, r_obs=0.05),
+        ),
+        completed=RefinementCompleted(n_steps=2, best_step=1, best_loss=1.0),
+        rotations=(_rotation(0),),
+    )
+
+    assert "Epoch curve" in text
+    epoch_curve = text.split("Epoch curve")[1].split("\n--- ")[0]
+    assert "1" in epoch_curve and "0.900000" in epoch_curve and "0.800000" in epoch_curve
+    assert "2" in epoch_curve and "0.100000" in epoch_curve and "0.050000" in epoch_curve
+
+
+def test_summary_epoch_curve_renders_na_for_unevaluated_epochs(tmp_path: Path) -> None:
+    text = _run(
+        tmp_path,
+        steps=(_step(wr2=None, r_obs=None),),
+        rotations=(_rotation(0),),
+    )
+
+    epoch_curve = text.split("Epoch curve")[1].split("\n--- ")[0]
+    assert "n/a" in epoch_curve
+
+
+def test_summary_epoch_curve_adds_validation_columns_when_a_selection_engine_ran(
+    tmp_path: Path,
+) -> None:
+    text = _run(
+        tmp_path,
+        steps=(
+            _step(iteration=0, wr2=0.9, r_obs=0.8, val_wr2=0.95, val_r_obs=0.85),
+            _step(iteration=1, wr2=0.1, r_obs=0.05, val_wr2=0.2, val_r_obs=0.15),
+        ),
+        completed=RefinementCompleted(n_steps=2, best_step=1, best_loss=1.0),
+        rotations=(_rotation(0),),
+    )
+
+    epoch_curve = text.split("Epoch curve")[1].split("\n--- ")[0]
+    assert "Val wR2" in epoch_curve and "Val R_obs" in epoch_curve
+    assert "0.950000" in epoch_curve and "0.850000" in epoch_curve
+    assert "0.200000" in epoch_curve and "0.150000" in epoch_curve
+
+
+def test_summary_epoch_curve_omits_validation_columns_without_a_selection_engine(
+    tmp_path: Path,
+) -> None:
+    text = _run(tmp_path, rotations=(_rotation(0),))
+
+    epoch_curve = text.split("Epoch curve")[1].split("\n--- ")[0]
+    assert "Val wR2" not in epoch_curve


### PR DESCRIPTION
`pool()` renumbers `rotation_index` onto a global index space and, until now, that was the only
record of where a rotation came from. Anything wanting to attribute a pooled rotation back to its
dataset had to re-derive it from the cumulative pre-ignore counts — so the same offset arithmetic
was written out in more than one place, and the fits had to accept a `dataset` argument threaded
down from the app boundary purely so their events could be labelled.

`PatternBatch` now carries the ref, stamped once in `setup_datasets` — the one place the exp_data
ref and the rotations are both in hand. It rides with the rotation from there, so it survives
pooling, the train/validation subsetting in `refine_experiment`, and any future filtering or
reordering, **with no contiguity assumption and no lookup table to keep in sync**.

### What this deletes

- `optimize_orientation` and `optimize_thickness` take **no dataset argument**. Each reads the label
  off the plan it was handed (new `dataset_of()`), which returns `""` for a pooled or unlabelled
  plan — the honest answer for a label, since there is no one dataset to name.
- `RotationMetrics` carries the ref, read off the orientation the reporting loop already holds, so
  `RefinedRotationMetrics` is stamped without the app boundary computing anything.

### What this adds for users

Console lines for both fits name the dataset they are fitting, which a pooled multi-dataset run
could not previously tell you.

### ⚠️ This invalidates every cached preprocess checkpoint, once

The plan checkpoint format goes **5 → 6** for the new field. Runs recompute cleanly rather than
crashing, but the expensive preprocess phase reruns once per experiment. Plan accordingly.

That bump needed a guard, and it is the part most worth a close look. `read_plan` raises on a format
it cannot read, but the checkpoint reuse gate keys on the release `__version__` rather than the
format — so a checkpoint written by an earlier format *within the same release* passes the lock and
then dies inside `read_plan`, on what is from the user's side an ordinary resume. `plan_is_readable()`
makes such a checkpoint stale instead, and `_prepare` recomputes and rewrites it.

**Verified against the committed format-5 example checkpoint**: it recomputes cleanly, then reuses on
the next run.

The committed quartz anchor fixture is migrated in place rather than regenerated, so its geometry
stays byte-identical and the anchor still anchors.

### One more thing

`setup_datasets` now states its records-to-`exp_data` correspondence explicitly. Two call sites index
refs by dataset position, and a silent mismatch would mislabel every rotation of the extra datasets
rather than fail. Several tests were passing two records against a one-ref config — a state
production cannot produce — and are widened to match.

### Not done here

`_thickness_networks` looks like another copy of the same offset arithmetic but is **not**, and
cannot be replaced by the label: `ApparentThicknessNN` indexes `normalized_alphas` by
`rotation_index - start` and requires the range to be exactly the alphas wide, so it must span the
*pre-ignore* block. Grouping the settled plan by dataset label would give the narrower *observed*
span and misalign every lookup. Left alone, with the reasoning recorded in the docstring.

---

## Stack position

This is one of 10 PRs splitting `feature/observability-report-sections` (~1500 lines, 28 files)
into single-concern pieces. **They are stacked: this PR's base is `feat/validation-metrics-per-epoch`**, so the diff shows
only its own change. **Merge bottom-up, in this order** — merging out of order will pull in
unreviewed commits from below:

| # | PR | branch | |
|---|---|---|---|
| 1 | #179 | `fix/thickness-plot-findfont-spam` |  |
| 2 | #180 | `fix/thickness-plot-y-axis-floor` |  |
| 3 | #181 | `fix/unique-reflection-counts` |  |
| 4 | #182 | `refactor/preprocess-outcome` |  |
| 5 | #183 | `refactor/remove-quiet-flag` |  |
| 6 | #184 | `feat/console-completion-boxes` |  |
| 7 | #185 | `feat/validation-metrics-per-epoch` |  |
| 8 | _not yet opened_ | `feat/dataset-ref-on-rotations` | foundation for 9 and 10 **← this PR** |
| 9 | _not yet opened_ | `feat/report-orientation-search-section` | needs 8 |
| 10 | _not yet opened_ | `feat/report-per-dataset-summary` | needs 8 |

