### PR TITLE
Remove two duplicates introduced while splitting the observability branch

### DIFF
--- a/src/diffBloch/app/loggers/__init__.py
+++ b/src/diffBloch/app/loggers/__init__.py
@@ -58,7 +58,6 @@ __all__ = [
     "EarlyAbortLogger",
     "FitAbortedError",
     "format_measurements",
-    "print_summary_box",
     "namespaced_measurements",
     "print_summary_box",
     "residual_label",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -349,13 +349,6 @@ def test_preprocess_delegates_and_reports_without_scoring(
                 n_rotations=2, n_stages=3, total_hkl=7, matched_hkl=5, max_solve_beams=9
             )
         )
-        # _preprocess() itself emits this once preprocessing settles; ConsoleLogger is what turns
-        # it into the PREPROCESS COMPLETE box, so the fake must emit it too.
-        logger.report(
-            PreprocessCompleted(
-                n_rotations=2, n_stages=3, total_hkl=7, matched_hkl=5, max_solve_beams=9
-            )
-        )
         return _FakePlan()
 
     monkeypatch.setattr("diffBloch.app.cli.preprocess_experiment", fake_preprocess_experiment)


### PR DESCRIPTION
Two duplicated entries that landed on `main` while splitting
`feature/observability-report-sections` into the #190–#194 stack. Both are artifacts of
squash-merging a stack whose branches had edited the same region at different offsets — git combined
the two versions without reporting a conflict, leaving each entry twice.

**`app.loggers.__all__` listed `"print_summary_box"` twice**, the first copy out of alphabetical
order between `"format_measurements"` and `"namespaced_measurements"`. Inert at runtime — a repeated
name in `__all__` changes nothing about what `import *` binds — but the list is maintained sorted,
and neither ruff nor mypy flags a repeat.

**`test_cli.py`'s fake `preprocess_experiment` reported `PreprocessCompleted` twice**, so the test
rendered two `PREPROCESS COMPLETE` boxes where a real run emits one. The assertions are regex
searches over captured stdout, so they passed either way; the cost is that the fake stopped
modelling the thing it stands in for.

No behaviour change. Independent of #193/#194 — touches no file either of those touch, so it can
merge in any order.
