### PR TITLE
Report what the orientation search actually bought, per rotation

### DIFF
--- a/src/diffBloch/app/loggers/summary.py
+++ b/src/diffBloch/app/loggers/summary.py
@@ -41,6 +41,7 @@ from diffBloch.observability import (
     Event,
     ExperimentDeclared,
     ObjectiveManifest,
+    OrientationOptimized,
     RefinedRotationMetrics,
     RefinementCompleted,
     RefinementOutputsWritten,
@@ -107,6 +108,7 @@ class SummaryLogger:
     _steps: list[RefinementStep] = field(default_factory=list, init=False, repr=False)
     _completed: RefinementCompleted | None = field(default=None, init=False, repr=False)
     _rotations: list[RefinedRotationMetrics] = field(default_factory=list, init=False, repr=False)
+    _orientations: list[OrientationOptimized] = field(default_factory=list, init=False, repr=False)
     _profiles: dict[str, ThicknessProfile] = field(default_factory=dict, init=False, repr=False)
     _started_at: float = field(default=0.0, init=False, repr=False)
 
@@ -127,6 +129,8 @@ class SummaryLogger:
             self._completed = event
         elif isinstance(event, RefinedRotationMetrics):
             self._rotations.append(event)
+        elif isinstance(event, OrientationOptimized):
+            self._orientations.append(event)
         elif isinstance(event, ThicknessProfile):
             # Keyed by dataset so a re-reported profile replaces its section (last event wins),
             # while insertion order keeps sections in exp_data order.
@@ -157,6 +161,7 @@ class SummaryLogger:
         self._simulation_parameters(lines, rule)
         self._crystallographic_parameters(lines, rule, Path(outputs.structure))
         self._objective_terms(lines, rule)
+        self._orientation_optimization(lines, rule)
         self._objective_components(lines, rule)
         self._epoch_curve(lines, rule)
         self._rotation_metrics(lines, rule)
@@ -273,6 +278,38 @@ class SummaryLogger:
         lines.append(f" penalties  : {penalties or 'none'}")
         lines.append(f" constraints: {', '.join(manifest.constraints) or 'none'}")
         lines.append(f" components : {', '.join(manifest.components) or 'none'}")
+
+    def _orientation_optimization(self, lines: list[str], rule: Callable[[str], None]) -> None:
+        rule("Orientation optimization")
+        if not self._orientations:
+            lines.append(" enabled: no (orientation search was not part of this run)")
+            return
+        residual = self._orientations[0].residual
+        lines.append(
+            ascii_table(
+                [
+                    "Dataset",
+                    "Rotation",
+                    "delta alpha (deg)",
+                    "delta beta (deg)",
+                    "delta omega (deg)",
+                    f"seed {residual}",
+                    f"final {residual}",
+                ],
+                [
+                    [
+                        event.dataset,
+                        str(event.rotation_index),
+                        f"{event.alpha:.4f}",
+                        f"{event.beta:.4f}",
+                        f"{event.omega:.4f}",
+                        f"{event.seed_score:.6f}",
+                        f"{event.score:.6f}",
+                    ]
+                    for event in self._orientations
+                ],
+            )
+        )
 
     def _objective_components(self, lines: list[str], rule: Callable[[str], None]) -> None:
         rule("Objective components (best epoch)")

--- a/src/diffBloch/observability.py
+++ b/src/diffBloch/observability.py
@@ -262,22 +262,32 @@ class OrientationOptimized:
     ran against, matching :attr:`ThicknessProfile.label`'s convention, and read off the rotation's
     own ``pattern``), since ``optimize_orientation`` runs once per dataset, before a multi-dataset
     pool renumbers anything -- so a rotation index alone cannot disambiguate a pooled run; pair it
-    with ``dataset``. ``score`` the final orientation's value under ``residual`` -- the
-    :class:`~diffBloch.config.schema.LossMetricsConfig` name (``"wr2"``/``"robs"``) that produced
-    it, carried alongside so a consumer can label the number correctly
-    (:attr:`measurements` keys on it directly, e.g. ``{"wr2": ...}`` or ``{"robs": ...}``) rather
-    than a generic, misleading ``wr2`` field under a different residual. ``n_trials`` the number of
-    trial orientations the search scored, ``n_passes`` scipy's reported iteration count (the
-    quantity ``NelderMeadSearch.max_iterations`` caps), and ``pass_cap`` that cap itself -- carried
-    per event so a plot can show each rotation's headroom (``n_passes`` vs ``pass_cap``) and flag
-    any rotation that ran to the cap. With ``workers > 1`` events arrive in *completion* order (the
-    plan itself stays ordered). The channel is shared with the step's ``PlanStepCompleted`` summary
-    line, like the refinement stream's events.
+    with ``dataset``. ``score`` the final orientation's value
+    under ``residual`` -- the :class:`~diffBloch.config.schema.LossMetricsConfig` name
+    (``"wr2"``/``"robs"``) that produced it, carried alongside so a consumer can label the number
+    correctly (:attr:`measurements` keys on it directly, e.g. ``{"wr2": ...}`` or ``{"robs": ...}``)
+    rather than a generic, misleading ``wr2`` field under a different residual. ``seed_score`` is the
+    same metric at the *unsearched* seed orientation (the goniometer correction fixed at
+    ``(0, 0, 0)``), so ``seed_score - score`` states what the search actually bought. ``alpha``,
+    ``beta``, ``omega`` are the goniometer-correction angles (degrees) the search settled on --
+    exactly the ``(alpha, beta, omega)`` :func:`~diffBloch.preprocess.orientation.goniometer_rotation`
+    right-multiplies onto the seed orientation, so they are already "distance from the original
+    orientation" in the search's own three degrees of freedom, not a derived quantity. ``n_trials``
+    the number of trial orientations the search scored, ``n_passes`` scipy's reported iteration count
+    (the quantity ``NelderMeadSearch.max_iterations`` caps), and ``pass_cap`` that cap itself --
+    carried per event so a plot can show each rotation's headroom (``n_passes`` vs ``pass_cap``) and
+    flag any rotation that ran to the cap. With ``workers > 1`` events arrive in *completion* order
+    (the plan itself stays ordered). The channel is shared with the step's ``PlanStepCompleted``
+    summary line, like the refinement stream's events.
     """
 
     channel: ClassVar[str] = "orientation"
     rotation_index: int
     score: float
+    seed_score: float
+    alpha: float
+    beta: float
+    omega: float
     residual: str
     n_matched_hkl: int
     n_trials: int
@@ -291,7 +301,14 @@ class OrientationOptimized:
 
     @property
     def measurements(self) -> Mapping[str, float]:
-        return {self.residual: self.score, "n_matched_hkl": float(self.n_matched_hkl)}
+        return {
+            self.residual: self.score,
+            f"seed_{self.residual}": self.seed_score,
+            "delta_alpha_deg": self.alpha,
+            "delta_beta_deg": self.beta,
+            "delta_omega_deg": self.omega,
+            "n_matched_hkl": float(self.n_matched_hkl),
+        }
 
 
 @dataclass(frozen=True)

--- a/src/diffBloch/preprocess/steps/optimize_orientation.py
+++ b/src/diffBloch/preprocess/steps/optimize_orientation.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import replace
+from typing import NamedTuple
 
 import numpy as np
 import torch
@@ -202,7 +203,7 @@ def optimize_orientation(
         params = refinement.params if device is None else refinement.params.to(device)
         fgb = engine.fgb(params)
 
-        def refine(op: OrientationPlanLike) -> tuple[OrientationPlanLike, float, int, int]:
+        def refine(op: OrientationPlanLike) -> _FitResult:
             trial_fgb: Tensor | Callable[[OrientationPlanLike], Tensor] = fgb
             if coupling is not None:
                 cached = fgb.clone()
@@ -240,25 +241,25 @@ def optimize_orientation(
         # plan rather than passed in -- a recipe step takes no dataset argument.
         dataset = dataset_of(built)
         logger.report(OrientationOptimizationStarted(total_rotations=len(built), dataset=dataset))
-        results_by_index: dict[int, tuple[OrientationPlanLike, float, int, int]] = {}
+        results_by_index: dict[int, _FitResult] = {}
         cap = search.max_iterations
 
-        def report(
-            index: int,
-            result: tuple[OrientationPlanLike, float, int, int],
-        ) -> None:
-            fitted, score, n_trials, n_passes = result
+        def report(index: int, result: _FitResult) -> None:
             results_by_index[index] = result
-            pattern_index = fitted.alignment.pattern_index
+            pattern_index = result.plan.alignment.pattern_index
             n_matched = int(pattern_index.shape[0])
             logger.report(
                 OrientationOptimized(
-                    rotation_index=fitted.pattern.rotation_index,
-                    score=score,
+                    rotation_index=result.plan.pattern.rotation_index,
+                    score=result.score,
+                    seed_score=result.seed_score,
+                    alpha=result.alpha,
+                    beta=result.beta,
+                    omega=result.omega,
                     residual=residual,
                     n_matched_hkl=n_matched,
-                    n_trials=n_trials,
-                    n_passes=n_passes,
+                    n_trials=result.n_trials,
+                    n_passes=result.n_passes,
                     pass_cap=cap,
                     dataset=dataset,
                 )
@@ -284,7 +285,7 @@ def optimize_orientation(
             for index, op in enumerate(built):
                 report(index, refine(op))
         ordered_results = tuple(results_by_index[i] for i in range(len(built)))
-        ordered = tuple(result[0] for result in ordered_results)
+        ordered = tuple(result.plan for result in ordered_results)
 
         def strong_matched_hkl(op: OrientationPlanLike) -> Tensor:
             pattern_index = op.alignment.pattern_index
@@ -294,13 +295,13 @@ def optimize_orientation(
         logger.report(
             OrientationOptimizationSummary(
                 n_orientations=len(ordered_results),
-                mean_score=sum(result[1] for result in ordered_results) / len(ordered_results),
+                mean_score=sum(result.score for result in ordered_results) / len(ordered_results),
                 residual=residual,
                 unique_matched_hkl=unique_hkl_count(op.alignment.hkl for op in ordered),
                 unique_strong_hkl=unique_hkl_count(strong_matched_hkl(op) for op in ordered),
                 unique_observed_hkl=unique_hkl_count(op.pattern.hkl for op in ordered),
-                total_trials=sum(result[2] for result in ordered_results),
-                max_passes=max(result[3] for result in ordered_results),
+                total_trials=sum(result.n_trials for result in ordered_results),
+                max_passes=max(result.n_passes for result in ordered_results),
             )
         )
         return replace(plan, orientations=ordered)
@@ -333,6 +334,20 @@ def _comparable_score(score: float, plan: OrientationPlanLike, search: NelderMea
     return score / n_matched if n_matched > 0 else float("inf")
 
 
+class _FitResult(NamedTuple):
+    """One rotation's finished search: the fitted plan plus everything :class:`OrientationOptimized`
+    reports about it."""
+
+    plan: OrientationPlanLike
+    score: float
+    n_trials: int
+    n_passes: int
+    alpha: float
+    beta: float
+    omega: float
+    seed_score: float
+
+
 def _refine_one(
     engine: RefinementEngine,
     fgb: Tensor | Callable[[OrientationPlanLike], Tensor],
@@ -342,7 +357,7 @@ def _refine_one(
     search: NelderMeadSearch,
     coupling: TrialCoupling | None,
     validate: bool = True,
-) -> tuple[OrientationPlanLike, float, int, int]:
+) -> _FitResult:
     """Local Nelder-Mead search over the goniometer correction ``(alpha, beta, omega)``.
 
     Every trial composes directly off the fixed seed orientation: ``seed_orientation @
@@ -351,6 +366,11 @@ def _refine_one(
     ``method="Nelder-Mead"`` from a fixed initial simplex of edge length ``search.step_size``
     around ``(alpha, beta, omega) = (0, 0, 0)``, exactly mirroring the reference implementation
     this port is checked against. ``n_passes`` is scipy's reported iteration count (``result.nit``).
+
+    ``seed_score`` is the same metric evaluated once more at the unsearched seed orientation
+    (``alpha = beta = omega = 0``) -- one extra forward solve on top of the search's own trials, paid
+    so the report can state what the search actually bought (``seed_score - score``) instead of only
+    the post-search value.
     """
     grid = plan.structure_factor_grid
     n_trials = 0
@@ -363,6 +383,11 @@ def _refine_one(
         if coupling is None:
             return op.with_orientation(grid, orientation)
         return _coupled_trial(grid, op, orientation, coupling, gather_cache, validate=validate)
+
+    seed_trial = build_trial(seed_orientation)
+    n_trials += 1
+    seed_trial_fgb = fgb(seed_trial) if callable(fgb) else fgb
+    seed_score = float(engine.score_orientation(seed_trial, seed_trial_fgb))
 
     def objective(params: NDArray[np.float64]) -> float:
         nonlocal n_trials
@@ -404,7 +429,16 @@ def _refine_one(
     # result.fun is the comparable (penalized) score minimised above; report the plain score
     # instead (self.scores, under whichever residual ExperimentConfig.loss_metrics configures).
     score = float(engine.score_orientation(current, current_fgb))
-    return current, score, n_trials, int(result.nit)
+    return _FitResult(
+        plan=current,
+        score=score,
+        n_trials=n_trials,
+        n_passes=int(result.nit),
+        alpha=float(alpha),
+        beta=float(beta),
+        omega=float(omega),
+        seed_score=seed_score,
+    )
 
 
 def _coupled_trial(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -23,8 +23,8 @@ from diffBloch.preprocess.inference import InferenceResult, RotationInference
 
 FIXTURE = Path(__file__).parent.parent / "fixtures" / "quartz_min" / "experiment.yaml"
 LOCKED = Path(__file__).parent.parent / "fixtures" / "locked_min"
-# A real CIF on disk: SummaryLogger reads the written structure back on the terminal event, so the
-# artifact path a fake emits has to point at a file that parses.
+# A real CIF on disk: SummaryLogger reads the written structure back on the terminal
+# event, so the artifact path a fake emits has to point at a file that parses.
 REFINED_CIF = Path(__file__).parent.parent / "fixtures" / "quartz_anchor" / "enantiomer_1.cif"
 
 
@@ -322,6 +322,10 @@ def test_preprocess_delegates_and_reports_without_scoring(
             OrientationOptimized(
                 rotation_index=3,
                 score=0.25,
+                seed_score=0.4,
+                alpha=0.1,
+                beta=0.0,
+                omega=-0.1,
                 residual="wr2",
                 n_matched_hkl=2,
                 n_trials=10,
@@ -334,6 +338,10 @@ def test_preprocess_delegates_and_reports_without_scoring(
             OrientationOptimized(
                 rotation_index=8,
                 score=0.5,
+                seed_score=0.6,
+                alpha=0.05,
+                beta=-0.05,
+                omega=0.0,
                 residual="wr2",
                 n_matched_hkl=3,
                 n_trials=10,
@@ -515,7 +523,8 @@ def test_refine_delegates_and_reports(
     assert rc == 0
     assert captured["dir"] == str(tmp_path)
     # The refine path fans out to the console and to the summary sink that writes
-    # refinement_report.txt -- composed here, not inside refine_experiment.
+    # refinement_report.txt -- composed here, not inside refine_experiment. Both COMPLETE boxes
+    # come from the ConsoleLogger's own event handling, so no third sink is wired in for them.
     logger = captured["logger"]
     assert isinstance(logger, MultiLogger)
     assert [type(s).__name__ for s in logger.loggers] == ["ConsoleLogger", "SummaryLogger"]

--- a/tests/unit/test_coupling_step.py
+++ b/tests/unit/test_coupling_step.py
@@ -451,6 +451,10 @@ def test_fit_orientation_emits_progress_events() -> None:
     assert all(e.n_trials >= 1 and e.score >= 0.0 for e in fits)
     # n_passes is the capped quantity and must be observable within its cap for calibration.
     assert all(1 <= e.n_passes <= e.pass_cap == search.max_iterations for e in fits)
+    # seed_score is a real evaluation (not a placeholder), and the search actually moved the
+    # orientation away from the unsearched seed on at least one of its three degrees of freedom.
+    assert all(e.seed_score >= 0.0 for e in fits)
+    assert all(any((e.alpha, e.beta, e.omega)) for e in fits)
 
 
 def test_scored_set_stays_pinned_when_the_solve_union_is_larger() -> None:

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -61,6 +61,10 @@ def _fitted(index: int, score: float, residual: str = "wr2") -> OrientationOptim
     return OrientationOptimized(
         rotation_index=index,
         score=score,
+        seed_score=score + 0.1,
+        alpha=0.05,
+        beta=-0.02,
+        omega=0.01,
         residual=residual,
         n_matched_hkl=42,
         n_trials=10,
@@ -316,6 +320,40 @@ def test_console_logger_formats_refinement_epoch_metrics(
     )
 
 
+def test_console_logger_prints_validation_metrics_when_a_selection_engine_ran(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger = ConsoleLogger(level=logging.INFO)
+    with caplog.at_level(logging.INFO, logger="diffBloch.loggers"):
+        logger.report(
+            RefinementStep(
+                iteration=7,
+                loss=4.95,
+                wr2=0.05,
+                val_wr2=0.09,
+                val_r_obs=0.07,
+                val_n_rotations=10,
+                val_n_wr2_evaluated=9,
+                val_n_r_obs_evaluated=8,
+            )
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert "Refinement epoch   8 │ wR2 0.050000 │ R_obs n/a │ diffraction loss n/a" in messages
+    assert "  validation      │ wR2 0.090000 [9/10] │ R_obs 0.070000 [8/10]" in messages
+
+
+def test_console_logger_omits_validation_line_without_a_selection_engine(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No val_wr2 on the event -> no validation line, not one printed with placeholder values."""
+    logger = ConsoleLogger(level=logging.INFO)
+    with caplog.at_level(logging.INFO, logger="diffBloch.loggers"):
+        logger.report(RefinementStep(iteration=0, loss=1.0, wr2=0.1))
+
+    assert not any("validation" in record.getMessage() for record in caplog.records)
+
+
 def test_objective_manifest_declares_composition_including_the_empty_case() -> None:
     empty = ObjectiveManifest()
     assert empty.channel == "objective"
@@ -487,7 +525,7 @@ def test_console_logger_labels_orientation_refinement_index(
     assert (
         caplog.records[-1]
         .getMessage()
-        .startswith("orientation optimization[rotation_index=10] wr2=0.025 n_matched_hkl=42")
+        .startswith("orientation optimization[rotation_index=10] wr2=0.025")
     )
 
 
@@ -589,6 +627,39 @@ def test_console_logger_renders_a_thickness_progress_bar_on_a_tty(
     out = capsys.readouterr().out
     assert "1/2" in out and "2/2" in out
     assert out.endswith("\n")
+
+
+def test_console_logger_names_the_dataset_on_orientation_and_thickness_started(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Regression for #140-adjacent multi-dataset log readability: previously these two lines
+    carried only a rotation count, with no way to tell which dataset a pooled run's announcement
+    belonged to."""
+    logger = ConsoleLogger(level=logging.INFO)
+    with caplog.at_level(logging.INFO, logger="diffBloch.loggers"):
+        logger.report(
+            OrientationOptimizationStarted(total_rotations=32, dataset="174_dyn.cif_pets")
+        )
+        logger.report(ThicknessOptimizationStarted(total_rotations=32, dataset="174_dyn.cif_pets"))
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert "Orientation optimization │ 174_dyn.cif_pets │ 32 rotation(s)" in messages
+    assert "Thickness optimization │ 174_dyn.cif_pets │ 32 rotation(s)" in messages
+
+
+def test_console_logger_omits_the_dataset_segment_when_unlabeled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A direct API caller outside the multi-dataset preprocess loop passes no dataset_label -- the
+    line must fall back to its original plain form, not print an empty "│  │" segment."""
+    logger = ConsoleLogger(level=logging.INFO)
+    with caplog.at_level(logging.INFO, logger="diffBloch.loggers"):
+        logger.report(OrientationOptimizationStarted(total_rotations=52))
+        logger.report(ThicknessOptimizationStarted(total_rotations=52))
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert "Orientation optimization │ 52 rotation(s)" in messages
+    assert "Thickness optimization │ 52 rotation(s)" in messages
 
 
 def test_console_logger_falls_back_to_plain_lines_off_a_tty(

--- a/tests/unit/test_optimize_orientation.py
+++ b/tests/unit/test_optimize_orientation.py
@@ -326,7 +326,16 @@ def test_fit_orientation_workers_abort_cancels_pending_rotations(
     ):
         calls.append(1)
         time.sleep(0.03)  # a window in which the abort can cancel the still-queued rotations
-        return op, 0.5, 1, 1
+        return fo._FitResult(
+            plan=op,
+            score=0.5,
+            n_trials=1,
+            n_passes=1,
+            alpha=0.0,
+            beta=0.0,
+            omega=0.0,
+            seed_score=0.5,
+        )
 
     monkeypatch.setattr(fo, "_refine_one", stub)
     grid, asu_plan, spec, numbers = _silicon()

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -51,6 +51,10 @@ def test_report_ignores_events_that_are_not_thickness_optimized(tmp_path: Path) 
         OrientationOptimized(
             rotation_index=3,
             score=0.05,
+            seed_score=0.09,
+            alpha=0.02,
+            beta=0.0,
+            omega=-0.01,
             residual="wr2",
             n_matched_hkl=100,
             n_trials=40,

--- a/tests/unit/test_summary_logger.py
+++ b/tests/unit/test_summary_logger.py
@@ -16,6 +16,7 @@ from diffBloch.observability import (
     ExperimentDeclared,
     ObjectiveManifest,
     ObjectiveTerm,
+    OrientationOptimized,
     RefinedRotationMetrics,
     RefinementCompleted,
     RefinementOutputsWritten,
@@ -97,6 +98,7 @@ def _run(
     experiment: ExperimentDeclared | None = None,
     steps: tuple[RefinementStep, ...] = (),
     rotations: tuple[RefinedRotationMetrics, ...] = (),
+    orientations: tuple[OrientationOptimized, ...] = (),
     profiles: tuple[ThicknessProfile, ...] = (),
     manifest: ObjectiveManifest | None = None,
     completed: RefinementCompleted | None = None,
@@ -110,6 +112,8 @@ def _run(
         if manifest is not None
         else ObjectiveManifest(penalties=(ObjectiveTerm(name="bond_length", weight=3.0),))
     )
+    for orientation in orientations:
+        logger.report(orientation)
     for step in steps or (_step(),):
         logger.report(step)
     logger.report(
@@ -128,6 +132,33 @@ def _run(
         logger.report(profile)
     logger.report(RefinementOutputsWritten(structure=str(structure)))
     return (tmp_path / "refinement_report.txt").read_text()
+
+
+def _orientation(
+    index: int,
+    *,
+    alpha: float = 0.05,
+    beta: float = -0.02,
+    omega: float = 0.01,
+    score: float = 0.02,
+    seed_score: float = 0.08,
+    residual: str = "wr2",
+    dataset: str = "q.cif_pets",
+) -> OrientationOptimized:
+    return OrientationOptimized(
+        rotation_index=index,
+        score=score,
+        seed_score=seed_score,
+        alpha=alpha,
+        beta=beta,
+        omega=omega,
+        residual=residual,
+        n_matched_hkl=5,
+        n_trials=20,
+        n_passes=4,
+        pass_cap=2000,
+        dataset=dataset,
+    )
 
 
 def _rotation(
@@ -434,3 +465,30 @@ def test_summary_epoch_curve_omits_validation_columns_without_a_selection_engine
 
     epoch_curve = text.split("Epoch curve")[1].split("\n--- ")[0]
     assert "Val wR2" not in epoch_curve
+
+
+def test_summary_orientation_optimization_defaults_to_disabled(tmp_path: Path) -> None:
+    text = _run(tmp_path, rotations=(_rotation(0),))
+
+    orientation_section = text.split("Orientation optimization")[1].split("\n--- ")[0]
+    assert "enabled: no" in orientation_section
+
+
+def test_summary_orientation_optimization_lists_delta_angles_and_before_after_score(
+    tmp_path: Path,
+) -> None:
+    text = _run(
+        tmp_path,
+        orientations=(
+            _orientation(0, alpha=0.15, beta=-0.05, omega=0.02, seed_score=0.09, score=0.03),
+        ),
+        rotations=(_rotation(0),),
+    )
+
+    orientation_section = text.split("Orientation optimization")[1].split("\n--- ")[0]
+    assert "0.1500" in orientation_section  # delta alpha
+    assert "-0.0500" in orientation_section  # delta beta
+    assert "0.0200" in orientation_section  # delta omega
+    assert "0.090000" in orientation_section  # seed score (before the search)
+    assert "0.030000" in orientation_section  # final score (after the search)
+    assert "q.cif_pets" in orientation_section


### PR DESCRIPTION
The orientation fit is the long phase of a preprocess run, and afterwards there was no way to tell
whether it had done anything. The report showed no trace of it, and the per-rotation console line
gave only the final score — with no reference point, a wR2 of 0.02 could equally be a search that
recovered a badly seeded orientation or one that had nothing to do.

`OrientationOptimized` now carries the two things that answer it: `seed_score`, the same metric
evaluated at the **unsearched** seed orientation, and the settled `(alpha, beta, omega)` goniometer
correction in degrees. Those angles are not a derived quantity — they are exactly what
`goniometer_rotation` right-multiplies onto the seed, so they already *are* "distance from the
original orientation" in the search's own three degrees of freedom.

A new **Orientation optimization** section of `refinement_report.txt` tables them per rotation, so:

- a large angle with a barely-improved score (a search that wandered) reads differently from
- a small angle with a large improvement (a seed that was nearly right)

and a run that reused a checkpoint says so plainly rather than showing an empty table.

### ⚠️ This costs one extra forward solve per rotation

`seed_score` is a real evaluation, paid for **reporting** rather than for the fit. It is one solve
against the ~100+ trials a coupled search already runs per rotation, so it is within noise of the
phase it measures — but it is not free, and that is worth an explicit decision rather than a
footnote.

### Also here

`_refine_one`'s 4-tuple return becomes a named `_FitResult`. Eight positional values indexed as
`result[0]..result[3]` at three call sites was already at the limit of what is readable, and this
adds four more.

### Testing

`test_coupling_step` asserts `seed_score` is a real evaluation rather than a placeholder, and that
the search actually moved the orientation on at least one degree of freedom.

---

## ⚠️ Merge procedure — please read

The previous attempt at this stack (#184–#188) was marked *merged* by GitHub but **none of that
content reached `main`**. The cause: `refactor/remove-quiet-flag` was merged to `main` (#183) and
then **not deleted**, so the PRs still based on it kept that base and merged into a branch that no
longer had a route to `main`. GitHub only auto-retargets an open PR when its base branch is
*deleted*.

To avoid a repeat, either:

- **merge strictly bottom-up and delete each base branch on merge** (the "Delete branch" button —
  this retargets the next PR to `main` automatically), or
- **retarget each PR to `main` by hand** once the one below it has landed.

If a PR here shows more commits than the one listed below, its base has not caught up yet — do not
merge it until it does.

## Stack

Rebuilt fresh off current `main` (`ddfbb1f`). One commit each; merge in this order:

| # | branch | commits | files |
|---|---|---|---|
| 1 | `feat/console-boxes-from-events` | 1 | 6 |
| 2 | `feat/per-epoch-validation-metrics` | 1 | 6 |
| 3 | `feat/rotation-dataset-ref` | 1 | 22 |
| 4 | `feat/orientation-search-report` | 1 | 9 |
| 5 | `feat/per-dataset-report` | 1 | 2 |
