### PR TITLE
Break the refined-model metrics out per dataset

### DIFF
--- a/src/diffBloch/app/loggers/summary.py
+++ b/src/diffBloch/app/loggers/summary.py
@@ -70,6 +70,18 @@ def ascii_table(headers: list[str], rows: list[list[str]]) -> str:
     return "\n".join(lines)
 
 
+def _finite_mean_cell(values: Sequence[float]) -> str:
+    """A compact ``mean [n_finite/n_total]`` cell, ``n/a [0/n_total]`` when nothing was finite.
+
+    Every mean in the report states the denominator it was taken over: a mean that covers fewer
+    rotations is a different quantity, not a better one.
+    """
+    finite = [value for value in values if math.isfinite(value)]
+    if not finite:
+        return f"n/a [0/{len(values)}]"
+    return f"{sum(finite) / len(finite):.6f} [{len(finite)}/{len(values)}]"
+
+
 def _cif_loop_as_table(block: gemmi.cif.Block, first_tag: str) -> str | None:
     """Render a CIF loop (identified by its first column tag) as a plain aligned ASCII table.
 
@@ -165,6 +177,7 @@ class SummaryLogger:
         self._objective_components(lines, rule)
         self._epoch_curve(lines, rule)
         self._rotation_metrics(lines, rule)
+        self._per_dataset_summary(lines, rule)
         self._thickness_profile(lines, rule)
         self._refined_structure(lines, rule, Path(outputs.structure))
 
@@ -379,21 +392,9 @@ class SummaryLogger:
                     ],
                 )
             )
-            finite_wr2 = [row.wr2 for row in rows if math.isfinite(row.wr2)]
-            finite_r_obs = [row.r_obs for row in rows if math.isfinite(row.r_obs)]
             lines.append("")
-
-            def mean_line(label: str, finite: list[float]) -> str:
-                # Each mean states the denominator it was taken over: a mean that covers fewer
-                # rotations is a different quantity, not a better one.
-                if not finite:
-                    return f" mean {label} = n/a [0/{len(rows)}]"
-                return (
-                    f" mean {label} = {sum(finite) / len(finite):.6f} [{len(finite)}/{len(rows)}]"
-                )
-
-            lines.append(mean_line("wR2  ", finite_wr2))
-            lines.append(mean_line("R_obs", finite_r_obs))
+            lines.append(f" mean wR2   = {_finite_mean_cell([row.wr2 for row in rows])}")
+            lines.append(f" mean R_obs = {_finite_mean_cell([row.r_obs for row in rows])}")
 
         rule("Per-rotation wR2 / R_obs (final refined model)")
         block(self._rotations)
@@ -403,6 +404,53 @@ class SummaryLogger:
             lines.append(f" n_rotations = {len(validation)}")
             lines.append("")
             block(validation)
+
+    def _per_dataset_summary(self, lines: list[str], rule: Callable[[str], None]) -> None:
+        # Distinct datasets, in first-seen (exp_data) order -- a single-dataset run has nothing a
+        # per-dataset breakdown would add over the table above, so the section is omitted entirely.
+        labels: list[str] = []
+        for row in self._rotations:
+            if row.dataset not in labels:
+                labels.append(row.dataset)
+        if len(labels) < 2:
+            return
+
+        rule("Per-dataset summary")
+
+        def dataset_row(name: str, rows: Sequence[RefinedRotationMetrics]) -> list[str]:
+            train = [row for row in rows if not row.is_validation]
+            validation = [row for row in rows if row.is_validation]
+            return [
+                name,
+                f"{len(train)}/{len(validation)}",
+                _finite_mean_cell([row.wr2 for row in train]),
+                _finite_mean_cell([row.r_obs for row in train]),
+                _finite_mean_cell([row.wr2 for row in validation]),
+                _finite_mean_cell([row.r_obs for row in validation]),
+                _finite_mean_cell([row.wr2 for row in rows]),
+                _finite_mean_cell([row.r_obs for row in rows]),
+            ]
+
+        rows = [
+            dataset_row(label, [row for row in self._rotations if row.dataset == label])
+            for label in labels
+        ]
+        rows.append(dataset_row("All datasets", self._rotations))
+        lines.append(
+            ascii_table(
+                [
+                    "Dataset",
+                    "N (train/val)",
+                    "Train wR2",
+                    "Train R_obs",
+                    "Val wR2",
+                    "Val R_obs",
+                    "Total wR2",
+                    "Total R_obs",
+                ],
+                rows,
+            )
+        )
 
     def _thickness_profile(self, lines: list[str], rule: Callable[[str], None]) -> None:
         if not self._profiles:

--- a/tests/unit/test_summary_logger.py
+++ b/tests/unit/test_summary_logger.py
@@ -134,6 +134,23 @@ def _run(
     return (tmp_path / "refinement_report.txt").read_text()
 
 
+def _rotation(
+    index: int,
+    *,
+    wr2: float = 0.2,
+    is_validation: bool = False,
+    dataset: str = "q.cif_pets",
+) -> RefinedRotationMetrics:
+    return RefinedRotationMetrics(
+        rotation_index=index,
+        wr2=wr2,
+        r_obs=0.15,
+        n_matched=5,
+        is_validation=is_validation,
+        dataset=dataset,
+    )
+
+
 def _orientation(
     index: int,
     *,
@@ -157,23 +174,6 @@ def _orientation(
         n_trials=20,
         n_passes=4,
         pass_cap=2000,
-        dataset=dataset,
-    )
-
-
-def _rotation(
-    index: int,
-    *,
-    wr2: float = 0.2,
-    is_validation: bool = False,
-    dataset: str = "q.cif_pets",
-) -> RefinedRotationMetrics:
-    return RefinedRotationMetrics(
-        rotation_index=index,
-        wr2=wr2,
-        r_obs=0.15,
-        n_matched=5,
-        is_validation=is_validation,
         dataset=dataset,
     )
 
@@ -254,6 +254,121 @@ def test_summary_selects_the_best_epoch_not_the_last(tmp_path: Path) -> None:
 
     assert "objective total = 1" in text
     assert "10.00 [3/4]" in text  # the best epoch's wR2, not epoch 2's
+
+
+def test_summary_epoch_curve_lists_every_recorded_step(tmp_path: Path) -> None:
+    """The epoch curve is the whole trajectory, not just the best epoch."""
+    text = _run(
+        tmp_path,
+        steps=(
+            _step(iteration=0, wr2=0.9, r_obs=0.8),
+            _step(iteration=1, wr2=0.1, r_obs=0.05),
+        ),
+        completed=RefinementCompleted(n_steps=2, best_step=1, best_loss=1.0),
+        rotations=(_rotation(0),),
+    )
+
+    assert "Epoch curve" in text
+    epoch_curve = text.split("Epoch curve")[1].split("\n--- ")[0]
+    assert "1" in epoch_curve and "0.900000" in epoch_curve and "0.800000" in epoch_curve
+    assert "2" in epoch_curve and "0.100000" in epoch_curve and "0.050000" in epoch_curve
+
+
+def test_summary_epoch_curve_renders_na_for_unevaluated_epochs(tmp_path: Path) -> None:
+    text = _run(
+        tmp_path,
+        steps=(_step(wr2=None, r_obs=None),),
+        rotations=(_rotation(0),),
+    )
+
+    epoch_curve = text.split("Epoch curve")[1].split("\n--- ")[0]
+    assert "n/a" in epoch_curve
+
+
+def test_summary_epoch_curve_adds_validation_columns_when_a_selection_engine_ran(
+    tmp_path: Path,
+) -> None:
+    text = _run(
+        tmp_path,
+        steps=(
+            _step(iteration=0, wr2=0.9, r_obs=0.8, val_wr2=0.95, val_r_obs=0.85),
+            _step(iteration=1, wr2=0.1, r_obs=0.05, val_wr2=0.2, val_r_obs=0.15),
+        ),
+        completed=RefinementCompleted(n_steps=2, best_step=1, best_loss=1.0),
+        rotations=(_rotation(0),),
+    )
+
+    epoch_curve = text.split("Epoch curve")[1].split("\n--- ")[0]
+    assert "Val wR2" in epoch_curve and "Val R_obs" in epoch_curve
+    assert "0.950000" in epoch_curve and "0.850000" in epoch_curve
+    assert "0.200000" in epoch_curve and "0.150000" in epoch_curve
+
+
+def test_summary_epoch_curve_omits_validation_columns_without_a_selection_engine(
+    tmp_path: Path,
+) -> None:
+    text = _run(tmp_path, rotations=(_rotation(0),))
+
+    epoch_curve = text.split("Epoch curve")[1].split("\n--- ")[0]
+    assert "Val wR2" not in epoch_curve
+
+
+def test_summary_orientation_optimization_defaults_to_disabled(tmp_path: Path) -> None:
+    text = _run(tmp_path, rotations=(_rotation(0),))
+
+    orientation_section = text.split("Orientation optimization")[1].split("\n--- ")[0]
+    assert "enabled: no" in orientation_section
+
+
+def test_summary_orientation_optimization_lists_delta_angles_and_before_after_score(
+    tmp_path: Path,
+) -> None:
+    text = _run(
+        tmp_path,
+        orientations=(
+            _orientation(0, alpha=0.15, beta=-0.05, omega=0.02, seed_score=0.09, score=0.03),
+        ),
+        rotations=(_rotation(0),),
+    )
+
+    orientation_section = text.split("Orientation optimization")[1].split("\n--- ")[0]
+    assert "0.1500" in orientation_section  # delta alpha
+    assert "-0.0500" in orientation_section  # delta beta
+    assert "0.0200" in orientation_section  # delta omega
+    assert "0.090000" in orientation_section  # seed score (before the search)
+    assert "0.030000" in orientation_section  # final score (after the search)
+    assert "q.cif_pets" in orientation_section
+
+
+def test_summary_per_dataset_summary_is_omitted_for_a_single_dataset(tmp_path: Path) -> None:
+    text = _run(tmp_path, rotations=(_rotation(0), _rotation(1)))
+
+    assert "Per-dataset summary" not in text
+
+
+def test_summary_per_dataset_summary_breaks_out_train_validation_and_total(
+    tmp_path: Path,
+) -> None:
+    text = _run(
+        tmp_path,
+        rotations=(
+            _rotation(0, wr2=0.1, dataset="a.cif_pets"),
+            _rotation(1, wr2=0.3, is_validation=True, dataset="a.cif_pets"),
+            _rotation(2, wr2=0.2, dataset="b.cif_pets"),
+        ),
+    )
+
+    assert "Per-dataset summary" in text
+    per_dataset = text.split("Per-dataset summary")[1].split("\n--- ")[0]
+    assert "a.cif_pets" in per_dataset and "b.cif_pets" in per_dataset
+    assert "All datasets" in per_dataset
+    # a.cif_pets: 1 train (wr2=0.1), 1 validation (wr2=0.3), 2 total.
+    assert "0.100000 [1/1]" in per_dataset  # a's train wR2
+    assert "0.300000 [1/1]" in per_dataset  # a's validation wR2
+    # b.cif_pets has no validation rotations -- the cell must not blow up on an empty split.
+    assert "n/a [0/0]" in per_dataset
+    # All datasets aggregates every rotation regardless of which dataset it came from.
+    assert "0.200000 [3/3]" in per_dataset  # mean wR2 over all three rotations
 
 
 def test_summary_renders_an_unevaluated_mean_as_na(tmp_path: Path) -> None:
@@ -408,87 +523,3 @@ def test_ascii_table_widens_a_column_to_its_content() -> None:
     table = ascii_table(["A", "B"], [["a-very-long-cell", "1"]])
     header, rule, row = table.splitlines()
     assert len(header) == len(rule) == len(row)
-
-
-def test_summary_epoch_curve_lists_every_recorded_step(tmp_path: Path) -> None:
-    """The epoch curve is the whole trajectory, not just the best epoch."""
-    text = _run(
-        tmp_path,
-        steps=(
-            _step(iteration=0, wr2=0.9, r_obs=0.8),
-            _step(iteration=1, wr2=0.1, r_obs=0.05),
-        ),
-        completed=RefinementCompleted(n_steps=2, best_step=1, best_loss=1.0),
-        rotations=(_rotation(0),),
-    )
-
-    assert "Epoch curve" in text
-    epoch_curve = text.split("Epoch curve")[1].split("\n--- ")[0]
-    assert "1" in epoch_curve and "0.900000" in epoch_curve and "0.800000" in epoch_curve
-    assert "2" in epoch_curve and "0.100000" in epoch_curve and "0.050000" in epoch_curve
-
-
-def test_summary_epoch_curve_renders_na_for_unevaluated_epochs(tmp_path: Path) -> None:
-    text = _run(
-        tmp_path,
-        steps=(_step(wr2=None, r_obs=None),),
-        rotations=(_rotation(0),),
-    )
-
-    epoch_curve = text.split("Epoch curve")[1].split("\n--- ")[0]
-    assert "n/a" in epoch_curve
-
-
-def test_summary_epoch_curve_adds_validation_columns_when_a_selection_engine_ran(
-    tmp_path: Path,
-) -> None:
-    text = _run(
-        tmp_path,
-        steps=(
-            _step(iteration=0, wr2=0.9, r_obs=0.8, val_wr2=0.95, val_r_obs=0.85),
-            _step(iteration=1, wr2=0.1, r_obs=0.05, val_wr2=0.2, val_r_obs=0.15),
-        ),
-        completed=RefinementCompleted(n_steps=2, best_step=1, best_loss=1.0),
-        rotations=(_rotation(0),),
-    )
-
-    epoch_curve = text.split("Epoch curve")[1].split("\n--- ")[0]
-    assert "Val wR2" in epoch_curve and "Val R_obs" in epoch_curve
-    assert "0.950000" in epoch_curve and "0.850000" in epoch_curve
-    assert "0.200000" in epoch_curve and "0.150000" in epoch_curve
-
-
-def test_summary_epoch_curve_omits_validation_columns_without_a_selection_engine(
-    tmp_path: Path,
-) -> None:
-    text = _run(tmp_path, rotations=(_rotation(0),))
-
-    epoch_curve = text.split("Epoch curve")[1].split("\n--- ")[0]
-    assert "Val wR2" not in epoch_curve
-
-
-def test_summary_orientation_optimization_defaults_to_disabled(tmp_path: Path) -> None:
-    text = _run(tmp_path, rotations=(_rotation(0),))
-
-    orientation_section = text.split("Orientation optimization")[1].split("\n--- ")[0]
-    assert "enabled: no" in orientation_section
-
-
-def test_summary_orientation_optimization_lists_delta_angles_and_before_after_score(
-    tmp_path: Path,
-) -> None:
-    text = _run(
-        tmp_path,
-        orientations=(
-            _orientation(0, alpha=0.15, beta=-0.05, omega=0.02, seed_score=0.09, score=0.03),
-        ),
-        rotations=(_rotation(0),),
-    )
-
-    orientation_section = text.split("Orientation optimization")[1].split("\n--- ")[0]
-    assert "0.1500" in orientation_section  # delta alpha
-    assert "-0.0500" in orientation_section  # delta beta
-    assert "0.0200" in orientation_section  # delta omega
-    assert "0.090000" in orientation_section  # seed score (before the search)
-    assert "0.030000" in orientation_section  # final score (after the search)
-    assert "q.cif_pets" in orientation_section


### PR DESCRIPTION
A pooled multi-dataset refinement reported one mean wR2 and one mean R_obs over every rotation in
the experiment. That aggregate hides the question the pooling was done to ask: **do the datasets
agree?** Two files fitting equally well and one file dragging the mean are the same number, and the
per-rotation table below it does not answer it either — you would have to know which pooled rotation
index belongs to which file and average by hand.

This adds a **Per-dataset summary** section: train, validation, and total wR2/R_obs per dataset,
with an `All datasets` row so the pooled number stays visible next to the parts it came from.

```
Dataset            N (train/val)  Train wR2       Train R_obs     Val wR2         Val R_obs
-----------------  -------------  --------------  --------------  --------------  --------------
quartz.cif_pets    2/0            0.263422 [2/2]  0.200005 [2/2]  n/a [0/0]       n/a [0/0]
quartz_b.cif_pets  1/1            0.210078 [1/1]  0.162343 [1/1]  0.368827 [1/1]  0.278743 [1/1]
All datasets       3/1            0.245640 [3/3]  0.187451 [3/3]  0.368827 [1/1]  0.278743 [1/1]
```

Each rotation's dataset ref comes off its own `pattern`, so this is a **grouping of what the report
already had**, not new computation.

The section is omitted entirely for a single-dataset run, where every row would restate the table
above it.

### `_finite_mean_cell`

Extracted and shared with the per-rotation table. Every mean in the report states the denominator it
was taken over — a mean covering fewer rotations is a different quantity, not a better one — and
with a train/val split some cells cover no rotations at all, so `n/a [0/0]` has to be a value the
formatter produces rather than a case each caller handles.

### Testing

Covered both ways: the section appears with correct per-dataset refs for a two-dataset run, and is
absent for one dataset. Verified end-to-end on a real two-dataset pooled refinement.

---

## ⚠️ Merge procedure — please read

The previous attempt at this stack (#184–#188) was marked *merged* by GitHub but **none of that
content reached `main`**. The cause: `refactor/remove-quiet-flag` was merged to `main` (#183) and
then **not deleted**, so the PRs still based on it kept that base and merged into a branch that no
longer had a route to `main`. GitHub only auto-retargets an open PR when its base branch is
*deleted*.

To avoid a repeat, either:

- **merge strictly bottom-up and delete each base branch on merge** (the "Delete branch" button —
  this retargets the next PR to `main` automatically), or
- **retarget each PR to `main` by hand** once the one below it has landed.

If a PR here shows more commits than the one listed below, its base has not caught up yet — do not
merge it until it does.

## Stack

Rebuilt fresh off current `main` (`ddfbb1f`). One commit each; merge in this order:

| # | branch | commits | files |
|---|---|---|---|
| 1 | `feat/console-boxes-from-events` | 1 | 6 |
| 2 | `feat/per-epoch-validation-metrics` | 1 | 6 |
| 3 | `feat/rotation-dataset-ref` | 1 | 22 |
| 4 | `feat/orientation-search-report` | 1 | 9 |
| 5 | `feat/per-dataset-report` | 1 | 2 |

